### PR TITLE
fix: add get-operations HTTP client and Prettier fixes for staging build/CI

### DIFF
--- a/src/components/custom/double-slider.tsx
+++ b/src/components/custom/double-slider.tsx
@@ -5,8 +5,9 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-interface CustomSliderProps
-  extends React.ComponentPropsWithoutRef<typeof SliderPrimitive.Root> {
+interface CustomSliderProps extends React.ComponentPropsWithoutRef<
+  typeof SliderPrimitive.Root
+> {
   unity?: string
   labelFormatter?: (value: number, thumbIndex: number) => string
 }

--- a/src/components/custom/multi-select-with-search.tsx
+++ b/src/components/custom/multi-select-with-search.tsx
@@ -57,7 +57,8 @@ const multiSelectVariants = cva(
  * Props for MultiSelect component
  */
 interface MultiSelectProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+  extends
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof multiSelectVariants> {
   /**
    * An array of option objects to be displayed in the multi-select component.

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -24,7 +24,8 @@ const badgeVariants = cva(
 )
 
 export interface BadgeProps
-  extends React.HTMLAttributes<HTMLDivElement>,
+  extends
+    React.HTMLAttributes<HTMLDivElement>,
     VariantProps<typeof badgeVariants> {}
 
 function Badge({ className, variant, ...props }: BadgeProps) {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -34,7 +34,8 @@ const buttonVariants = cva(
 )
 
 export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+  extends
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
   asChild?: boolean
 }

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -50,7 +50,8 @@ const sheetVariants = cva(
 )
 
 interface SheetContentProps
-  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+  extends
+    React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
     VariantProps<typeof sheetVariants> {}
 
 const SheetContent = React.forwardRef<

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/http/operations/get-operations.ts
+++ b/src/http/operations/get-operations.ts
@@ -1,0 +1,17 @@
+import { api } from '@/lib/api'
+import type { PaginationRequest, PaginationResponse } from '@/models/pagination'
+
+export interface Operation {
+  id: string
+  title: string
+}
+
+export interface GetOperationsResponse extends PaginationResponse {
+  items: Operation[]
+}
+
+export function getOperations({ page, size }: PaginationRequest) {
+  return api.get<GetOperationsResponse>('/operations', {
+    params: { page, size },
+  })
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This change restores the missing operations HTTP client and aligns several UI components with the project’s Prettier rules so the staging build and CI pass.

- **New HTTP module** `src/http/operations/get-operations.ts`: defines `Operation`, `GetOperationsResponse`, and `getOperations({ page, size })` calling `GET /operations` with pagination query params, using the shared `api` client and existing `PaginationRequest` / `PaginationResponse` types.
- **Formatting-only updates** in `double-slider`, `multi-select-with-search`, `badge`, `button`, `sheet`, and `textarea`: line breaks and interface `extends` layout per Prettier (no runtime behavior change).

## Motivation and Context

The staging pipeline was failing because code expected an operations client module that was not present, and/or CI rejected formatting on the listed files. Adding `get-operations` fixes the missing-module/build issue; the Prettier edits satisfy the formatter check without changing component behavior.

## Screenshots (if appropriate):

N/A — no visual or UX changes.

## Types of changes

- [x] fix: used when there is correction of errors that are generating bugs in the system.
- [ ] feat: indicates the development of a new feature for the project.
- [ ] perf: indicates a change that improved system performance.
- [ ] test: indicates any type of creation or change of test codes.
- [ ] refactor: used when there is a code refactoring that does not have any type of impact on the system's business logic/rules.
- [x] style: used when there are formatting and code style changes that do not alter the system in any way.
- [ ] chore: indicates changes to the project that do not affect the system or test files.
- [ ] docs: used when there are changes to the project documentation.
- [ ] build: used to indicate changes that affect the project's build process or external dependencies.
- [ ] ci: used for changes to CI configuration files.
- [ ] revert: indicates the revert of a previous commit