### PR TITLE
test(radar-layer): fix hook tests with react-query provider

### DIFF
--- a/src/__tests__/hooks/mapLayers/use-radar-layer.test.tsx
+++ b/src/__tests__/hooks/mapLayers/use-radar-layer.test.tsx
@@ -1,7 +1,9 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
 
 import { useRadarLayer } from '@/hooks/mapLayers/use-radar-layer'
-import type { Radar } from '@/models/entities'
+import type { CollectionPoint } from '@/models/entities'
 
 jest.mock('deck.gl', () => ({
   IconLayer: jest.fn().mockImplementation(() => ({
@@ -10,8 +12,8 @@ jest.mock('deck.gl', () => ({
   })),
 }))
 
-jest.mock('@/hooks/useQueries/useRadars', () => ({
-  useRadars: () => ({
+jest.mock('@/hooks/useQueries/useCollectionPoints', () => ({
+  useCollectionPoints: () => ({
     data: [
       {
         cetRioCode: 'RDR123',
@@ -47,13 +49,32 @@ jest.mock('@/assets/radar-icon-atlas.png', () => ({
   src: '/mock-radar-icon-atlas.png',
 }))
 
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
+
+const renderUseRadarLayer = () =>
+  renderHook(() => useRadarLayer(), { wrapper: createWrapper() })
+
 describe('useRadarLayer', () => {
   beforeEach(() => {
     jest.clearAllMocks()
   })
 
   it('deve retornar estrutura correta do hook', () => {
-    const { result } = renderHook(() => useRadarLayer())
+    const { result } = renderUseRadarLayer()
 
     expect(result.current).toHaveProperty('data')
     expect(result.current).toHaveProperty('layer')
@@ -67,19 +88,19 @@ describe('useRadarLayer', () => {
   })
 
   it('deve inicializar com selectedObject como null', () => {
-    const { result } = renderHook(() => useRadarLayer())
+    const { result } = renderUseRadarLayer()
 
     expect(result.current.selectedObject).toBeNull()
   })
 
   it('deve inicializar com isVisible como true', () => {
-    const { result } = renderHook(() => useRadarLayer())
+    const { result } = renderUseRadarLayer()
 
     expect(result.current.isVisible).toBe(true)
   })
 
   it('deve permitir alterar isVisible', () => {
-    const { result } = renderHook(() => useRadarLayer())
+    const { result } = renderUseRadarLayer()
 
     act(() => {
       result.current.setIsVisible(false)
@@ -89,7 +110,7 @@ describe('useRadarLayer', () => {
   })
 
   it('deve permitir alterar hoveredObject', () => {
-    const { result } = renderHook(() => useRadarLayer())
+    const { result } = renderUseRadarLayer()
     const mockPickingInfo = { object: { cetRioCode: 'RDR123' } } as any
 
     act(() => {
@@ -100,20 +121,23 @@ describe('useRadarLayer', () => {
   })
 
   it('deve selecionar radar quando handleSelectObject é chamado com radar diferente', () => {
-    const { result } = renderHook(() => useRadarLayer())
-    const mockRadar: Radar = {
+    const { result } = renderUseRadarLayer()
+    const mockRadar = {
       cetRioCode: 'RDR123',
+      codigoPontoColeta: 'PC123',
       location: 'avenida brasil',
       district: 'centro',
       latitude: -22.9068,
       longitude: -43.1729,
       company: 'CET-Rio',
+      statusAtivo: 'ATIVO',
       activeInLast24Hours: true,
+      totalDetections: 1,
       lastDetectionTime: '2024-01-15T10:30:00Z',
       hasData: true,
       direction: 'norte',
       lane: 'direita',
-    }
+    } as CollectionPoint
 
     act(() => {
       result.current.handleSelectObject(mockRadar)
@@ -123,20 +147,23 @@ describe('useRadarLayer', () => {
   })
 
   it('deve desselecionar radar quando handleSelectObject é chamado com mesmo radar', () => {
-    const { result } = renderHook(() => useRadarLayer())
-    const mockRadar: Radar = {
+    const { result } = renderUseRadarLayer()
+    const mockRadar = {
       cetRioCode: 'RDR123',
+      codigoPontoColeta: 'PC123',
       location: 'avenida brasil',
       district: 'centro',
       latitude: -22.9068,
       longitude: -43.1729,
       company: 'CET-Rio',
+      statusAtivo: 'ATIVO',
       activeInLast24Hours: true,
+      totalDetections: 1,
       lastDetectionTime: '2024-01-15T10:30:00Z',
       hasData: true,
       direction: 'norte',
       lane: 'direita',
-    }
+    } as CollectionPoint
 
     act(() => {
       result.current.handleSelectObject(mockRadar)
@@ -151,20 +178,23 @@ describe('useRadarLayer', () => {
   })
 
   it('deve chamar clearCamera quando fornecido', () => {
-    const { result } = renderHook(() => useRadarLayer())
-    const mockRadar: Radar = {
+    const { result } = renderUseRadarLayer()
+    const mockRadar = {
       cetRioCode: 'RDR123',
+      codigoPontoColeta: 'PC123',
       location: 'avenida brasil',
       district: 'centro',
       latitude: -22.9068,
       longitude: -43.1729,
       company: 'CET-Rio',
+      statusAtivo: 'ATIVO',
       activeInLast24Hours: true,
+      totalDetections: 1,
       lastDetectionTime: '2024-01-15T10:30:00Z',
       hasData: true,
       direction: 'norte',
       lane: 'direita',
-    }
+    } as CollectionPoint
     const mockClearCamera = jest.fn()
 
     act(() => {
@@ -175,13 +205,13 @@ describe('useRadarLayer', () => {
   })
 
   it('deve criar layer com configurações corretas', () => {
-    const { result } = renderHook(() => useRadarLayer())
+    const { result } = renderUseRadarLayer()
 
     expect(result.current.layer).toBeDefined()
   })
 
   it('deve criar layer com dados corretos', () => {
-    const { result } = renderHook(() => useRadarLayer())
+    const { result } = renderUseRadarLayer()
 
     expect(result.current.data).toHaveLength(2)
     expect(result.current.data?.[0]?.cetRioCode).toBe('RDR123')
@@ -189,31 +219,31 @@ describe('useRadarLayer', () => {
   })
 
   it('deve criar layer com iconMapping correto', () => {
-    const { result } = renderHook(() => useRadarLayer())
+    const { result } = renderUseRadarLayer()
 
     expect(result.current.layer).toBeDefined()
   })
 
   it('deve criar layer com getIcon function', () => {
-    const { result } = renderHook(() => useRadarLayer())
+    const { result } = renderUseRadarLayer()
 
     expect(result.current.layer).toBeDefined()
   })
 
   it('deve criar layer com getPosition function', () => {
-    const { result } = renderHook(() => useRadarLayer())
+    const { result } = renderUseRadarLayer()
 
     expect(result.current.layer).toBeDefined()
   })
 
   it('deve criar layer com getColor function', () => {
-    const { result } = renderHook(() => useRadarLayer())
+    const { result } = renderUseRadarLayer()
 
     expect(result.current.layer).toBeDefined()
   })
 
   it('deve retornar dados corretos do useRadars', () => {
-    const { result } = renderHook(() => useRadarLayer())
+    const { result } = renderUseRadarLayer()
 
     expect(result.current.data).toHaveLength(2)
     expect(result.current.data?.[0]?.cetRioCode).toBe('RDR123')
@@ -221,7 +251,7 @@ describe('useRadarLayer', () => {
   })
 
   it('deve manter referência estável das funções entre renders', () => {
-    const { result, rerender } = renderHook(() => useRadarLayer())
+    const { result, rerender } = renderUseRadarLayer()
 
     const firstRender = {
       setHoveredObject: result.current.setHoveredObject,

--- a/src/__tests__/hooks/use-radar-layer-multiselect.test.tsx
+++ b/src/__tests__/hooks/use-radar-layer-multiselect.test.tsx
@@ -1,13 +1,15 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { act, renderHook } from '@testing-library/react'
+import type { ReactNode } from 'react'
 
 import { useRadarLayer } from '@/hooks/mapLayers/use-radar-layer'
-import type { Radar } from '@/models/entities'
+import type { CollectionPoint } from '@/models/entities'
 import { useMapStore } from '@/stores/use-map-store'
 
 jest.mock('@/stores/use-map-store')
 
-jest.mock('@/hooks/useQueries/useRadars', () => ({
-  useRadars: () => ({
+jest.mock('@/hooks/useQueries/useCollectionPoints', () => ({
+  useCollectionPoints: () => ({
     data: [
       {
         cetRioCode: '0540461121',
@@ -54,9 +56,25 @@ jest.mock('@/hooks/useQueries/useRadars', () => ({
         company: 'CET-Rio',
         activeInLast24Hours: true,
       },
-    ] as Radar[],
+    ] as CollectionPoint[],
   }),
 }))
+
+const createWrapper = () => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  })
+
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    )
+  }
+}
 
 describe('useRadarLayer - Multi-selection bug', () => {
   let mockSetMultipleSelectedRadars: jest.Mock
@@ -75,15 +93,16 @@ describe('useRadarLayer - Multi-selection bug', () => {
   })
 
   it('should reproduce bug: select 4+ radars, deselect some, reselect', () => {
-    const { result, rerender } = renderHook(() =>
-      useRadarLayer(mockMultipleSelectedRadars),
+    const { result, rerender } = renderHook(
+      () => useRadarLayer(mockMultipleSelectedRadars),
+      { wrapper: createWrapper() },
     )
 
     const radars = [
-      { cetRioCode: '0540461121' } as Radar,
-      { cetRioCode: '0540461122' } as Radar,
-      { cetRioCode: '0540461123' } as Radar,
-      { cetRioCode: '0540461124' } as Radar,
+      { cetRioCode: '0540461121' } as CollectionPoint,
+      { cetRioCode: '0540461122' } as CollectionPoint,
+      { cetRioCode: '0540461123' } as CollectionPoint,
+      { cetRioCode: '0540461124' } as CollectionPoint,
     ]
 
     act(() => {
@@ -121,7 +140,7 @@ describe('useRadarLayer - Multi-selection bug', () => {
     act(() => {
       result.current.handleMultiSelectObject({
         cetRioCode: '0540461122',
-      } as Radar)
+      } as CollectionPoint)
     })
 
     mockMultipleSelectedRadars = ['0540461124', '0540461123', '0540461121']
@@ -130,7 +149,7 @@ describe('useRadarLayer - Multi-selection bug', () => {
     act(() => {
       result.current.handleMultiSelectObject({
         cetRioCode: '0540461125',
-      } as Radar)
+      } as CollectionPoint)
     })
 
     expect(mockSetMultipleSelectedRadars).toHaveBeenCalledTimes(6)
@@ -139,8 +158,9 @@ describe('useRadarLayer - Multi-selection bug', () => {
   it('should verify if selectedObjects is calculated correctly', () => {
     mockMultipleSelectedRadars = ['0540461121', '0540461123']
 
-    const { result } = renderHook(() =>
-      useRadarLayer(mockMultipleSelectedRadars),
+    const { result } = renderHook(
+      () => useRadarLayer(mockMultipleSelectedRadars),
+      { wrapper: createWrapper() },
     )
 
     expect(result.current.selectedObjects).toHaveLength(2)
@@ -153,8 +173,9 @@ describe('useRadarLayer - Multi-selection bug', () => {
   it('should verify if state does not change when it should not', () => {
     mockMultipleSelectedRadars = ['0540461121', '0540461122']
 
-    const { result, rerender } = renderHook(() =>
-      useRadarLayer(mockMultipleSelectedRadars),
+    const { result, rerender } = renderHook(
+      () => useRadarLayer(mockMultipleSelectedRadars),
+      { wrapper: createWrapper() },
     )
 
     const initialSelectedObjects = result.current.selectedObjects


### PR DESCRIPTION
Add QueryClientProvider wrapper to radar-layer hook tests, update mocks to useCollectionPoints, and align test objects with CollectionPoint types.