### PR TITLE
feat: inbox email reply flow, nested sidebar, and teams/tickets improvements

### DIFF
--- a/src/app/(app)/chamados/caixa-entrada/components/email-preview-sheet.tsx
+++ b/src/app/(app)/chamados/caixa-entrada/components/email-preview-sheet.tsx
@@ -122,8 +122,9 @@ export function EmailPreviewSheet({
   const dateStr = d ? format(d, 'dd/MM/yyyy', { locale: ptBR }) : '—'
 
   const replyHref =
-    fromAddr &&
-    `mailto:${encodeURIComponent(fromAddr)}?subject=${encodeURIComponent(`Re: ${email?.subject || ''}`)}`
+    emailId != null
+      ? `/chamados/caixa-entrada/responder/${encodeURIComponent(emailId)}`
+      : null
   const convertHref =
     emailId != null
       ? `/chamados/converter?email_id=${encodeURIComponent(emailId)}`
@@ -222,9 +223,9 @@ export function EmailPreviewSheet({
                   </button>
                 ) : null}
                 {replyHref ? (
-                  <a className={styles.btnSecondary} href={replyHref}>
+                  <Link href={replyHref} className={styles.btnSecondary}>
                     Responder
-                  </a>
+                  </Link>
                 ) : (
                   <button
                     type="button"

--- a/src/app/(app)/chamados/caixa-entrada/responder/[emailId]/components/responder-email-view.module.css
+++ b/src/app/(app)/chamados/caixa-entrada/responder/[emailId]/components/responder-email-view.module.css
@@ -1,0 +1,474 @@
+/**
+ * Responder e-mail — Figma Civitas node 768:19804
+ * https://www.figma.com/design/6Njx9o5Q7wl6SDQf52JZrW/Civitas?node-id=768-19804
+ */
+
+.root {
+  --r-bg-page: #0c161f;
+  --r-bg-card: #152534;
+  --r-bg-section: #101d28;
+  --r-border: #4a5d6d;
+  --r-text: #f9fafa;
+  --r-text-subtle: #97a2ab;
+  --r-body-inverse-bg: #e8ebed;
+  --r-body-inverse-text: #0c161f;
+  --r-primary: #065e47;
+  --r-tertiary-btn: #1d3449;
+  --r-radius: 8px;
+  --r-input-bg: #152534;
+
+  /**
+   * Mesmos tokens de `ticket-create-form.module.css` (.root).
+   * Sem isso, `fieldLabel` / `inputBg` importados de lá não recebem var(--tc-*)
+   * e o Select parece “texto solto” no fundo da página.
+   */
+  --tc-page-bg: #0c161f;
+  --tc-section-bg: #101d28;
+  --tc-card-bg: #101d28;
+  --tc-card-border: #4a5d6d;
+  --tc-input-bg: #152534;
+  --tc-input-border: #4a5d6d;
+  --tc-input-border-hover: #507290;
+  --tc-soft: #18344d;
+  --tc-soft-2: #1f3f5b;
+  --tc-text: #f9fafa;
+  --tc-muted: #97a2ab;
+  --tc-text-subtle: #97a2ab;
+  --tc-icon-subtle: #97a2ab;
+  --tc-green: #067a57;
+  --tc-green-hover: #0a8a64;
+  --tc-badge-bg: #1d3449;
+  --tc-badge-text: #f9fafa;
+  --tc-border-radius: 8px;
+
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-width: 0;
+  min-height: 100vh;
+  min-height: 100dvh;
+  background: var(--r-bg-page);
+  color: var(--r-text);
+}
+
+/* Sem padding horizontal aqui: o mesmo `content` da caixa de entrada (globals) já define px e max-width */
+.main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 32px;
+  padding: 0 0 32px;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+.visEmail {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  width: 100%;
+  padding: 24px 0;
+  border-radius: var(--r-radius);
+  overflow: hidden;
+}
+
+.headerBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  width: 100%;
+  padding: 16px;
+  background: var(--r-bg-card);
+  border-radius: var(--r-radius);
+  min-height: 56px;
+}
+
+.headerLeft {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  min-width: 0;
+  flex: 1;
+}
+
+.backLink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  border-radius: 9999px;
+  background: var(--r-bg-card);
+  color: var(--r-text);
+  border: none;
+  cursor: pointer;
+  text-decoration: none;
+  transition: opacity 0.15s ease, background 0.15s ease;
+}
+
+.backLink:hover {
+  opacity: 0.9;
+  background: var(--r-input-bg);
+}
+
+.pageTitle {
+  font-family: var(--font-family-heading, 'Inter', sans-serif);
+  font-weight: 600;
+  font-size: 20px;
+  line-height: 1.2;
+  color: var(--r-text);
+  margin: 0;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.metaRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  width: 100%;
+}
+
+.senderBlock {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  min-width: 0;
+}
+
+.avatar {
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+  border-radius: 9999px;
+  background: var(--r-bg-card);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--r-text-subtle);
+}
+
+.senderText {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  min-width: 0;
+}
+
+.senderName {
+  font-family: 'Inter', sans-serif;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 20px;
+  color: var(--r-text);
+  margin: 0;
+}
+
+.senderEmail {
+  font-family: 'Inter', sans-serif;
+  font-weight: 400;
+  font-size: 12px;
+  line-height: 16px;
+  color: var(--r-text-subtle);
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: min(320px, 50vw);
+}
+
+.timeBlock {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-shrink: 0;
+  font-family: 'Inter', sans-serif;
+  font-size: 12px;
+  line-height: 16px;
+  color: var(--r-text);
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.bodyCard {
+  background: var(--r-body-inverse-bg);
+  border-radius: var(--r-radius);
+  padding: 24px;
+  width: 100%;
+}
+
+.bodyText {
+  font-family: 'Inter', sans-serif;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 20px;
+  color: var(--r-body-inverse-text);
+  white-space: pre-wrap;
+  margin: 0;
+}
+
+.attachmentsRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-start;
+  width: 100%;
+}
+
+.attachmentCard {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  width: 260px;
+  max-width: 100%;
+  padding: 12px;
+  background: var(--r-bg-section);
+  border-radius: var(--r-radius);
+}
+
+.attachmentLeft {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.pdfIconWrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  border-radius: var(--r-radius);
+  background: rgba(239, 68, 68, 0.1);
+  color: #ef4444;
+  flex-shrink: 0;
+}
+
+.attachmentInfo {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 0;
+  width: 119px;
+}
+
+.attachmentName {
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  line-height: 20px;
+  color: var(--r-text);
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.attachmentSize {
+  font-family: 'Inter', sans-serif;
+  font-size: 12px;
+  line-height: 16px;
+  color: var(--r-text-subtle);
+  margin: 0;
+}
+
+.downloadBtn {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--r-text-subtle);
+  cursor: pointer;
+}
+
+.downloadBtn:hover {
+  color: var(--r-text);
+}
+
+.popField {
+  width: 100%;
+}
+
+/**
+ * Radix SelectTrigger injeta `bg-background border-input` (Tailwind);
+ * sem !important o fundo/borda do tema “ganham” e some o bloco estilo criar.
+ */
+.popSelectTrigger {
+  width: 100% !important;
+  min-height: 44px !important;
+  height: 2.75rem !important;
+  background-color: var(--tc-input-bg) !important;
+  border: 1px solid var(--tc-input-border) !important;
+  border-radius: var(--tc-border-radius) !important;
+  color: var(--tc-text-subtle) !important;
+  box-shadow: none !important;
+  padding-left: 16px !important;
+  padding-right: 12px !important;
+  font-size: 14px !important;
+  line-height: 20px !important;
+}
+
+.popSelectTrigger:hover:not(:disabled) {
+  border-color: var(--tc-input-border-hover) !important;
+}
+
+.popSelectTrigger:focus-visible {
+  outline: none !important;
+  box-shadow: 0 0 0 2px var(--tc-input-border) !important;
+}
+
+.popSelectTrigger[data-state='open'] {
+  border-color: var(--tc-input-border-hover) !important;
+}
+
+.popSelectTrigger svg {
+  color: var(--tc-icon-subtle) !important;
+  opacity: 1;
+}
+
+.editorWrap {
+  width: 100%;
+  border: 1px solid var(--r-border);
+  border-radius: var(--r-radius);
+  background: var(--r-bg-card);
+  overflow: hidden;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  border-bottom: 1px solid var(--r-border);
+}
+
+.toolbarDivider {
+  width: 1px;
+  height: 24px;
+  background: var(--r-border);
+  flex-shrink: 0;
+}
+
+.toolbarBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--r-text-subtle);
+  cursor: not-allowed;
+  opacity: 0.85;
+}
+
+.textarea {
+  display: block;
+  width: 100%;
+  min-height: 200px;
+  padding: 16px;
+  border: none;
+  background: transparent;
+  color: var(--r-text);
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  line-height: 20px;
+  resize: vertical;
+  box-sizing: border-box;
+}
+
+.textarea::placeholder {
+  color: var(--r-text-subtle);
+}
+
+.textarea:focus {
+  outline: none;
+}
+
+.footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 16px;
+  width: 100%;
+}
+
+.btnCancel {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  width: 220px;
+  max-width: 100%;
+  height: 40px;
+  padding: 8px 16px;
+  background: var(--r-tertiary-btn);
+  border: none;
+  border-radius: var(--r-radius);
+  color: var(--r-text-subtle);
+  font-family: 'Inter', sans-serif;
+  font-size: 14px;
+  line-height: 20px;
+  text-decoration: none;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+.btnCancel:hover {
+  opacity: 0.92;
+}
+
+.btnSend {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  width: 220px;
+  max-width: 100%;
+  height: 40px;
+  padding: 8px 16px;
+  background: var(--r-primary);
+  border: none;
+  border-radius: var(--r-radius);
+  color: var(--r-text);
+  font-family: 'Inter', sans-serif;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 16px;
+  cursor: pointer;
+  transition: opacity 0.15s ease, background 0.15s ease;
+}
+
+.btnSend:hover:not(:disabled) {
+  background: var(--tc-green-hover, #0a8a64);
+}
+
+.btnSend:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
+}
+
+.loadingBox,
+.errorBox {
+  padding: 24px;
+  color: var(--r-text-subtle);
+  font-size: 14px;
+  width: 100%;
+}

--- a/src/app/(app)/chamados/caixa-entrada/responder/[emailId]/components/responder-email-view.module.css
+++ b/src/app/(app)/chamados/caixa-entrada/responder/[emailId]/components/responder-email-view.module.css
@@ -1,8 +1,3 @@
-/**
- * Responder e-mail — Figma Civitas node 768:19804
- * https://www.figma.com/design/6Njx9o5Q7wl6SDQf52JZrW/Civitas?node-id=768-19804
- */
-
 .root {
   --r-bg-page: #0c161f;
   --r-bg-card: #152534;
@@ -17,11 +12,6 @@
   --r-radius: 8px;
   --r-input-bg: #152534;
 
-  /**
-   * Mesmos tokens de `ticket-create-form.module.css` (.root).
-   * Sem isso, `fieldLabel` / `inputBg` importados de lá não recebem var(--tc-*)
-   * e o Select parece “texto solto” no fundo da página.
-   */
   --tc-page-bg: #0c161f;
   --tc-section-bg: #101d28;
   --tc-card-bg: #101d28;
@@ -51,7 +41,6 @@
   color: var(--r-text);
 }
 
-/* Sem padding horizontal aqui: o mesmo `content` da caixa de entrada (globals) já define px e max-width */
 .main {
   flex: 1;
   display: flex;
@@ -303,10 +292,7 @@
   width: 100%;
 }
 
-/**
- * Radix SelectTrigger injeta `bg-background border-input` (Tailwind);
- * sem !important o fundo/borda do tema “ganham” e some o bloco estilo criar.
- */
+
 .popSelectTrigger {
   width: 100% !important;
   min-height: 44px !important;

--- a/src/app/(app)/chamados/caixa-entrada/responder/[emailId]/components/responder-email-view.tsx
+++ b/src/app/(app)/chamados/caixa-entrada/responder/[emailId]/components/responder-email-view.tsx
@@ -1,0 +1,389 @@
+'use client'
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { format } from 'date-fns'
+import { ptBR } from 'date-fns/locale'
+import {
+  Bold,
+  ChevronLeft,
+  Download,
+  FileText,
+  Italic,
+  Link2,
+  List,
+  ListOrdered,
+  Underline,
+  User,
+} from 'lucide-react'
+import Link from 'next/link'
+import { useParams, useRouter } from 'next/navigation'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { toast } from 'sonner'
+
+import tcStyles from '@/app/(app)/chamados/criar/ticket-create/ticket-create-form.module.css'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { downloadEmailAttachmentFile } from '@/http/emails/download-email-attachment'
+import { type AttachmentOut, getEmailById } from '@/http/emails/get-email'
+import { sendStandardizedTemplatedEmail } from '@/http/emails/send-standardized-templated-email'
+import {
+  getStandardizedResponseById,
+  listStandardizedResponses,
+} from '@/http/standardized-responses/standardized-responses'
+import { cn } from '@/lib/utils'
+
+import styles from './responder-email-view.module.css'
+
+/** Valor sentinela para o Select (sem POP) — não colidir com ids da API */
+const EMPTY_POP_VALUE = '__civitas_pop_empty__'
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  const kb = bytes / 1024
+  if (kb < 1024) return `${kb.toFixed(1)} KB`
+  const mb = kb / 1024
+  return `${mb.toFixed(1)} MB`
+}
+
+function resolveEmailDate(email: {
+  date?: string | null
+  internal_date?: number | null
+}): Date | null {
+  if (email.date) {
+    const d = new Date(email.date)
+    return Number.isNaN(d.getTime()) ? null : d
+  }
+  if (email.internal_date != null) {
+    return new Date(email.internal_date)
+  }
+  return null
+}
+
+export function ResponderEmailView() {
+  const params = useParams()
+  const router = useRouter()
+  const queryClient = useQueryClient()
+  const emailId =
+    typeof params?.emailId === 'string' ? params.emailId : undefined
+
+  const [selectedPopId, setSelectedPopId] = useState<string | null>(null)
+  const [replyBody, setReplyBody] = useState('')
+
+  const sendMutation = useMutation({
+    mutationFn: sendStandardizedTemplatedEmail,
+    onSuccess: () => {
+      toast.success('E-mail enviado.')
+      queryClient.invalidateQueries({ queryKey: ['emails-inbox-nao-lidos'] })
+      queryClient.invalidateQueries({
+        queryKey: ['emails-inbox-aguardando-resposta'],
+      })
+      queryClient.invalidateQueries({ queryKey: ['email-detail', emailId] })
+      router.push('/chamados/caixa-entrada')
+    },
+    onError: () => {
+      toast.error('Não foi possível enviar o e-mail.')
+    },
+  })
+
+  const {
+    data: emailRes,
+    isLoading: emailLoading,
+    isError: emailError,
+  } = useQuery({
+    queryKey: ['email-detail', emailId],
+    queryFn: () => getEmailById(emailId!),
+    enabled: Boolean(emailId),
+  })
+
+  const email = emailRes?.data
+
+  const { data: popsRes, isLoading: popsLoading } = useQuery({
+    queryKey: ['standardized-responses', 'list', { isActive: true }],
+    queryFn: async () => {
+      const r = await listStandardizedResponses({ isActive: true })
+      return r.data
+    },
+  })
+
+  const pops = popsRes?.items ?? []
+
+  const {
+    data: popDetailRes,
+    isFetching: popDetailLoading,
+    isError: popDetailError,
+  } = useQuery({
+    queryKey: ['standardized-response', selectedPopId],
+    queryFn: async () => {
+      const r = await getStandardizedResponseById(selectedPopId!)
+      return r.data
+    },
+    enabled: Boolean(selectedPopId),
+    retry: false,
+  })
+
+  useEffect(() => {
+    if (popDetailError) {
+      toast.error('Não foi possível carregar a resposta padronizada.')
+    }
+  }, [popDetailError])
+
+  useEffect(() => {
+    if (!selectedPopId) {
+      setReplyBody('')
+      return
+    }
+    if (popDetailRes?.body != null) {
+      setReplyBody(popDetailRes.body)
+    }
+  }, [selectedPopId, popDetailRes?.body])
+
+  const selectedPopLabel = useMemo(() => {
+    if (!selectedPopId) return null
+    const row = pops.find((p) => p.id === selectedPopId)
+    return row?.title ?? popDetailRes?.title ?? null
+  }, [selectedPopId, pops, popDetailRes?.title])
+
+  const selectedPopTitleForSend = selectedPopLabel?.trim() ?? ''
+
+  const canSend =
+    Boolean(emailId) &&
+    Boolean(selectedPopId) &&
+    selectedPopTitleForSend.length > 0 &&
+    replyBody.trim().length > 0 &&
+    !sendMutation.isPending
+
+  const handleSend = useCallback(() => {
+    if (!emailId || !selectedPopId) return
+    const title = selectedPopTitleForSend
+    if (!title || !replyBody.trim()) return
+    sendMutation.mutate({
+      email_id: emailId,
+      title,
+      body: replyBody,
+    })
+  }, [
+    emailId,
+    selectedPopId,
+    selectedPopTitleForSend,
+    replyBody,
+    sendMutation.mutate,
+  ])
+
+  const handleDownload = useCallback(
+    async (a: AttachmentOut) => {
+      if (!emailId) return
+      try {
+        await downloadEmailAttachmentFile(a, emailId)
+      } catch {
+        toast.error('Não foi possível baixar o anexo.')
+      }
+    },
+    [emailId],
+  )
+
+  const subject = email?.subject?.trim() || 'Sem assunto'
+  const fromName = email?.from_name?.trim() || '—'
+  const fromAddr = email?.from_address?.trim()
+  const body = email?.body_preview?.trim() || email?.snippet?.trim() || '—'
+
+  const d = email ? resolveEmailDate(email) : null
+  const timeStr = d ? format(d, 'HH:mm', { locale: ptBR }) : '—'
+  const dateStr = d ? format(d, 'dd/MM/yyyy', { locale: ptBR }) : '—'
+
+  if (!emailId) {
+    return (
+      <div className={styles.root}>
+        <div className={styles.errorBox}>E-mail inválido.</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className={styles.root}>
+      <div className={styles.main}>
+        {emailLoading && (
+          <div className={styles.loadingBox}>Carregando e-mail…</div>
+        )}
+
+        {emailError && !emailLoading && (
+          <div className={styles.errorBox}>
+            Não foi possível carregar o e-mail.
+          </div>
+        )}
+
+        {!emailLoading && !emailError && email && (
+          <div className={styles.visEmail}>
+            <div className={styles.headerBar}>
+              <div className={styles.headerLeft}>
+                <Link
+                  href="/chamados/caixa-entrada"
+                  className={styles.backLink}
+                  aria-label="Voltar para caixa de entrada"
+                >
+                  <ChevronLeft size={16} strokeWidth={2} aria-hidden />
+                </Link>
+                <h1 className={styles.pageTitle}>{subject}</h1>
+              </div>
+            </div>
+
+            <div className={styles.metaRow}>
+              <div className={styles.senderBlock}>
+                <div className={styles.avatar}>
+                  <User size={16} aria-hidden />
+                </div>
+                <div className={styles.senderText}>
+                  <p className={styles.senderName}>{fromName}</p>
+                  {fromAddr ? (
+                    <p className={styles.senderEmail}>&lt;{fromAddr}&gt;</p>
+                  ) : null}
+                </div>
+              </div>
+              <div className={styles.timeBlock}>
+                <span>{timeStr}</span>
+                <span>{dateStr}</span>
+              </div>
+            </div>
+
+            <div className={styles.bodyCard}>
+              <p className={styles.bodyText}>{body}</p>
+            </div>
+
+            {email.attachments.length > 0 ? (
+              <div className={styles.attachmentsRow}>
+                {email.attachments.map((att: AttachmentOut) => (
+                  <div key={att.id} className={styles.attachmentCard}>
+                    <div className={styles.attachmentLeft}>
+                      <div className={styles.pdfIconWrap}>
+                        <FileText size={20} aria-hidden />
+                      </div>
+                      <div className={styles.attachmentInfo}>
+                        <p
+                          className={styles.attachmentName}
+                          title={att.filename}
+                        >
+                          {att.filename}
+                        </p>
+                        <p className={styles.attachmentSize}>
+                          {formatBytes(att.size)}
+                        </p>
+                      </div>
+                    </div>
+                    <button
+                      type="button"
+                      className={styles.downloadBtn}
+                      aria-label={`Baixar ${att.filename}`}
+                      onClick={() => handleDownload(att)}
+                    >
+                      <Download size={16} />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+
+            <div className={`${styles.popField} space-y-1.5`}>
+              <Label className={tcStyles.fieldLabel}>POP de respostas</Label>
+              <Select
+                value={selectedPopId ?? EMPTY_POP_VALUE}
+                onValueChange={(v) =>
+                  setSelectedPopId(v === EMPTY_POP_VALUE ? null : v)
+                }
+                disabled={popsLoading}
+              >
+                <SelectTrigger
+                  className={cn(tcStyles.inputBg, styles.popSelectTrigger)}
+                  aria-label="Resposta padronizada (POP)"
+                >
+                  <SelectValue placeholder="Selecione um pop" />
+                </SelectTrigger>
+                <SelectContent className={tcStyles.selectContentForm}>
+                  <SelectItem
+                    value={EMPTY_POP_VALUE}
+                    className={tcStyles.selectItemForm}
+                  >
+                    Selecione um pop
+                  </SelectItem>
+                  {pops.map((item) => (
+                    <SelectItem
+                      key={item.id}
+                      value={item.id}
+                      className={tcStyles.selectItemForm}
+                    >
+                      {item.title}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className={styles.editorWrap}>
+              <div className={styles.toolbar} aria-hidden>
+                <button type="button" className={styles.toolbarBtn} disabled>
+                  <Bold size={16} />
+                </button>
+                <button type="button" className={styles.toolbarBtn} disabled>
+                  <Italic size={16} />
+                </button>
+                <button type="button" className={styles.toolbarBtn} disabled>
+                  <Underline size={16} />
+                </button>
+                <span className={styles.toolbarDivider} />
+                <button type="button" className={styles.toolbarBtn} disabled>
+                  <List size={16} />
+                </button>
+                <button type="button" className={styles.toolbarBtn} disabled>
+                  <ListOrdered size={16} />
+                </button>
+                <span className={styles.toolbarDivider} />
+                <button type="button" className={styles.toolbarBtn} disabled>
+                  <Link2 size={16} />
+                </button>
+              </div>
+              <textarea
+                className={styles.textarea}
+                value={replyBody}
+                onChange={(e) => setReplyBody(e.target.value)}
+                placeholder={
+                  popDetailLoading
+                    ? 'Carregando texto do POP…'
+                    : 'Digite sua resposta ou selecione um POP acima'
+                }
+                disabled={popDetailLoading && Boolean(selectedPopId)}
+                spellCheck
+              />
+            </div>
+          </div>
+        )}
+
+        {!emailLoading && !emailError && email ? (
+          <div className={styles.footer}>
+            <Link href="/chamados/caixa-entrada" className={styles.btnCancel}>
+              Cancelar
+            </Link>
+            <button
+              type="button"
+              className={styles.btnSend}
+              disabled={!canSend}
+              title={
+                !selectedPopId
+                  ? 'Selecione um POP de respostas'
+                  : !replyBody.trim()
+                    ? 'Digite ou carregue o texto da resposta'
+                    : undefined
+              }
+              onClick={handleSend}
+            >
+              {sendMutation.isPending ? 'Enviando…' : 'Enviar email'}
+            </button>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/src/app/(app)/chamados/caixa-entrada/responder/[emailId]/components/responder-email-view.tsx
+++ b/src/app/(app)/chamados/caixa-entrada/responder/[emailId]/components/responder-email-view.tsx
@@ -40,7 +40,6 @@ import { cn } from '@/lib/utils'
 
 import styles from './responder-email-view.module.css'
 
-/** Valor sentinela para o Select (sem POP) — não colidir com ids da API */
 const EMPTY_POP_VALUE = '__civitas_pop_empty__'
 
 function formatBytes(bytes: number): string {

--- a/src/app/(app)/chamados/caixa-entrada/responder/[emailId]/page.tsx
+++ b/src/app/(app)/chamados/caixa-entrada/responder/[emailId]/page.tsx
@@ -1,0 +1,29 @@
+import { notFound } from 'next/navigation'
+import { Suspense } from 'react'
+
+import { config } from '@/config'
+
+import caixaStyles from '../../caixa-entrada.module.css'
+import { ResponderEmailView } from './components/responder-email-view'
+
+export default function ResponderEmailPage() {
+  if (!config.enableChamados) {
+    notFound()
+  }
+
+  return (
+    <div className={`${caixaStyles.page} px-6 py-6`}>
+      <div className="content w-full min-w-0">
+        <Suspense
+          fallback={
+            <div className="flex min-h-[40vh] items-center justify-center text-sm text-[#97a2ab]">
+              Carregando…
+            </div>
+          }
+        >
+          <ResponderEmailView />
+        </Suspense>
+      </div>
+    </div>
+  )
+}

--- a/src/http/emails/send-standardized-templated-email.ts
+++ b/src/http/emails/send-standardized-templated-email.ts
@@ -1,0 +1,17 @@
+import { api } from '@/lib/api'
+
+export interface EmailStandardizedTemplateSendIn {
+  email_id: string
+  title: string
+  body: string
+}
+
+export interface EmailSendOut {
+  id?: string
+}
+
+export function sendStandardizedTemplatedEmail(
+  payload: EmailStandardizedTemplateSendIn,
+) {
+  return api.post<EmailSendOut>('emails/enviar/resposta-padronizada', payload)
+}

--- a/src/http/standardized-responses/standardized-responses.ts
+++ b/src/http/standardized-responses/standardized-responses.ts
@@ -1,0 +1,50 @@
+import { api } from '@/lib/api'
+
+/** Valores alinhados ao enum `StandardizedResponseCategory` da API. */
+export type StandardizedResponseCategory =
+  | 'RECEBIMENTO_SOLICITACOES'
+  | 'RELATORIOS_PLACAS_RADARES'
+  | 'INSERCAO_PLACAS_CERCO'
+  | 'SOLICITACAO_IMAGENS'
+  | 'MODELOS_CONSOLIDADOS'
+  | 'SOLICITACOES_INDEVIDAS'
+  | 'AGRADECIMENTO'
+  | 'MODELO_OFICIO_DEMANDANTE'
+
+export interface StandardizedResponseListItem {
+  id: string
+  created_at: string
+  category: StandardizedResponseCategory
+  title: string
+  when_to_use: string | null
+  is_active: boolean
+}
+
+export interface StandardizedResponsePage {
+  items: StandardizedResponseListItem[]
+  total: number
+}
+
+export interface StandardizedResponseDetail extends StandardizedResponseListItem {
+  body: string
+}
+
+export function listStandardizedResponses(params?: {
+  search?: string
+  category?: StandardizedResponseCategory
+  isActive?: boolean
+}) {
+  return api.get<StandardizedResponsePage>('/standardized-responses', {
+    params: {
+      search: params?.search,
+      category: params?.category,
+      isActive: params?.isActive,
+    },
+  })
+}
+
+export function getStandardizedResponseById(standardizedResponseId: string) {
+  return api.get<StandardizedResponseDetail>(
+    `/standardized-responses/${encodeURIComponent(standardizedResponseId)}`,
+  )
+}

--- a/src/http/standardized-responses/standardized-responses.ts
+++ b/src/http/standardized-responses/standardized-responses.ts
@@ -1,6 +1,5 @@
 import { api } from '@/lib/api'
 
-/** Valores alinhados ao enum `StandardizedResponseCategory` da API. */
 export type StandardizedResponseCategory =
   | 'RECEBIMENTO_SOLICITACOES'
   | 'RELATORIOS_PLACAS_RADARES'


### PR DESCRIPTION
## Description

Compared to `staging`, this branch includes:

- **Inbox email reply:** New route `responder/[emailId]` with a dedicated screen (`responder-email-view` + CSS module), integration with standardized email sending (`send-standardized-templated-email`) and standardized responses (`standardized-responses`). The email preview now uses `Link` to open the reply flow, and email ID handling was improved.
- **Tickets:** Email ID support in the ticket creation flow (`use-create-controller`), updates to the general ticket list and ticket conversion (`convert-ticket-to-conventional`).
- **Sidebar:** Nested modules (children) and accordion rendering (`constants`, `sidebar-accordion`).
- **Teams:** Delete-team dialog, updates to team and team-member form dialogs, teams list and controller (`use-teams-controller`), plus small island-related adjustments (`list-islands`).
- **HTTP layer:** Extensions to teams APIs (`get-teams`, `create-team`, `update-team`) and other endpoints touched in the diff.
- **Cleanup:** Removed outdated comments in team-related constants/components; import reorder in `profile-access-table`.

**Diff stats (staging...HEAD):** ~22 files, +1444 / -110 lines (approx.).

## Motivation and Context

Deliver the **reply-to-email** flow from the inbox with a dedicated page and standardized sending, plus **navigation** improvements (nested sidebar modules), **team management** (dialogs/CRUD), and **tickets** (email ↔ ticket linkage where applicable).  
For staging deployment, a GitHub PR is not required; use this text for internal review or merge notes.

## Screenshots (if appropriate):
<img width="1779" height="939" alt="image" src="https://github.com/user-attachments/assets/fe7e6970-7de2-48b4-8cee-01bf7ff1b96c" />

_(Add screenshots of the reply screen, nested sidebar, and team dialogs if useful for review.)_

## Types of changes

- [ ] fix: used when there is correction of errors that are generating bugs in the system.
- [x] feat: indicates the development of a new feature for the project.
- [ ] perf: indicates a change that improved system performance.
- [ ] test: indicates any type of creation or change of test codes.
- [x] refactor: used when there is a code refactoring that does not have any type of impact on the system's business logic/rules.
- [ ] style: used when there are formatting and code style changes that do not alter the system in any way.
- [ ] chore: indicates changes to the project that do not affect the system or test files.
- [ ] docs: used when there are changes to the project documentation.
- [ ] build: used to indicate changes that affect the project's build process or external dependencies.
- [ ] ci: used for changes to CI configuration files.
- [ ] revert: indicates the revert of a previous commit