### PR TITLE
feat(map): update camera card UI and sync with backend API changes

### DIFF
--- a/src/__tests__/components/map/camera-select-card.test.tsx
+++ b/src/__tests__/components/map/camera-select-card.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react'
 
 import { CameraSelectCard } from '@/app/(app)/veiculos/components/map/components/select-cards/camera-select-card'
-import type { CameraCOR } from '@/models/entities'
+import type { Camera } from '@/models/entities'
 
 jest.mock('@/utils/string-extensions', () => ({
   capitalizeFirstLetter: jest.fn(
@@ -16,22 +16,24 @@ Object.defineProperty(window, 'open', {
 })
 
 describe('CameraSelectCard', () => {
-  const mockCamera: CameraCOR = {
+  const mockCamera: Camera = {
     code: 'CAM001',
     location: 'centro',
     zone: 'zona sul',
     streamingUrl: 'https://example.com/stream',
     longitude: -43.1729,
     latitude: -22.9068,
+    sistemaOrigem: 'DC3',
   }
 
-  const mockCameraWithoutStreaming: CameraCOR = {
+  const mockCameraWithoutStreaming: Camera = {
     code: 'CAM002',
     location: 'botafogo',
     zone: 'zona sul',
     streamingUrl: '',
     longitude: -43.1729,
     latitude: -22.9068,
+    sistemaOrigem: 'DC3',
   }
 
   const defaultProps = {
@@ -171,13 +173,14 @@ describe('CameraSelectCard', () => {
 
   describe('undefined/null values', () => {
     it('should handle undefined values gracefully', () => {
-      const mockCameraWithUndefined: CameraCOR = {
+      const mockCameraWithUndefined: Camera = {
         code: 'CAM003',
         location: 'teste',
         zone: 'teste',
         streamingUrl: '',
         longitude: -43.1729,
         latitude: -22.9068,
+        sistemaOrigem: 'DC3',
       }
 
       render(
@@ -195,13 +198,14 @@ describe('CameraSelectCard', () => {
     })
 
     it('should handle null values gracefully', () => {
-      const mockCameraWithNull: CameraCOR = {
+      const mockCameraWithNull: Camera = {
         code: 'CAM004',
         location: 'teste',
         zone: 'teste',
         streamingUrl: '',
         longitude: -43.1729,
         latitude: -22.9068,
+        sistemaOrigem: 'DC3',
       }
 
       render(

--- a/src/__tests__/components/map/layer-toggle-integration.test.tsx
+++ b/src/__tests__/components/map/layer-toggle-integration.test.tsx
@@ -24,7 +24,7 @@ jest.mock('@/hooks/mapLayers/use-radar-layer', () => ({
 }))
 
 jest.mock('@/hooks/mapLayers/use-cameras', () => ({
-  useCameraCOR: () => ({
+  useCamera: () => ({
     isVisible: true, // Camada de câmeras deve estar visível por padrão
     setIsVisible: mockSetIsCameraVisible,
     data: [],

--- a/src/__tests__/components/map/layer-toggle.test.tsx
+++ b/src/__tests__/components/map/layer-toggle.test.tsx
@@ -14,7 +14,7 @@ jest.mock('@/hooks/mapLayers/use-radar-layer', () => ({
 }))
 
 jest.mock('@/hooks/mapLayers/use-cameras', () => ({
-  useCameraCOR: () => ({
+  useCamera: () => ({
     isVisible: true, // Camada de câmeras deve estar visível por padrão
     setIsVisible: jest.fn(),
     data: [],

--- a/src/__tests__/components/map/select-cards-layout.test.tsx
+++ b/src/__tests__/components/map/select-cards-layout.test.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react'
 
 import { CameraSelectCard } from '@/app/(app)/veiculos/components/map/components/select-cards/camera-select-card'
 import { RadarSelectCard } from '@/app/(app)/veiculos/components/map/components/select-cards/radar-select-card'
-import type { CameraCOR, Radar } from '@/models/entities'
+import type { Camera, Radar } from '@/models/entities'
 import { useMapStore } from '@/stores/use-map-store'
 
 jest.mock('@/stores/use-map-store', () => ({
@@ -29,13 +29,14 @@ const mockRadar: Radar = {
   streetNumber: '1000',
 }
 
-const mockCamera: CameraCOR = {
+const mockCamera: Camera = {
   code: 'CAM001',
   latitude: -22.9068,
   longitude: -43.1729,
   location: 'copacabana palace',
   zone: 'zona sul',
   streamingUrl: 'https://example.com/stream',
+  sistemaOrigem: 'DC3',
 }
 
 describe('Select Cards Layout Snapshots', () => {
@@ -112,7 +113,7 @@ describe('Select Cards Layout Snapshots', () => {
     })
 
     it('deve manter o layout compacto do camera card sem streaming', () => {
-      const cameraWithoutStreaming: CameraCOR = {
+      const cameraWithoutStreaming: Camera = {
         ...mockCamera,
         streamingUrl: '',
       }

--- a/src/app/(app)/novidades/components/changelog.tsx
+++ b/src/app/(app)/novidades/components/changelog.tsx
@@ -19,6 +19,37 @@ export interface Card {
 
 export const changelog: Card[] = [
   {
+    title: '11 de Fevereiro de 2026',
+    subCards: [
+      {
+        tag: 'Adicionado',
+        title: 'Integração de câmeras CIVITAS (DC3)',
+        content: (
+          <>
+            <p>
+              A camada de câmeras do mapa foi expandida para incluir
+              equipamentos do sistema <strong>DC3</strong>, além das câmeras já
+              existentes do TIXXI.
+            </p>
+            <p>
+              Para facilitar a identificação, foi adicionada uma nova informação
+              de <strong>Sistema</strong> no cartão de detalhes da câmera
+              (acessível ao clicar com o botão direito ou selecionar a câmera),
+              permitindo distinguir a origem de cada equipamento.
+            </p>
+            <Image
+              src="https://storage.googleapis.com/rj-civitas-public/assets/card-camera-civitas-dc3-campo-sistema.png"
+              alt="Exemplo de cartão de câmera CIVITAS (DC3) com campo de sistema"
+              width={400}
+              height={300}
+              className="mb-4"
+            />
+          </>
+        ),
+      },
+    ],
+  },
+  {
     title: '15 de Setembro de 2025',
     subCards: [
       {

--- a/src/app/(app)/veiculos/components/map/components/select-cards/camera-select-card.tsx
+++ b/src/app/(app)/veiculos/components/map/components/select-cards/camera-select-card.tsx
@@ -8,12 +8,12 @@ import { useCallback } from 'react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
-import type { CameraCOR } from '@/models/entities'
+import type { Camera } from '@/models/entities'
 import { useMapStore } from '@/stores/use-map-store'
 
 interface CameraSelectCardProps {
-  selectedObject: CameraCOR | null
-  setSelectedObject: (value: CameraCOR | null) => void
+  selectedObject: Camera | null
+  setSelectedObject: (value: Camera | null) => void
   className?: string
 }
 
@@ -75,11 +75,19 @@ export function CameraSelectCard({
         </CardHeader>
         <CardContent className="px-4 py-3">
           <div className="space-y-3 text-sm">
-            <div className="flex flex-col space-y-1">
-              <span className="text-sm font-medium">Código</span>
-              <span className="text-sm text-muted-foreground">
-                {selectedObject?.code}
-              </span>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="flex flex-col space-y-1">
+                <span className="text-sm font-medium">Código</span>
+                <span className="text-sm text-muted-foreground">
+                  {selectedObject?.code}
+                </span>
+              </div>
+              <div className="flex flex-col space-y-1">
+                <span className="text-sm font-medium">Sistema</span>
+                <span className="text-sm text-muted-foreground">
+                  {selectedObject?.sistemaOrigem}
+                </span>
+              </div>
             </div>
 
             <div className="flex flex-col space-y-1">
@@ -92,12 +100,14 @@ export function CameraSelectCard({
               </span>
             </div>
 
-            <div className="flex flex-col space-y-1">
-              <span className="text-sm font-medium">Zona</span>
-              <span className="text-sm text-muted-foreground">
-                {selectedObject?.zone.capitalizeFirstLetter()}
-              </span>
-            </div>
+            {selectedObject?.zone && (
+              <div className="flex flex-col space-y-1">
+                <span className="text-sm font-medium">Zona</span>
+                <span className="text-sm text-muted-foreground">
+                  {selectedObject?.zone.capitalizeFirstLetter()}
+                </span>
+              </div>
+            )}
 
             <div className="grid grid-cols-2 gap-4">
               <div className="flex flex-col space-y-1">
@@ -135,18 +145,18 @@ export function CameraSelectCard({
                 </Button>
               )}
             </div>
-            {selectedObject?.streamingUrl && (
-              <div className="pt-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="w-full"
-                  onClick={handleOpenStreaming}
-                >
-                  Abrir Streaming
-                </Button>
-              </div>
-            )}
+
+            <div className="pt-2">
+              <Button
+                variant="outline"
+                size="sm"
+                className="w-full"
+                onClick={handleOpenStreaming}
+                disabled={!selectedObject?.streamingUrl}
+              >
+                Abrir Streaming
+              </Button>
+            </div>
           </div>
         </CardContent>
       </div>

--- a/src/components/custom/map-hover-card.tsx
+++ b/src/components/custom/map-hover-card.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from 'react'
 import { cn } from '@/lib/utils'
 import type {
   Agent,
-  CameraCOR,
+  Camera,
   FogoCruzadoIncident,
   Point,
   Radar,
@@ -18,7 +18,7 @@ import { Card } from '../ui/card'
 interface MapHoverCardProps {
   children?: ReactNode
   hoveredObject: PickingInfo<
-    CameraCOR | Radar | FogoCruzadoIncident | Agent | WazeAlert | Report | Point
+    Camera | Radar | FogoCruzadoIncident | Agent | WazeAlert | Report | Point
   > | null
   className?: string
 }

--- a/src/contexts/map-context.tsx
+++ b/src/contexts/map-context.tsx
@@ -18,7 +18,7 @@ import {
   type UseBusStopLayer,
   useBusStopLayer,
 } from '@/hooks/mapLayers/use-bus-stop-layer'
-import { type UseCameraCOR, useCameraCOR } from '@/hooks/mapLayers/use-cameras'
+import { type UseCamera, useCamera } from '@/hooks/mapLayers/use-cameras'
 import {
   type UseCISPLayer,
   useCISPLayer,
@@ -48,7 +48,7 @@ interface MapContextProps {
   layers: {
     radars: UseRadarLayer
     trips: UseTrips
-    cameras: UseCameraCOR
+    cameras: UseCamera
     agents: UseAgents
     fogoCruzado: UseFogoCruzadoIncidents
     waze: UseWazePoliceAlerts
@@ -132,7 +132,7 @@ export function MapContextProvider({ children }: MapContextProviderProps) {
   // Layers usando hooks tradicionais
   const radars = useRadarLayer(multipleSelectedRadars)
   const trips = useTrips({ setViewport })
-  const cameras = useCameraCOR()
+  const cameras = useCamera()
   const agents = useAgents()
   const fogoCruzado = useFogoCruzadoIncidents()
   const waze = useWazePoliceAlerts()

--- a/src/hooks/mapLayers/use-cameras.tsx
+++ b/src/hooks/mapLayers/use-cameras.tsx
@@ -10,41 +10,38 @@ import {
 } from 'react'
 
 import cameraIconAtlas from '@/assets/camera-icon-atlas.png'
-import { getCameraCOR } from '@/http/cameras-cor/get-cameras-cor'
-import { CameraCOR } from '@/models/entities'
+import { getCamera } from '@/http/cameras-cor/get-cameras-cor'
+import { Camera } from '@/models/entities'
 
-export interface UseCameraCOR {
-  data: CameraCOR[]
+export interface UseCamera {
+  data: Camera[]
   failed: boolean
-  layer: IconLayer<CameraCOR, object>
+  layer: IconLayer<Camera, object>
   isLoading: boolean
   isVisible: boolean
   setIsVisible: Dispatch<SetStateAction<boolean>>
-  hoveredObject: PickingInfo<CameraCOR> | null
-  setHoveredObject: Dispatch<SetStateAction<PickingInfo<CameraCOR> | null>>
-  selectedObject: CameraCOR | null
-  setSelectedObject: Dispatch<SetStateAction<CameraCOR | null>>
-  handleSelectObject: (
-    camera: CameraCOR | null,
-    clearRadar?: () => void,
-  ) => void
+  hoveredObject: PickingInfo<Camera> | null
+  setHoveredObject: Dispatch<SetStateAction<PickingInfo<Camera> | null>>
+  selectedObject: Camera | null
+  setSelectedObject: Dispatch<SetStateAction<Camera | null>>
+  handleSelectObject: (camera: Camera | null, clearRadar?: () => void) => void
 }
 
-export function useCameraCOR(): UseCameraCOR {
+export function useCamera(): UseCamera {
   const [hoveredObject, setHoveredObject] =
-    useState<PickingInfo<CameraCOR> | null>(null)
+    useState<PickingInfo<Camera> | null>(null)
   const [isVisible, setIsVisible] = useState(true)
-  const [selectedObject, setSelectedObject] = useState<CameraCOR | null>(null)
+  const [selectedObject, setSelectedObject] = useState<Camera | null>(null)
 
   const { data, isLoading } = useQuery({
     queryKey: ['cameras'],
-    queryFn: () => getCameraCOR(),
+    queryFn: () => getCamera(),
     staleTime: Infinity,
     refetchOnWindowFocus: false,
   })
 
   const handleSelectObject = useCallback(
-    (camera: CameraCOR | null, clearRadar?: () => void) => {
+    (camera: Camera | null, clearRadar?: () => void) => {
       if (camera === null || selectedObject?.code === camera.code) {
         setSelectedObject(null)
       } else {
@@ -59,7 +56,7 @@ export function useCameraCOR(): UseCameraCOR {
 
   const layer = useMemo(
     () =>
-      new IconLayer<CameraCOR>({
+      new IconLayer<Camera>({
         id: 'cameras',
         data,
         pickable: true,

--- a/src/hooks/maps/use-map-search.ts
+++ b/src/hooks/maps/use-map-search.ts
@@ -2,7 +2,7 @@
 
 import { useCallback } from 'react'
 
-import type { CameraCOR, Radar } from '@/models/entities'
+import type { Camera, Radar } from '@/models/entities'
 
 interface SearchSubmitProps {
   address: string
@@ -10,7 +10,7 @@ interface SearchSubmitProps {
 
 interface UseMapSearchProps {
   radars: Radar[] | undefined
-  cameras: CameraCOR[] | undefined
+  cameras: Camera[] | undefined
   setViewport: (viewport: {
     latitude: number
     longitude: number

--- a/src/hooks/maps/use-mouse-interactions.ts
+++ b/src/hooks/maps/use-mouse-interactions.ts
@@ -3,15 +3,15 @@
 import { type Deck, type PickingInfo } from 'deck.gl'
 import { type MouseEvent, useCallback, useRef } from 'react'
 
-import type { CameraCOR, Radar } from '@/models/entities'
+import type { Camera, Radar } from '@/models/entities'
 import { useMapStore } from '@/stores/use-map-store'
 
 interface UseMouseInteractionsProps {
   deckRef: React.RefObject<Deck | null>
   multiSelectRadar: (radar: Radar) => void
-  selectCamera: (camera: CameraCOR | null, clearRadar?: () => void) => void
+  selectCamera: (camera: Camera | null, clearRadar?: () => void) => void
   setSelectedRadar: (radar: Radar | null) => void
-  setSelectedCamera: (camera: CameraCOR | null) => void
+  setSelectedCamera: (camera: Camera | null) => void
   setContextMenuPickingInfo: (info: PickingInfo | null) => void
   setOpenContextMenu: (open: boolean) => void
   zoomToLocation: (lat: number, lng: number, zoom: number) => void
@@ -49,7 +49,7 @@ export function useMouseInteractions({
       }
 
       if (info?.layer?.id === 'cameras' && info.object) {
-        const camera = info.object as CameraCOR
+        const camera = info.object as Camera
         selectCamera(camera, () => {
           setSelectedRadar(null)
           const setRadarInfoMode = useMapStore.getState().setRadarInfoMode

--- a/src/hooks/maps/use-selection-management.ts
+++ b/src/hooks/maps/use-selection-management.ts
@@ -2,13 +2,13 @@
 
 import { useEffect } from 'react'
 
-import type { CameraCOR, Radar } from '@/models/entities'
+import type { Camera, Radar } from '@/models/entities'
 import { useMapStore } from '@/stores/use-map-store'
 
 interface UseSelectionManagementProps {
   selectedRadar: Radar | null
-  selectedCamera: CameraCOR | null
-  setSelectedCamera: (camera: CameraCOR | null) => void
+  selectedCamera: Camera | null
+  setSelectedCamera: (camera: Camera | null) => void
 }
 
 export function useSelectionManagement({

--- a/src/hooks/useQueries/useCameras.tsx
+++ b/src/hooks/useQueries/useCameras.tsx
@@ -1,11 +1,11 @@
 import { useQuery } from '@tanstack/react-query'
 
-import { getCameraCOR } from '@/http/cameras-cor/get-cameras-cor'
+import { getCamera } from '@/http/cameras-cor/get-cameras-cor'
 
 export function useCameras() {
   return useQuery({
     queryKey: ['cameras'],
-    queryFn: () => getCameraCOR(),
+    queryFn: () => getCamera(),
     staleTime: Infinity,
     refetchOnWindowFocus: false,
   })

--- a/src/http/cameras-cor/get-cameras-cor.ts
+++ b/src/http/cameras-cor/get-cameras-cor.ts
@@ -1,8 +1,8 @@
 import { api } from '@/lib/api'
-import type { BackendCameraCOR, CameraCOR } from '@/models/entities'
+import type { BackendCamera, Camera } from '@/models/entities'
 
-export async function getCameraCOR() {
-  const response = await api.get<BackendCameraCOR[]>('/cameras-cor')
+export async function getCamera() {
+  const response = await api.get<BackendCamera[]>('/cameras')
 
   const data = response.data.map((item) => {
     return {
@@ -12,7 +12,8 @@ export async function getCameraCOR() {
       streamingUrl: item.Streamming,
       latitude: Number(item.Latitude),
       longitude: Number(item.Longitude),
-    } as CameraCOR
+      sistemaOrigem: item.sistema_origem,
+    } as Camera
   })
 
   return data

--- a/src/models/entities.d.ts
+++ b/src/models/entities.d.ts
@@ -98,22 +98,24 @@ export type Profile = {
   isAdmin: boolean
 }
 
-export type BackendCameraCOR = {
+export type BackendCamera = {
   CameraCode: string
   CameraName: string
   CameraZone: string
   Latitude: string
   Longitude: string
   Streamming: string
+  sistema_origem: string
 }
 
-export type CameraCOR = {
+export type Camera = {
   code: string
   location: string
   zone: string
   latitude: number
   longitude: number
   streamingUrl: string
+  sistemaOrigem: string
 }
 
 export type BackendRadar = {

--- a/src/stores/use-map-store.ts
+++ b/src/stores/use-map-store.ts
@@ -13,7 +13,7 @@ import { useAddressMarker } from '@/hooks/mapLayers/use-address-marker'
 import { useAgents } from '@/hooks/mapLayers/use-agents'
 import { useAISPLayer } from '@/hooks/mapLayers/use-AISP-layer'
 import { useBusStopLayer } from '@/hooks/mapLayers/use-bus-stop-layer'
-import { useCameraCOR } from '@/hooks/mapLayers/use-cameras'
+import { useCamera } from '@/hooks/mapLayers/use-cameras'
 import { useCISPLayer } from '@/hooks/mapLayers/use-CISP-layer'
 import { useFogoCruzadoIncidents } from '@/hooks/mapLayers/use-fogo-cruzado'
 import { useRadarLayer } from '@/hooks/mapLayers/use-radar-layer'
@@ -180,7 +180,7 @@ export function useMapLayers() {
   // Os layers são memoizados internamente
   const radars = useRadarLayer(multipleSelectedRadars)
   const trips = useTrips({ setViewport })
-  const cameras = useCameraCOR()
+  const cameras = useCamera()
   const agents = useAgents()
   const fogoCruzado = useFogoCruzadoIncidents()
   const waze = useWazePoliceAlerts()


### PR DESCRIPTION
- Update 'get-cameras-cor' service to map 'sistema_origem' to 'sistemaOrigem'.
- Add 'Sistema' field to the camera details card.
- Conditionally render the 'Zona' field only when data is available.
- Disable the 'Abrir Streaming' button when the streaming URL is null.