### PR TITLE
feat(vehicles): support SENTRY plate passages in search-by-plate

### DIFF
--- a/src/__tests__/components/map/__snapshots__/select-cards-layout.test.tsx.snap
+++ b/src/__tests__/components/map/__snapshots__/select-cards-layout.test.tsx.snap
@@ -46,18 +46,36 @@ exports[`Select Cards Layout Snapshots CameraSelectCard Layout deve manter o lay
         class="space-y-3 text-sm"
       >
         <div
-          class="flex flex-col space-y-1"
+          class="grid grid-cols-2 gap-4"
         >
-          <span
-            class="text-sm font-medium"
+          <div
+            class="flex flex-col space-y-1"
           >
-            Código
-          </span>
-          <span
-            class="text-sm text-muted-foreground"
+            <span
+              class="text-sm font-medium"
+            >
+              Código
+            </span>
+            <span
+              class="text-sm text-muted-foreground"
+            >
+              CAM001
+            </span>
+          </div>
+          <div
+            class="flex flex-col space-y-1"
           >
-            CAM001
-          </span>
+            <span
+              class="text-sm font-medium"
+            >
+              Sistema
+            </span>
+            <span
+              class="text-sm text-muted-foreground"
+            >
+              DC3
+            </span>
+          </div>
         </div>
         <div
           class="flex flex-col space-y-1"
@@ -259,18 +277,36 @@ exports[`Select Cards Layout Snapshots CameraSelectCard Layout deve manter o lay
         class="space-y-3 text-sm"
       >
         <div
-          class="flex flex-col space-y-1"
+          class="grid grid-cols-2 gap-4"
         >
-          <span
-            class="text-sm font-medium"
+          <div
+            class="flex flex-col space-y-1"
           >
-            Código
-          </span>
-          <span
-            class="text-sm text-muted-foreground"
+            <span
+              class="text-sm font-medium"
+            >
+              Código
+            </span>
+            <span
+              class="text-sm text-muted-foreground"
+            >
+              CAM001
+            </span>
+          </div>
+          <div
+            class="flex flex-col space-y-1"
           >
-            CAM001
-          </span>
+            <span
+              class="text-sm font-medium"
+            >
+              Sistema
+            </span>
+            <span
+              class="text-sm text-muted-foreground"
+            >
+              DC3
+            </span>
+          </div>
         </div>
         <div
           class="flex flex-col space-y-1"
@@ -411,6 +447,16 @@ exports[`Select Cards Layout Snapshots CameraSelectCard Layout deve manter o lay
             </svg>
           </button>
         </div>
+        <div
+          class="pt-2"
+        >
+          <button
+            class="inline-flex items-center justify-center whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3 w-full"
+            disabled=""
+          >
+            Abrir Streaming
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -463,16 +509,32 @@ exports[`Select Cards Layout Snapshots CameraSelectCard Layout deve manter o lay
         class="space-y-3 text-sm"
       >
         <div
-          class="flex flex-col space-y-1"
+          class="grid grid-cols-2 gap-4"
         >
-          <span
-            class="text-sm font-medium"
+          <div
+            class="flex flex-col space-y-1"
           >
-            Código
-          </span>
-          <span
-            class="text-sm text-muted-foreground"
-          />
+            <span
+              class="text-sm font-medium"
+            >
+              Código
+            </span>
+            <span
+              class="text-sm text-muted-foreground"
+            />
+          </div>
+          <div
+            class="flex flex-col space-y-1"
+          >
+            <span
+              class="text-sm font-medium"
+            >
+              Sistema
+            </span>
+            <span
+              class="text-sm text-muted-foreground"
+            />
+          </div>
         </div>
         <div
           class="flex flex-col space-y-1"
@@ -507,18 +569,6 @@ exports[`Select Cards Layout Snapshots CameraSelectCard Layout deve manter o lay
               Localização
             </span>
           </div>
-          <span
-            class="text-sm text-muted-foreground"
-          />
-        </div>
-        <div
-          class="flex flex-col space-y-1"
-        >
-          <span
-            class="text-sm font-medium"
-          >
-            Zona
-          </span>
           <span
             class="text-sm text-muted-foreground"
           />
@@ -603,6 +653,16 @@ exports[`Select Cards Layout Snapshots CameraSelectCard Layout deve manter o lay
                 d="M3 3v5h5"
               />
             </svg>
+          </button>
+        </div>
+        <div
+          class="pt-2"
+        >
+          <button
+            class="inline-flex items-center justify-center whitespace-nowrap text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 rounded-md px-3 w-full"
+            disabled=""
+          >
+            Abrir Streaming
           </button>
         </div>
       </div>

--- a/src/__tests__/components/map/camera-select-card.test.tsx
+++ b/src/__tests__/components/map/camera-select-card.test.tsx
@@ -141,7 +141,7 @@ describe('CameraSelectCard', () => {
       )
     })
 
-    it('should not display streaming button when streamingUrl is not available', () => {
+    it('should display streaming button with disabled state when streamingUrl is not available', () => {
       render(
         <CameraSelectCard
           {...defaultProps}
@@ -149,7 +149,9 @@ describe('CameraSelectCard', () => {
         />,
       )
 
-      expect(screen.queryByText('Abrir Streaming')).not.toBeInTheDocument()
+      const button = screen.getByText('Abrir Streaming')
+      expect(button).toBeInTheDocument()
+      expect(button).toBeDisabled()
     })
   })
 

--- a/src/app/(app)/veiculos/busca-por-placa/veiculo/components/trip-list/components/point-card.tsx
+++ b/src/app/(app)/veiculos/busca-por-placa/veiculo/components/trip-list/components/point-card.tsx
@@ -134,7 +134,9 @@ export function PointCard({ point }: PointCardProps) {
           {`${point.speed} Km/h`}
         </span>
         <span className="block truncate text-xs text-muted-foreground">
-          {`Sentido ${point.direction?.capitalizeFirstLetter()}`}
+          {point.direction?.trim()
+            ? `Sentido ${point.direction.capitalizeFirstLetter()}`
+            : 'Sentido'}
         </span>
       </div>
     </div>

--- a/src/http/cars/path/get-car-path.ts
+++ b/src/http/cars/path/get-car-path.ts
@@ -14,6 +14,7 @@ export interface Point {
   longitude: number
   bairro: string
   localidade: string
+  sentido?: string | null
   velocidade: number
   seconds_to_next_point: number | null
 }

--- a/src/utils/format-car-path-response.ts
+++ b/src/utils/format-car-path-response.ts
@@ -13,7 +13,11 @@ export function formatCarPathResponse(response: GetCarPathResponse) {
 
     const formattedPoints = points
       .map((point, index) => {
-        const { location, direction, lane } = formatLocation(point.localidade)
+        const { location, direction, lane } = formatLocation(
+          point.localidade ?? '',
+        )
+        const directionFromApi = point.sentido?.trim()
+        const directionValue = directionFromApi ?? direction
         const from = [point.longitude, point.latitude] as Coordinates
         const to =
           points.at(index + 1) &&
@@ -32,7 +36,7 @@ export function formatCarPathResponse(response: GetCarPathResponse) {
           endTime: points.at(index + 1)?.datahora,
           district: point.bairro,
           location,
-          direction,
+          direction: directionValue,
           speed: point.velocidade,
           lane,
           secondsToNextPoint: point.seconds_to_next_point,

--- a/src/utils/formatLocation.ts
+++ b/src/utils/formatLocation.ts
@@ -1,15 +1,30 @@
 export function formatLocation(phrase: string) {
+  const trimmed = typeof phrase === 'string' ? phrase.trim() : ''
+
+  if (!trimmed) {
+    return { location: '', direction: '', lane: '' }
+  }
+
+  // Padrão esperado para RADAR: "LOCAL - SENTIDO X - FX Y"
+  if (!trimmed.includes(' - SENTIDO ')) {
+    return {
+      location: trimmed,
+      direction: '',
+      lane: '',
+    }
+  }
+
   // Extract everything before " - SENTIDO"
-  const locationMatch = phrase.match(/.*(?= - SENTIDO)/)
-  const location = locationMatch ? locationMatch[0] : ''
+  const locationMatch = trimmed.match(/.*(?= - SENTIDO)/)
+  const location = locationMatch ? locationMatch[0].trim() : trimmed
 
   // Extract the content between " - SENTIDO " and " - "
-  const directionMatch = phrase.match(/(?<=- SENTIDO ).*?(?= -)/)
-  const direction = directionMatch ? directionMatch[0] : ''
+  const directionMatch = trimmed.match(/(?<=- SENTIDO ).*?(?= -)/)
+  const direction = directionMatch ? directionMatch[0].trim() : ''
 
   // Extract everything after " - FX "
-  const laneMatch = phrase.match(/(?<=- FX ).*/)
-  const lane = laneMatch ? laneMatch[0] : ''
+  const laneMatch = trimmed.match(/(?<=- FX ).*/)
+  const lane = laneMatch ? laneMatch[0].trim() : ''
 
   return {
     location,


### PR DESCRIPTION
- Fallback in formatLocation when localidade does not match ' - SENTIDO ' pattern
- Use API sentido when present, else parsed direction from localidade
- Handle empty localidade and optional sentido; show Sentido label when direction is empty

Backend now returns SENTRY + CET-Rio data; frontend adjusted to display both sources correctly.