### PR TITLE
feat: filter standardized responses by RECEBIMENTO_SOLICITACOES on email reply

### DIFF
--- a/src/app/(app)/chamados/caixa-entrada/responder/[emailId]/components/responder-email-view.tsx
+++ b/src/app/(app)/chamados/caixa-entrada/responder/[emailId]/components/responder-email-view.tsx
@@ -103,9 +103,16 @@ export function ResponderEmailView() {
   const email = emailRes?.data
 
   const { data: popsRes, isLoading: popsLoading } = useQuery({
-    queryKey: ['standardized-responses', 'list', { isActive: true }],
+    queryKey: [
+      'standardized-responses',
+      'list',
+      { isActive: true, category: 'RECEBIMENTO_SOLICITACOES' as const },
+    ],
     queryFn: async () => {
-      const r = await listStandardizedResponses({ isActive: true })
+      const r = await listStandardizedResponses({
+        isActive: true,
+        category: 'RECEBIMENTO_SOLICITACOES',
+      })
       return r.data
     },
   })

--- a/src/http/standardized-responses/standardized-responses.ts
+++ b/src/http/standardized-responses/standardized-responses.ts
@@ -24,7 +24,8 @@ export interface StandardizedResponsePage {
   total: number
 }
 
-export interface StandardizedResponseDetail extends StandardizedResponseListItem {
+export interface StandardizedResponseDetail
+  extends StandardizedResponseListItem {
   body: string
 }
 


### PR DESCRIPTION
## Description

This branch scopes **standardized responses** on the **reply email** screen (`ResponderEmailView`) to the **`RECEBIMENTO_SOLICITACOES`** category, in addition to `isActive: true`. The React Query `queryKey` and the `listStandardizedResponses` request were updated so the list matches the intended inbox/reply context.

A small **formatting-only** change splits the `StandardizedResponseDetail extends StandardizedResponseListItem` declaration across lines in `standardized-responses.ts` for readability.

**Commits (vs `staging`):**

1. `feat:` enhance standardized responses query by adding category filter for `RECEBIMENTO_SOLICITACOES`
2. `refactor:` improve formatting of `StandardizedResponseDetail` interface for better readability

**Changed files:**

- `src/app/(app)/chamados/caixa-entrada/responder/[emailId]/components/responder-email-view.tsx`
- `src/http/standardized-responses/standardized-responses.ts`

## Related Issue


## Motivation and Context

Standardized responses used when replying to emails should be limited to the correct **business category** so operators only see templates relevant to **request intake / inbox replies**, instead of every active standardized response in the system.

## How has this been tested?

- [ ] Open **Inbox → Reply** for an email and confirm the standardized-response list only includes items with category **`RECEBIMENTO_SOLICITACOES`** (and active).
- [ ] Confirm other flows that list standardized responses without this filter still behave as before.

*(Automated tests were not run as part of this review.)*

## Screenshots (if appropriate):

N/A (data filtering / no visual redesign).

## Types of changes

- [ ] fix: used when there is correction of errors that are generating bugs in the system.
- [x] feat: indicates the development of a new feature for the project.
- [ ] perf: indicates a change that improved system performance.
- [ ] test: indicates any type of creation or change of test codes.
- [x] refactor: used when there is a code refactoring that does not have any type of impact on the system's business logic/rules.
- [ ] style: used when there are formatting and code style changes that do not alter the system in any way.
- [ ] chore: indicates changes to the project that do not affect the system or test files.
- [ ] docs: used when there are changes to the project documentation.
- [ ] build: used to indicate changes that affect the project's build process or external dependencies.
- [ ] ci: used for changes to CI configuration files.
- [ ] revert: indicates the revert of a previous commit

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

---

**Branch:** `feat/response-email` · **Remote:** `origin/feat/response-email` (up to date when last checked)

**Note:** This summary compares **`staging...HEAD`**. If the PR targets **`main`**, update the base branch and refresh the description to match the actual diff.