### PR TITLE
feat(chamados): preview attachments, review comment & unblock, service filters, inbox unread badge

### DIFF
--- a/src/app/(app)/chamados/[ticketId]/components/ticket-detail-tab-chamado.tsx
+++ b/src/app/(app)/chamados/[ticketId]/components/ticket-detail-tab-chamado.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 
+import { TICKET_CREATE_STRING_LIMITS as CREATE_STR_LIMITS } from '@/app/(app)/chamados/criar/ticket-create/ticket-create.constant'
 import {
   Select,
   SelectContent,
@@ -28,6 +29,10 @@ import {
 } from '@/http/tickets/ticket-ficha'
 import { isApiError } from '@/lib/api'
 import { getApiErrorMessage } from '@/utils/error-handlers'
+import {
+  maskNumeroOficio,
+  normalizeNumeroOficio,
+} from '@/utils/string-formatters'
 
 import styles from '../ticket-detail.module.css'
 
@@ -92,7 +97,12 @@ function mapOutToDraft(f: TicketFichaOut): TicketFichaUpdateIn {
     numero_procedimento: f.numero_procedimento?.trim()
       ? f.numero_procedimento.trim()
       : null,
-    numero_oficio: f.numero_oficio?.trim() ? f.numero_oficio.trim() : null,
+    numero_oficio: (() => {
+      const t = f.numero_oficio?.trim()
+      if (!t) return null
+      const n = normalizeNumeroOficio(t)
+      return n || null
+    })(),
     natureza_id: f.natureza_id?.trim() ? f.natureza_id.trim() : null,
     possui_apelido_imprensa: f.possui_apelido_imprensa,
     apelido_imprensa: f.apelido_imprensa?.trim()
@@ -233,10 +243,12 @@ export function TicketDetailTabChamado({ ticketId }: Props) {
       return
     }
 
-    const oficio = draft.numero_oficio?.trim() ?? ''
+    const oficio = normalizeNumeroOficio(draft.numero_oficio?.trim() ?? '')
     const proc = draft.numero_procedimento?.trim() ?? ''
-    if (oficio.length > MAX_OFICIO_PROC) {
-      toast.error(`Nº de ofício: no máximo ${MAX_OFICIO_PROC} caracteres.`)
+    if (oficio && !/^\d{5}\/\d{4}$/.test(oficio)) {
+      toast.error(
+        'Nº de ofício: use o formato 00000/0000 (ex.: 00123/2026), ou deixe em branco.',
+      )
       return
     }
     if (proc.length > MAX_OFICIO_PROC) {
@@ -337,7 +349,7 @@ export function TicketDetailTabChamado({ ticketId }: Props) {
                   disabled={ticketTypesQuery.isLoading}
                 >
                   <SelectTrigger
-                    className={`h-11 ${styles.detailSelectTrigger}`}
+                    className={`h-11 ${styles.detailSelectTrigger} ${styles.solicitanteEditSelectTrigger}`}
                   >
                     <SelectValue
                       placeholder={
@@ -361,9 +373,7 @@ export function TicketDetailTabChamado({ ticketId }: Props) {
                 </Select>
               ) : (
                 <div
-                  className={`${styles.readonlyInput} ${
-                    hasTipoNome ? '' : styles.readonlyInputMuted
-                  }`}
+                  className={`${styles.readonlyInput} ${styles.solicitanteReadOnlyText}`}
                 >
                   {tipoNomeReadonly}
                 </div>
@@ -373,7 +383,9 @@ export function TicketDetailTabChamado({ ticketId }: Props) {
               <div className={styles.subLabel}>
                 <span className={styles.subLabelText}>Nº interno</span>
               </div>
-              <div className={styles.readonlyInput}>
+              <div
+                className={`${styles.readonlyInput} ${styles.solicitanteReadOnlyText}`}
+              >
                 {formatNumeroInterno(view.numero_interno ?? null)}
               </div>
             </div>
@@ -386,22 +398,37 @@ export function TicketDetailTabChamado({ ticketId }: Props) {
               </div>
               {isEditing ? (
                 <input
-                  className={styles.editableField}
+                  className={`${styles.editableField} ${styles.solicitanteEditField}`}
                   value={d.numero_oficio ?? ''}
-                  maxLength={MAX_OFICIO_PROC}
+                  inputMode="numeric"
+                  autoComplete="off"
+                  maxLength={CREATE_STR_LIMITS.numero_oficio}
+                  onBlur={() =>
+                    setDraft((prev) => {
+                      if (!prev) return prev
+                      const raw = (prev.numero_oficio ?? '').trim()
+                      if (!raw) return { ...prev, numero_oficio: null }
+                      const normalized = normalizeNumeroOficio(raw)
+                      return normalized === prev.numero_oficio
+                        ? prev
+                        : { ...prev, numero_oficio: normalized || null }
+                    })
+                  }
                   onChange={(e) =>
                     setDraft((prev) =>
                       prev
-                        ? { ...prev, numero_oficio: e.target.value || null }
+                        ? {
+                            ...prev,
+                            numero_oficio:
+                              maskNumeroOficio(e.target.value) || null,
+                          }
                         : prev,
                     )
                   }
                 />
               ) : (
                 <div
-                  className={`${styles.readonlyInput} ${
-                    view.numero_oficio?.trim() ? '' : styles.readonlyInputMuted
-                  }`}
+                  className={`${styles.readonlyInput} ${styles.solicitanteReadOnlyText}`}
                 >
                   {displayText(view.numero_oficio)}
                 </div>
@@ -413,7 +440,7 @@ export function TicketDetailTabChamado({ ticketId }: Props) {
               </div>
               {isEditing ? (
                 <input
-                  className={styles.editableField}
+                  className={`${styles.editableField} ${styles.solicitanteEditField}`}
                   value={d.numero_procedimento ?? ''}
                   maxLength={MAX_OFICIO_PROC}
                   onChange={(e) =>
@@ -429,11 +456,7 @@ export function TicketDetailTabChamado({ ticketId }: Props) {
                 />
               ) : (
                 <div
-                  className={`${styles.readonlyInput} ${
-                    view.numero_procedimento?.trim()
-                      ? ''
-                      : styles.readonlyInputMuted
-                  }`}
+                  className={`${styles.readonlyInput} ${styles.solicitanteReadOnlyText}`}
                 >
                   {displayText(view.numero_procedimento)}
                 </div>
@@ -465,7 +488,9 @@ export function TicketDetailTabChamado({ ticketId }: Props) {
                 }
                 disabled={operationsQuery.isLoading}
               >
-                <SelectTrigger className={`h-11 ${styles.detailSelectTrigger}`}>
+                <SelectTrigger
+                  className={`h-11 ${styles.detailSelectTrigger} ${styles.solicitanteEditSelectTrigger}`}
+                >
                   <SelectValue
                     placeholder={
                       operationsQuery.isLoading ? 'Carregando…' : undefined
@@ -494,13 +519,7 @@ export function TicketDetailTabChamado({ ticketId }: Props) {
               </Select>
             ) : (
               <div className={styles.readonlySelect}>
-                <span
-                  className={
-                    orgaoReadonlyTitle && orgaoReadonlyTitle !== 'Carregando…'
-                      ? ''
-                      : styles.readonlySelectMuted
-                  }
-                >
+                <span className={styles.solicitanteReadOnlyText}>
                   {selectedOrgaoId
                     ? displayText(orgaoReadonlyTitle || null)
                     : '—'}
@@ -531,7 +550,9 @@ export function TicketDetailTabChamado({ ticketId }: Props) {
                 }
                 disabled={ticketNaturesQuery.isLoading}
               >
-                <SelectTrigger className={`h-11 ${styles.detailSelectTrigger}`}>
+                <SelectTrigger
+                  className={`h-11 ${styles.detailSelectTrigger} ${styles.solicitanteEditSelectTrigger}`}
+                >
                   <SelectValue
                     placeholder={
                       ticketNaturesQuery.isLoading ? 'Carregando…' : 'Selecione'
@@ -554,11 +575,7 @@ export function TicketDetailTabChamado({ ticketId }: Props) {
               </Select>
             ) : (
               <div className={styles.readonlySelect}>
-                <span
-                  className={
-                    view.natureza_nome?.trim() ? '' : styles.readonlySelectMuted
-                  }
-                >
+                <span className={styles.solicitanteReadOnlyText}>
                   {view.natureza_nome?.trim()
                     ? view.natureza_nome
                     : 'Selecione'}
@@ -602,7 +619,7 @@ export function TicketDetailTabChamado({ ticketId }: Props) {
                   }
                 >
                   <SelectTrigger
-                    className={`h-11 ${styles.detailSelectTrigger}`}
+                    className={`h-11 ${styles.detailSelectTrigger} ${styles.solicitanteEditSelectTrigger}`}
                   >
                     <SelectValue />
                   </SelectTrigger>
@@ -617,7 +634,9 @@ export function TicketDetailTabChamado({ ticketId }: Props) {
                 </Select>
               ) : (
                 <div className={styles.readonlySelect}>
-                  <span>{pressSimNao}</span>
+                  <span className={styles.solicitanteReadOnlyText}>
+                    {pressSimNao}
+                  </span>
                   <ChevronDown
                     size={20}
                     className={styles.readonlySelectMuted}
@@ -635,7 +654,7 @@ export function TicketDetailTabChamado({ ticketId }: Props) {
                 </div>
                 {isEditing ? (
                   <input
-                    className={styles.editableField}
+                    className={`${styles.editableField} ${styles.solicitanteEditField}`}
                     value={d.apelido_imprensa ?? ''}
                     maxLength={MAX_APELIDO}
                     onChange={(e) =>
@@ -651,11 +670,7 @@ export function TicketDetailTabChamado({ ticketId }: Props) {
                   />
                 ) : (
                   <div
-                    className={`${styles.readonlyInput} ${
-                      view.apelido_imprensa?.trim()
-                        ? ''
-                        : styles.readonlyInputMuted
-                    }`}
+                    className={`${styles.readonlyInput} ${styles.solicitanteReadOnlyText}`}
                   >
                     {displayText(view.apelido_imprensa)}
                   </div>
@@ -667,7 +682,7 @@ export function TicketDetailTabChamado({ ticketId }: Props) {
                 </div>
                 {isEditing ? (
                   <input
-                    className={styles.editableField}
+                    className={`${styles.editableField} ${styles.solicitanteEditField}`}
                     type="url"
                     value={d.link_materia ?? ''}
                     onChange={(e) =>

--- a/src/app/(app)/chamados/[ticketId]/components/ticket-detail-tab-documentos.tsx
+++ b/src/app/(app)/chamados/[ticketId]/components/ticket-detail-tab-documentos.tsx
@@ -1,11 +1,14 @@
 'use client'
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
-import { Download, FileText, X } from 'lucide-react'
+import { Download, Eye, FileText, X } from 'lucide-react'
 import { useCallback, useState } from 'react'
 import { toast } from 'sonner'
 
-import { downloadTicketAttachmentFile } from '@/http/tickets/download-ticket-attachment'
+import {
+  downloadTicketAttachmentFile,
+  fetchTicketAttachmentBlob,
+} from '@/http/tickets/download-ticket-attachment'
 import {
   deleteTicketAttachment,
   getTicketAttachments,
@@ -29,6 +32,7 @@ type Props = {
 export function TicketDetailTabDocumentos({ ticketId }: Props) {
   const queryClient = useQueryClient()
   const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [viewingId, setViewingId] = useState<string | null>(null)
 
   const attachmentsQuery = useQuery({
     queryKey: ['ticket-attachments', ticketId],
@@ -67,6 +71,35 @@ export function TicketDetailTabDocumentos({ ticketId }: Props) {
         await downloadTicketAttachmentFile(a, ticketId)
       } catch {
         toast.error('Não foi possível baixar o anexo.')
+      }
+    },
+    [ticketId],
+  )
+
+  const handleView = useCallback(
+    async (a: { id: string; filename: string }) => {
+      try {
+        setViewingId(a.id)
+        const { blob, contentType } = await fetchTicketAttachmentBlob(
+          ticketId,
+          a.id,
+        )
+        const previewBlob = new Blob([blob], { type: contentType })
+        const previewUrl = URL.createObjectURL(previewBlob)
+        const newTab = window.open(previewUrl, '_blank', 'noopener,noreferrer')
+
+        if (!newTab) {
+          URL.revokeObjectURL(previewUrl)
+          toast.error('Não foi possível abrir a visualização do anexo.')
+          return
+        }
+
+        // Mantém a URL válida tempo suficiente para o navegador carregar o arquivo.
+        window.setTimeout(() => URL.revokeObjectURL(previewUrl), 60_000)
+      } catch {
+        toast.error('Não foi possível visualizar o anexo.')
+      } finally {
+        setViewingId(null)
       }
     },
     [ticketId],
@@ -143,9 +176,19 @@ export function TicketDetailTabDocumentos({ ticketId }: Props) {
                   <button
                     type="button"
                     className={styles.docIconBtn}
+                    aria-label={`Visualizar ${att.filename}`}
+                    title="Visualizar anexo"
+                    onClick={() => handleView(att)}
+                    disabled={deletingId === att.id || viewingId === att.id}
+                  >
+                    <Eye size={18} />
+                  </button>
+                  <button
+                    type="button"
+                    className={styles.docIconBtn}
                     aria-label={`Baixar ${att.filename}`}
                     onClick={() => handleDownload(att)}
-                    disabled={deletingId === att.id}
+                    disabled={deletingId === att.id || viewingId === att.id}
                   >
                     <Download size={18} />
                   </button>
@@ -155,7 +198,7 @@ export function TicketDetailTabDocumentos({ ticketId }: Props) {
                     aria-label={`Remover ${att.filename}`}
                     title="Remover anexo"
                     onClick={() => handleDelete(att)}
-                    disabled={deletingId === att.id}
+                    disabled={deletingId === att.id || viewingId === att.id}
                   >
                     <X size={18} />
                   </button>

--- a/src/app/(app)/chamados/[ticketId]/components/ticket-detail-tab-servicos.tsx
+++ b/src/app/(app)/chamados/[ticketId]/components/ticket-detail-tab-servicos.tsx
@@ -18,6 +18,12 @@ import {
 } from '@/components/ui/dialog'
 import type { TicketAttachmentOut } from '@/http/tickets/ticket-attachments'
 import {
+  completeTicketVideoAttachment,
+  putVideoToGcsSignedUrl,
+  requestTicketVideoUploadUrl,
+  uploadTicketServiceAttachmentsMultipart,
+} from '@/http/tickets/ticket-attachments'
+import {
   getTicketServicos,
   replaceTicketServicos,
   type TicketServicosOut,
@@ -117,10 +123,14 @@ type Props = {
   ticketId: string
 }
 
+type PendingServiceFilesByRowId = Record<string, File[]>
+
 export function TicketDetailTabServicos({ ticketId }: Props) {
   const queryClient = useQueryClient()
   const [isEditing, setIsEditing] = useState(false)
   const [addServicoOpen, setAddServicoOpen] = useState(false)
+  const [pendingFilesByRowId, setPendingFilesByRowId] =
+    useState<PendingServiceFilesByRowId>({})
 
   const servicosQuery = useQuery({
     queryKey: ['ticket', ticketId, 'servicos'],
@@ -154,24 +164,6 @@ export function TicketDetailTabServicos({ ticketId }: Props) {
   const replaceMutation = useMutation({
     mutationFn: (payload: ReturnType<typeof ticketServicosToReplacePayload>) =>
       replaceTicketServicos(ticketId, payload),
-    onSuccess: (data) => {
-      const c = cloneTicketServicos(data)
-      setDraft(c)
-      setSnapshot(cloneTicketServicos(data))
-      setIsEditing(false)
-      setExpandedId(null)
-      queryClient.setQueryData(['ticket', ticketId, 'servicos'], data)
-      queryClient.invalidateQueries({ queryKey: ['ticket', ticketId] })
-      toast.success('Serviços salvos com sucesso.')
-    },
-    onError: (err: unknown) => {
-      const msg = isApiError(err)
-        ? (err.response?.data as { detail?: string } | undefined)?.detail
-        : undefined
-      toast.error(
-        typeof msg === 'string' ? msg : 'Não foi possível salvar os serviços.',
-      )
-    },
   })
 
   const rows = useMemo(() => {
@@ -187,6 +179,7 @@ export function TicketDetailTabServicos({ ticketId }: Props) {
   const beginEdit = useCallback(() => {
     if (!snapshot) return
     setDraft(cloneTicketServicos(snapshot))
+    setPendingFilesByRowId({})
     setIsEditing(true)
   }, [snapshot])
 
@@ -194,9 +187,35 @@ export function TicketDetailTabServicos({ ticketId }: Props) {
     if (snapshot) {
       setDraft(cloneTicketServicos(snapshot))
     }
+    setPendingFilesByRowId({})
     setIsEditing(false)
     setExpandedId(null)
   }, [snapshot])
+
+  const queuePendingFiles = useCallback((rowId: string, files: File[]) => {
+    if (!files.length) return
+    setPendingFilesByRowId((prev) => ({
+      ...prev,
+      [rowId]: [...(prev[rowId] ?? []), ...files],
+    }))
+  }, [])
+
+  const removePendingFile = useCallback((rowId: string, index: number) => {
+    setPendingFilesByRowId((prev) => {
+      const rowFiles = prev[rowId] ?? []
+      if (!rowFiles[index]) return prev
+      const nextRowFiles = rowFiles.filter((_, i) => i !== index)
+      if (nextRowFiles.length === 0) {
+        const next = { ...prev }
+        delete next[rowId]
+        return next
+      }
+      return {
+        ...prev,
+        [rowId]: nextRowFiles,
+      }
+    })
+  }, [])
 
   const handleConcluidoChange = useCallback(
     (row: RowMeta, checked: boolean) => {
@@ -209,17 +228,147 @@ export function TicketDetailTabServicos({ ticketId }: Props) {
   )
 
   const handleSave = useCallback(() => {
-    if (!draft || !isEditing) return
-    const invalid = collectAllCompletedServiceErrors(draft)
-    if (invalid.length > 0) {
-      toast.error(
-        'Preencha todos os campos dos serviços marcados como concluídos.',
-      )
-      setExpandedId(invalid[0]?.rowId ?? null)
-      return
+    const save = async () => {
+      if (!draft || !isEditing) return
+      const invalid = collectAllCompletedServiceErrors(draft)
+      if (invalid.length > 0) {
+        toast.error(
+          'Preencha todos os campos dos serviços marcados como concluídos.',
+        )
+        setExpandedId(invalid[0]?.rowId ?? null)
+        return
+      }
+
+      const preSaveDraft = cloneTicketServicos(draft)
+      let saved: TicketServicosOut
+      try {
+        saved = await replaceMutation.mutateAsync(
+          ticketServicosToReplacePayload(draft),
+        )
+      } catch (err: unknown) {
+        const msg = isApiError(err)
+          ? (err.response?.data as { detail?: string } | undefined)?.detail
+          : undefined
+        toast.error(
+          typeof msg === 'string'
+            ? msg
+            : 'Não foi possível salvar os serviços.',
+        )
+        return
+      }
+
+      let pendingUploadFailures = 0
+      const nextPending: PendingServiceFilesByRowId = {}
+      let latestSaved = saved
+
+      try {
+        // Usa o estado mais recente do backend para mapear IDs por posição.
+        latestSaved = await getTicketServicos(ticketId)
+      } catch {
+        // fallback para retorno do PUT quando o refetch falhar
+      }
+
+      for (const kind of SERVICE_KINDS) {
+        const preRows = (preSaveDraft[kind] ?? []) as { id?: string }[]
+        const savedRows = (latestSaved[kind] ?? []) as { id?: string }[]
+
+        for (let index = 0; index < preRows.length; index++) {
+          const preRow = preRows[index]
+          if (!preRow?.id || !isLocalDraftServiceId(preRow.id)) continue
+          const files = pendingFilesByRowId[preRow.id] ?? []
+          if (!files.length) continue
+
+          const persistedServiceId = savedRows[index]?.id
+          if (!persistedServiceId) {
+            pendingUploadFailures += files.length
+            nextPending[preRow.id] = files
+            continue
+          }
+
+          const videoFiles = files.filter((file) =>
+            file.type.startsWith('video/'),
+          )
+          const nonVideoFiles = files.filter(
+            (file) => !file.type.startsWith('video/'),
+          )
+
+          try {
+            if (nonVideoFiles.length > 0) {
+              await uploadTicketServiceAttachmentsMultipart(
+                ticketId,
+                nonVideoFiles,
+                {
+                  service_type: kind,
+                  service_id: persistedServiceId,
+                },
+              )
+            }
+            for (const file of videoFiles) {
+              const contentType = file.type || 'video/mp4'
+              const uploadMeta = await requestTicketVideoUploadUrl(ticketId, {
+                filename: file.name,
+                content_type: contentType,
+                file_size: file.size,
+                resumable: true,
+                service_type: kind,
+                service_id: persistedServiceId,
+              })
+              await putVideoToGcsSignedUrl(
+                uploadMeta.signed_url,
+                file,
+                contentType,
+              )
+              await completeTicketVideoAttachment(ticketId, {
+                storage_key: uploadMeta.storage_key,
+                filename: file.name,
+                content_type: contentType,
+                size_bytes: file.size,
+                service_type: kind,
+                service_id: persistedServiceId,
+              })
+            }
+          } catch {
+            pendingUploadFailures += files.length
+            nextPending[preRow.id] = files
+          }
+        }
+      }
+
+      const c = cloneTicketServicos(latestSaved)
+      setDraft(c)
+      setSnapshot(cloneTicketServicos(latestSaved))
+      setPendingFilesByRowId(nextPending)
+      setIsEditing(false)
+      setExpandedId(null)
+      queryClient.setQueryData(['ticket', ticketId, 'servicos'], latestSaved)
+      queryClient.invalidateQueries({
+        queryKey: ['ticket', ticketId, 'servicos'],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ['ticket-attachments', ticketId],
+      })
+      queryClient.invalidateQueries({ queryKey: ['ticket', ticketId] })
+
+      if (pendingUploadFailures > 0) {
+        toast.error(
+          `Serviços salvos, mas ${pendingUploadFailures} anexo(s) não puderam ser enviados.`,
+        )
+      } else {
+        toast.success('Serviços e anexos salvos com sucesso.')
+      }
     }
-    replaceMutation.mutate(ticketServicosToReplacePayload(draft))
-  }, [draft, isEditing, replaceMutation])
+
+    save().catch(() => {
+      toast.error('Ocorreu um erro ao salvar os serviços.')
+    })
+  }, [
+    draft,
+    isEditing,
+    pendingFilesByRowId,
+    queryClient,
+    replaceMutation,
+    ticketId,
+  ])
 
   const handleAddKind = (kind: (typeof SERVICE_KINDS)[number]) => {
     setDraft((prev) => {
@@ -244,6 +393,13 @@ export function TicketDetailTabServicos({ ticketId }: Props) {
       if (!prev) return prev
       return removeServiceAt(prev, kind, index)
     })
+    if (isLocalDraftServiceId(rowId)) {
+      setPendingFilesByRowId((prev) => {
+        const next = { ...prev }
+        delete next[rowId]
+        return next
+      })
+    }
     if (expandedId === rowId) {
       setExpandedId(null)
     }
@@ -330,7 +486,11 @@ export function TicketDetailTabServicos({ ticketId }: Props) {
                         )
                       }
                     >
-                      <span className={styles.servicosBarLabel}>
+                      <span
+                        className={`${styles.servicosBarLabel} ${
+                          isEditing ? styles.servicosBarLabelEditing : ''
+                        }`}
+                      >
                         {row.title}
                       </span>
                       <ChevronDown
@@ -368,23 +528,36 @@ export function TicketDetailTabServicos({ ticketId }: Props) {
                             : null
                         }
                       />
-                      <TicketServicoAnexos
-                        ticketId={ticketId}
-                        title="Anexos deste serviço"
-                        attachments={
-                          (
-                            formSource[row.kind]?.[row.index] as
-                              | { anexos?: TicketAttachmentOut[] }
-                              | undefined
-                          )?.anexos ?? []
-                        }
-                        readOnly={!isEditing}
-                        serviceScope={{
-                          service_type: row.kind,
-                          service_id: row.rowId,
-                        }}
-                        uploadBlocked={isLocalDraftServiceId(row.rowId)}
-                      />
+                      {row.kind !== 'cerco_eletronico' ? (
+                        <TicketServicoAnexos
+                          ticketId={ticketId}
+                          title="Anexos deste serviço"
+                          attachments={
+                            (
+                              formSource[row.kind]?.[row.index] as
+                                | { anexos?: TicketAttachmentOut[] }
+                                | undefined
+                            )?.anexos ?? []
+                          }
+                          readOnly={!isEditing}
+                          serviceScope={{
+                            service_type: row.kind,
+                            service_id: row.rowId,
+                          }}
+                          uploadBlocked={isLocalDraftServiceId(row.rowId)}
+                          pendingFiles={pendingFilesByRowId[row.rowId] ?? []}
+                          onQueuePendingFiles={
+                            isLocalDraftServiceId(row.rowId)
+                              ? (files) => queuePendingFiles(row.rowId, files)
+                              : undefined
+                          }
+                          onRemovePendingFile={
+                            isLocalDraftServiceId(row.rowId)
+                              ? (index) => removePendingFile(row.rowId, index)
+                              : undefined
+                          }
+                        />
+                      ) : null}
                     </div>
                   ) : null}
                 </div>

--- a/src/app/(app)/chamados/[ticketId]/components/ticket-detail-tab-solicitante.tsx
+++ b/src/app/(app)/chamados/[ticketId]/components/ticket-detail-tab-solicitante.tsx
@@ -263,7 +263,9 @@ export function TicketDetailTabSolicitante({ ticketId }: Props) {
               }
               disabled={operationsQuery.isLoading}
             >
-              <SelectTrigger className={`h-11 ${styles.detailSelectTrigger}`}>
+              <SelectTrigger
+                className={`h-11 ${styles.detailSelectTrigger} ${styles.solicitanteEditSelectTrigger}`}
+              >
                 <SelectValue
                   placeholder={
                     operationsQuery.isLoading ? 'Carregando…' : 'Selecione'
@@ -288,11 +290,7 @@ export function TicketDetailTabSolicitante({ ticketId }: Props) {
             </Select>
           ) : (
             <div className={styles.readonlySelect}>
-              <span
-                className={
-                  view.demandante?.trim() ? '' : styles.readonlySelectMuted
-                }
-              >
+              <span className={styles.solicitanteReadOnlyText}>
                 {displayText(view.demandante)}
               </span>
               <ChevronDown
@@ -321,7 +319,7 @@ export function TicketDetailTabSolicitante({ ticketId }: Props) {
                 </div>
                 {isEditing ? (
                   <input
-                    className={styles.editableField}
+                    className={`${styles.editableField} ${styles.solicitanteEditField}`}
                     value={d.requisitante.requisitante_nome}
                     onChange={(e) =>
                       setRequisitante({ requisitante_nome: e.target.value })
@@ -330,11 +328,7 @@ export function TicketDetailTabSolicitante({ ticketId }: Props) {
                   />
                 ) : (
                   <div
-                    className={`${styles.readonlyInput} ${
-                      view.requisitante.requisitante_nome
-                        ? ''
-                        : styles.readonlyInputMuted
-                    }`}
+                    className={`${styles.readonlyInput} ${styles.solicitanteReadOnlyText}`}
                   >
                     {displayText(view.requisitante.requisitante_nome)}
                   </div>
@@ -348,7 +342,7 @@ export function TicketDetailTabSolicitante({ ticketId }: Props) {
                 </div>
                 {isEditing ? (
                   <input
-                    className={styles.editableField}
+                    className={`${styles.editableField} ${styles.solicitanteEditField}`}
                     value={d.requisitante.requisitante_telefone ?? ''}
                     onChange={(e) =>
                       setRequisitante({
@@ -359,11 +353,7 @@ export function TicketDetailTabSolicitante({ ticketId }: Props) {
                   />
                 ) : (
                   <div
-                    className={`${styles.readonlyInput} ${
-                      view.requisitante.requisitante_telefone
-                        ? ''
-                        : styles.readonlyInputMuted
-                    }`}
+                    className={`${styles.readonlyInput} ${styles.solicitanteReadOnlyText}`}
                   >
                     {displayText(view.requisitante.requisitante_telefone)}
                   </div>
@@ -375,7 +365,7 @@ export function TicketDetailTabSolicitante({ ticketId }: Props) {
                 </div>
                 {isEditing ? (
                   <input
-                    className={styles.editableField}
+                    className={`${styles.editableField} ${styles.solicitanteEditField}`}
                     type="email"
                     value={d.requisitante.requisitante_email}
                     onChange={(e) =>
@@ -384,7 +374,9 @@ export function TicketDetailTabSolicitante({ ticketId }: Props) {
                     autoComplete="email"
                   />
                 ) : (
-                  <div className={styles.readonlyInput}>
+                  <div
+                    className={`${styles.readonlyInput} ${styles.solicitanteReadOnlyText}`}
+                  >
                     {displayText(view.requisitante.requisitante_email)}
                   </div>
                 )}
@@ -411,7 +403,7 @@ export function TicketDetailTabSolicitante({ ticketId }: Props) {
                       <span className={styles.subLabelText}>{label}</span>
                     </div>
                     <div
-                      className={`${styles.readonlyInput} ${styles.readonlyInputMuted}`}
+                      className={`${styles.readonlyInput} ${styles.solicitanteReadOnlyText}`}
                     >
                       —
                     </div>
@@ -427,7 +419,9 @@ export function TicketDetailTabSolicitante({ ticketId }: Props) {
                       <div className={styles.subLabel}>
                         <span className={styles.subLabelText}>Nome</span>
                       </div>
-                      <div className={styles.readonlyInput}>
+                      <div
+                        className={`${styles.readonlyInput} ${styles.solicitanteReadOnlyText}`}
+                      >
                         {displayText(fp.nome)}
                       </div>
                     </div>
@@ -436,9 +430,7 @@ export function TicketDetailTabSolicitante({ ticketId }: Props) {
                         <span className={styles.subLabelText}>Contato</span>
                       </div>
                       <div
-                        className={`${styles.readonlyInput} ${
-                          fp.telefone ? '' : styles.readonlyInputMuted
-                        }`}
+                        className={`${styles.readonlyInput} ${styles.solicitanteReadOnlyText}`}
                       >
                         {displayText(fp.telefone)}
                       </div>
@@ -448,9 +440,7 @@ export function TicketDetailTabSolicitante({ ticketId }: Props) {
                         <span className={styles.subLabelText}>Email</span>
                       </div>
                       <div
-                        className={`${styles.readonlyInput} ${
-                          fp.email ? '' : styles.readonlyInputMuted
-                        }`}
+                        className={`${styles.readonlyInput} ${styles.solicitanteReadOnlyText}`}
                       >
                         {displayText(fp.email)}
                       </div>
@@ -465,7 +455,7 @@ export function TicketDetailTabSolicitante({ ticketId }: Props) {
                           <span className={styles.subLabelText}>Nome</span>
                         </div>
                         <input
-                          className={styles.editableField}
+                          className={`${styles.editableField} ${styles.solicitanteEditField}`}
                           value={fp.nome}
                           onChange={(e) =>
                             setFocal(index, { nome: e.target.value })
@@ -478,7 +468,7 @@ export function TicketDetailTabSolicitante({ ticketId }: Props) {
                           <span className={styles.subLabelText}>Contato</span>
                         </div>
                         <input
-                          className={styles.editableField}
+                          className={`${styles.editableField} ${styles.solicitanteEditField}`}
                           value={fp.telefone ?? ''}
                           onChange={(e) =>
                             setFocal(index, {
@@ -493,7 +483,7 @@ export function TicketDetailTabSolicitante({ ticketId }: Props) {
                           <span className={styles.subLabelText}>Email</span>
                         </div>
                         <input
-                          className={styles.editableField}
+                          className={`${styles.editableField} ${styles.solicitanteEditField}`}
                           type="email"
                           value={fp.email ?? ''}
                           onChange={(e) =>

--- a/src/app/(app)/chamados/[ticketId]/components/ticket-detail-view.tsx
+++ b/src/app/(app)/chamados/[ticketId]/components/ticket-detail-view.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMutation, useQuery } from '@tanstack/react-query'
+import { type QueryClient, useMutation, useQuery } from '@tanstack/react-query'
 import {
   ChevronDown,
   ChevronLeft,
@@ -26,6 +26,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import {
   Dialog,
   DialogContent,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
@@ -41,6 +42,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
 import {
   getTeamMembersByRole,
   type TeamMemberUserOut,
@@ -125,6 +127,23 @@ function formatReassignPriorityLabel(priority: TicketReassignPriority) {
   return 'Rotina'
 }
 
+/** Refaz o dashboard mesmo com a listagem desmontada (queries inativas). */
+async function invalidateChamadosAfterMutation(
+  client: QueryClient,
+  currentTicketId: string,
+) {
+  await Promise.all([
+    client.invalidateQueries({ queryKey: ['ticket', currentTicketId] }),
+    client.invalidateQueries({
+      queryKey: ['ticket', currentTicketId, 'allowed-actions'],
+    }),
+    client.invalidateQueries({
+      queryKey: ['tickets-dashboard'],
+      refetchType: 'all',
+    }),
+  ])
+}
+
 type Props = {
   ticketId: string
 }
@@ -133,6 +152,7 @@ type TicketWorkflowConfirmableAction =
   | 'FINALIZAR_SEM_ENCAMINHAR'
   | 'ENVIAR_EMAIL'
   | 'BLOQUEAR'
+  | 'DESBLOQUEAR'
 
 export function TicketDetailView({ ticketId }: Props) {
   const router = useRouter()
@@ -147,6 +167,8 @@ export function TicketDetailView({ ticketId }: Props) {
   const [finalizeOpen, setFinalizeOpen] = useState(false)
   const [workflowConfirmAction, setWorkflowConfirmAction] =
     useState<TicketWorkflowConfirmableAction | null>(null)
+  const [sendToReviewOpen, setSendToReviewOpen] = useState(false)
+  const [sendToReviewComment, setSendToReviewComment] = useState('')
   const [reassignOpen, setReassignOpen] = useState(false)
   const [selectedTeamId, setSelectedTeamId] = useState('')
   const [selectedResponsibleIds, setSelectedResponsibleIds] = useState<
@@ -191,6 +213,7 @@ export function TicketDetailView({ ticketId }: Props) {
   const canSendEmail = allowedActionIds.includes('ENVIAR_EMAIL')
   const canSendToReview = allowedActionIds.includes('ENVIAR_PARA_REVISAO')
   const canBlockTicket = allowedActionIds.includes('BLOQUEAR')
+  const canUnblockTicket = allowedActionIds.includes('DESBLOQUEAR')
   const canFinalizeWithoutForwarding = allowedActionIds.includes(
     'FINALIZAR_SEM_ENCAMINHAR',
   )
@@ -214,21 +237,20 @@ export function TicketDetailView({ ticketId }: Props) {
   })
 
   const finalizeMutation = useMutation({
-    mutationFn: () => applyTicketWorkflowAction(ticketId, 'FINALIZAR_CHAMADO'),
-    onSuccess: (response: ApplyTicketWorkflowActionOut) => {
-      queryClient
-        .invalidateQueries({ queryKey: ['ticket', ticketId] })
-        .catch(() => {})
-      queryClient
-        .invalidateQueries({
-          queryKey: ['ticket', ticketId, 'allowed-actions'],
-        })
-        .catch(() => {})
-      queryClient.invalidateQueries({ queryKey: ['tickets'] }).catch(() => {})
-      toast.success('Chamado finalizado e enviado para revisão.')
-      if (!response.is_actor_responsible) {
-        router.push('/chamados')
+    mutationFn: () =>
+      applyTicketWorkflowAction(ticketId, 'FINALIZAR_CHAMADO', {
+        comentario: null,
+      }),
+    onSuccess: async () => {
+      try {
+        await invalidateChamadosAfterMutation(queryClient, ticketId)
+      } catch {
+        /* noop */
       }
+      toast.success('Chamado finalizado e enviado para revisão.')
+      setTimeout(() => {
+        router.push('/chamados')
+      }, 1500)
     },
     onError: (error: unknown) => {
       toast.error(getApiErrorMessage(error))
@@ -242,18 +264,17 @@ export function TicketDetailView({ ticketId }: Props) {
         responsavel_ids: selectedResponsibleIds,
         prioridade: selectedPriority,
       }),
-    onSuccess: () => {
-      queryClient
-        .invalidateQueries({ queryKey: ['ticket', ticketId] })
-        .catch(() => {})
-      queryClient
-        .invalidateQueries({
-          queryKey: ['ticket', ticketId, 'allowed-actions'],
-        })
-        .catch(() => {})
-      queryClient.invalidateQueries({ queryKey: ['tickets'] }).catch(() => {})
+    onSuccess: async () => {
+      try {
+        await invalidateChamadosAfterMutation(queryClient, ticketId)
+      } catch {
+        /* noop */
+      }
       toast.success('Chamado reatribuído com sucesso.')
       setReassignOpen(false)
+      setTimeout(() => {
+        router.push('/chamados')
+      }, 1500)
     },
     onError: (error: unknown) => {
       toast.error(getApiErrorMessage(error))
@@ -261,28 +282,36 @@ export function TicketDetailView({ ticketId }: Props) {
   })
 
   const workflowActionMutation = useMutation({
-    mutationFn: ({ actionId }: { actionId: string }) =>
-      applyTicketWorkflowAction(ticketId, actionId),
-    onSuccess: (
-      response: ApplyTicketWorkflowActionOut,
-      variables: { actionId: string },
+    mutationFn: ({
+      actionId,
+      comentario,
+    }: {
+      actionId: string
+      comentario?: string | null
+    }) =>
+      applyTicketWorkflowAction(ticketId, actionId, {
+        comentario: comentario ?? null,
+      }),
+    onSuccess: async (
+      _response: ApplyTicketWorkflowActionOut,
+      variables: { actionId: string; comentario?: string | null },
     ) => {
-      queryClient
-        .invalidateQueries({ queryKey: ['ticket', ticketId] })
-        .catch(() => {})
-      queryClient
-        .invalidateQueries({
-          queryKey: ['ticket', ticketId, 'allowed-actions'],
-        })
-        .catch(() => {})
-      queryClient.invalidateQueries({ queryKey: ['tickets'] }).catch(() => {})
+      try {
+        await invalidateChamadosAfterMutation(queryClient, ticketId)
+      } catch {
+        /* noop */
+      }
 
       if (variables.actionId === 'ENVIAR_EMAIL') {
         toast.success('E-mail enviado com sucesso.')
       } else if (variables.actionId === 'ENVIAR_PARA_REVISAO') {
+        setSendToReviewOpen(false)
+        setSendToReviewComment('')
         toast.success('Chamado enviado para revisão com sucesso.')
       } else if (variables.actionId === 'BLOQUEAR') {
         toast.success('Chamado bloqueado com sucesso.')
+      } else if (variables.actionId === 'DESBLOQUEAR') {
+        toast.success('Chamado desbloqueado com sucesso.')
       } else if (variables.actionId === 'FINALIZAR_SEM_ENCAMINHAR') {
         toast.success('Chamado finalizado sem encaminhamento.')
       } else if (variables.actionId === 'REABRIR_DEMANDA') {
@@ -290,9 +319,9 @@ export function TicketDetailView({ ticketId }: Props) {
       } else {
         toast.success('Ação aplicada com sucesso.')
       }
-      if (!response.is_actor_responsible) {
+      setTimeout(() => {
         router.push('/chamados')
-      }
+      }, 1500)
     },
     onError: (error: unknown) => {
       toast.error(getApiErrorMessage(error))
@@ -459,7 +488,7 @@ export function TicketDetailView({ ticketId }: Props) {
                 <ChevronLeft size={18} />
               </Link>
               <p className={styles.title} role="heading" aria-level={1}>
-                {`Chamado #${cab.internal_number}`}
+                {`Chamado #${cab.internal_number} - ${displayText(cab.tipo_chamado_nome)}`}
               </p>
             </div>
             <span className={styles.statusBadge}>
@@ -573,11 +602,7 @@ export function TicketDetailView({ ticketId }: Props) {
             <button
               type="button"
               className={`${styles.actionSlot} ${styles.actionSecondary}`}
-              onClick={() =>
-                workflowActionMutation.mutate({
-                  actionId: 'ENVIAR_PARA_REVISAO',
-                })
-              }
+              onClick={() => setSendToReviewOpen(true)}
               disabled={workflowActionMutation.isPending}
             >
               {workflowActionMutation.isPending
@@ -595,6 +620,18 @@ export function TicketDetailView({ ticketId }: Props) {
               {workflowActionMutation.isPending
                 ? 'Aplicando ação…'
                 : 'Bloquear'}
+            </button>
+          ) : null}
+          {canUnblockTicket ? (
+            <button
+              type="button"
+              className={`${styles.actionSlot} ${styles.actionSecondary}`}
+              onClick={() => setWorkflowConfirmAction('DESBLOQUEAR')}
+              disabled={workflowActionMutation.isPending}
+            >
+              {workflowActionMutation.isPending
+                ? 'Aplicando ação…'
+                : 'Desbloquear'}
             </button>
           ) : null}
           {canReopenDemand ? (
@@ -721,7 +758,9 @@ export function TicketDetailView({ ticketId }: Props) {
                     ? 'Enviar e-mail?'
                     : workflowConfirmAction === 'BLOQUEAR'
                       ? 'Bloquear chamado?'
-                      : 'Confirmar ação'}
+                      : workflowConfirmAction === 'DESBLOQUEAR'
+                        ? 'Desbloquear chamado?'
+                        : 'Confirmar ação'}
               </AlertDialogTitle>
               <AlertDialogDescription>
                 {workflowConfirmAction === 'FINALIZAR_SEM_ENCAMINHAR'
@@ -730,7 +769,9 @@ export function TicketDetailView({ ticketId }: Props) {
                     ? 'Será disparado o e-mail conforme o fluxo do chamado. Deseja continuar?'
                     : workflowConfirmAction === 'BLOQUEAR'
                       ? 'O chamado ficará bloqueado conforme as regras do sistema. Deseja continuar?'
-                      : null}
+                      : workflowConfirmAction === 'DESBLOQUEAR'
+                        ? 'O chamado será desbloqueado e seguirá o fluxo configurado. Deseja continuar?'
+                        : null}
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
@@ -752,6 +793,63 @@ export function TicketDetailView({ ticketId }: Props) {
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>
+
+        <Dialog
+          open={sendToReviewOpen}
+          onOpenChange={(open) => {
+            setSendToReviewOpen(open)
+            if (!open) setSendToReviewComment('')
+          }}
+        >
+          <DialogContent className="sm:max-w-[540px]">
+            <DialogHeader>
+              <DialogTitle>Enviar para revisão</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-2">
+              <p className="text-sm text-muted-foreground">
+                Adicione um comentário para registrar o contexto da revisão.
+              </p>
+              <Textarea
+                value={sendToReviewComment}
+                onChange={(event) => setSendToReviewComment(event.target.value)}
+                placeholder="Digite o comentário da revisão"
+                className="min-h-[120px]"
+                disabled={workflowActionMutation.isPending}
+              />
+            </div>
+            <DialogFooter>
+              <button
+                type="button"
+                className={`${styles.footerBtn} ${styles.footerBtnDefault}`}
+                onClick={() => {
+                  setSendToReviewOpen(false)
+                  setSendToReviewComment('')
+                }}
+                disabled={workflowActionMutation.isPending}
+              >
+                Cancelar
+              </button>
+              <button
+                type="button"
+                className={`${styles.footerBtn} ${styles.footerBtnPrimary}`}
+                disabled={
+                  workflowActionMutation.isPending ||
+                  sendToReviewComment.trim().length === 0
+                }
+                onClick={() =>
+                  workflowActionMutation.mutate({
+                    actionId: 'ENVIAR_PARA_REVISAO',
+                    comentario: sendToReviewComment.trim(),
+                  })
+                }
+              >
+                {workflowActionMutation.isPending
+                  ? 'Aplicando ação…'
+                  : 'Confirmar'}
+              </button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
 
         <Dialog
           open={oficioOpen}

--- a/src/app/(app)/chamados/[ticketId]/components/ticket-servico-anexos.tsx
+++ b/src/app/(app)/chamados/[ticketId]/components/ticket-servico-anexos.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import {
   Copy,
   Download,
+  Eye,
   FileText,
   Loader2,
   Paperclip,
@@ -14,7 +15,11 @@ import {
 import { useCallback, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
-import { downloadTicketAttachmentFile } from '@/http/tickets/download-ticket-attachment'
+import {
+  downloadTicketAttachmentFile,
+  fetchTicketAttachmentBlob,
+  fetchTicketServiceAttachmentBlob,
+} from '@/http/tickets/download-ticket-attachment'
 import {
   completeTicketVideoAttachment,
   deleteTicketAttachment,
@@ -104,6 +109,9 @@ type Props = {
   serviceScope: TicketAttachmentMultipartMetadata | null
   uploadBlocked?: boolean
   uploadBlockedMessage?: string
+  pendingFiles?: File[]
+  onQueuePendingFiles?: (files: File[]) => void
+  onRemovePendingFile?: (index: number) => void
 }
 
 export function TicketServicoAnexos({
@@ -114,11 +122,15 @@ export function TicketServicoAnexos({
   serviceScope,
   uploadBlocked = false,
   uploadBlockedMessage = 'Guarde os serviços para anexar ficheiros a este serviço.',
+  pendingFiles = [],
+  onQueuePendingFiles,
+  onRemovePendingFile,
 }: Props) {
   const queryClient = useQueryClient()
   const uploadRef = useRef<HTMLInputElement>(null)
 
   const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [viewingId, setViewingId] = useState<string | null>(null)
   const [videoCopyingId, setVideoCopyingId] = useState<string | null>(null)
   const [videoRefreshingId, setVideoRefreshingId] = useState<string | null>(
     null,
@@ -236,6 +248,33 @@ export function TicketServicoAnexos({
     [serviceScope, ticketId],
   )
 
+  const handleView = useCallback(
+    async (att: TicketAttachmentOut) => {
+      try {
+        setViewingId(att.id)
+        const { blob, contentType } = serviceScope
+          ? await fetchTicketServiceAttachmentBlob(ticketId, att.id)
+          : await fetchTicketAttachmentBlob(ticketId, att.id)
+        const previewBlob = new Blob([blob], { type: contentType })
+        const previewUrl = URL.createObjectURL(previewBlob)
+        const newTab = window.open(previewUrl, '_blank', 'noopener,noreferrer')
+
+        if (!newTab) {
+          URL.revokeObjectURL(previewUrl)
+          toast.error('Não foi possível abrir a visualização do anexo.')
+          return
+        }
+
+        window.setTimeout(() => URL.revokeObjectURL(previewUrl), 60_000)
+      } catch {
+        toast.error('Não foi possível visualizar o anexo.')
+      } finally {
+        setViewingId(null)
+      }
+    },
+    [serviceScope, ticketId],
+  )
+
   const resolvePlaybackUrl = useCallback(
     (att: TicketAttachmentOut) =>
       videoPlaybackOverrides[att.id]?.signedUrl ??
@@ -336,6 +375,12 @@ export function TicketServicoAnexos({
           e.target.value = ''
           return
         }
+        if (uploadBlocked && onQueuePendingFiles) {
+          onQueuePendingFiles(videoFiles)
+          toast.success('Vídeo adicionado. Será enviado após guardar serviços.')
+          e.target.value = ''
+          return
+        }
         videoMutation.mutate(videoFile)
         e.target.value = ''
         return
@@ -349,10 +394,20 @@ export function TicketServicoAnexos({
         e.target.value = ''
         return
       }
+
+      if (uploadBlocked && onQueuePendingFiles) {
+        onQueuePendingFiles(files)
+        toast.success(
+          'Anexos adicionados. Serão enviados após guardar serviços.',
+        )
+        e.target.value = ''
+        return
+      }
+
       multipartMutation.mutate(nonVideoFiles)
       e.target.value = ''
     },
-    [multipartMutation, videoMutation],
+    [multipartMutation, onQueuePendingFiles, uploadBlocked, videoMutation],
   )
 
   const busy =
@@ -360,7 +415,8 @@ export function TicketServicoAnexos({
     videoMutation.isPending ||
     deleteMutation.isPending
 
-  const canUpload = !readOnly && !uploadBlocked && !busy
+  const canUpload =
+    !readOnly && !busy && (!uploadBlocked || !!onQueuePendingFiles)
   const nonVideoAttachments = attachments.filter(
     (att) => !isVideoAttachment(att),
   )
@@ -368,7 +424,7 @@ export function TicketServicoAnexos({
 
   return (
     <div
-      className={`${styles.servicoAnexos}${readOnly ? ` ${styles.servicoAnexosReadOnly}` : ''}`}
+      className={`${styles.servicoAnexos}${readOnly ? ` ${styles.servicoAnexosReadOnly}` : ''}${uploadBlocked && !readOnly ? ` ${styles.servicoAnexosBlocked}` : ''}`}
     >
       <div className={styles.servicoAnexosHeader}>
         <span className={styles.servicoAnexosTitle}>{title}</span>
@@ -412,7 +468,53 @@ export function TicketServicoAnexos({
       </div>
 
       {uploadBlocked && !readOnly ? (
-        <p className={styles.servicoAnexosHint}>{uploadBlockedMessage}</p>
+        <p className={styles.servicoAnexosHint}>
+          {uploadBlockedMessage}
+          {pendingFiles.length > 0
+            ? ` (${pendingFiles.length} pendente${pendingFiles.length > 1 ? 's' : ''})`
+            : ''}
+        </p>
+      ) : null}
+
+      {pendingFiles.length > 0 ? (
+        <div className={styles.servicoAnexosList}>
+          <div className={styles.docGrid}>
+            {pendingFiles.map((file, index) => (
+              <div
+                key={`${file.name}-${file.size}-${file.lastModified}-${index}`}
+                className={styles.docCard}
+              >
+                <div className={styles.docCardLeft}>
+                  <div className={styles.docPdfIcon} aria-hidden>
+                    <FileText size={20} />
+                  </div>
+                  <div className={styles.docInfo}>
+                    <p className={styles.docName} title={file.name}>
+                      {file.name}
+                    </p>
+                    <p className={styles.docSize}>
+                      {formatBytes(file.size)} - Pendente
+                    </p>
+                  </div>
+                </div>
+                <div className={styles.docCardActions}>
+                  {!readOnly && onRemovePendingFile ? (
+                    <button
+                      type="button"
+                      className={styles.docIconBtn}
+                      aria-label={`Remover pendente ${file.name}`}
+                      title="Remover pendente"
+                      onClick={() => onRemovePendingFile(index)}
+                      disabled={busy}
+                    >
+                      <X size={16} />
+                    </button>
+                  ) : null}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
       ) : null}
 
       {attachments.length === 0 ? (
@@ -441,12 +543,28 @@ export function TicketServicoAnexos({
                       <button
                         type="button"
                         className={styles.docIconBtn}
+                        aria-label={`Visualizar ${att.filename}`}
+                        title="Visualizar anexo"
+                        onClick={() => {
+                          handleView(att).catch(() => {})
+                        }}
+                        disabled={
+                          deletingId === att.id || viewingId === att.id || busy
+                        }
+                      >
+                        <Eye size={16} />
+                      </button>
+                      <button
+                        type="button"
+                        className={styles.docIconBtn}
                         aria-label={`Baixar ${att.filename}`}
                         title="Descarregar"
                         onClick={() => {
                           handleDownload(att).catch(() => {})
                         }}
-                        disabled={deletingId === att.id || busy}
+                        disabled={
+                          deletingId === att.id || viewingId === att.id || busy
+                        }
                       >
                         <Download size={16} />
                       </button>
@@ -457,7 +575,11 @@ export function TicketServicoAnexos({
                           aria-label={`Remover ${att.filename}`}
                           title="Remover"
                           onClick={() => handleDelete(att)}
-                          disabled={deletingId === att.id || busy}
+                          disabled={
+                            deletingId === att.id ||
+                            viewingId === att.id ||
+                            busy
+                          }
                         >
                           <X size={16} />
                         </button>

--- a/src/app/(app)/chamados/[ticketId]/ticket-detail.module.css
+++ b/src/app/(app)/chamados/[ticketId]/ticket-detail.module.css
@@ -523,6 +523,18 @@
   color: var(--td-muted);
 }
 
+.solicitanteReadOnlyText {
+  color: var(--td-muted) !important;
+}
+
+.solicitanteEditField {
+  color: var(--td-text);
+}
+
+.solicitanteEditSelectTrigger {
+  color: var(--td-text) !important;
+}
+
 .readonlyInputLinkCell {
   align-items: flex-start;
   padding-top: 10px;
@@ -622,7 +634,7 @@
   border: none;
   border-radius: 8px;
   background: #402c4c;
-  color: var(--td-muted);
+  color: var(--td-text);
   font-size: 14px;
   font-weight: 600;
   line-height: 16px;
@@ -708,6 +720,15 @@
 .detailSelectTrigger:disabled {
   opacity: 0.75;
   cursor: not-allowed;
+}
+
+/* Aba Solicitante: valor selecionado em branco no modo edição */
+.solicitanteEditSelectTrigger {
+  color: var(--td-text, #f9fafa) !important;
+}
+
+.solicitanteEditSelectTrigger[data-placeholder] {
+  color: var(--td-muted, #97a2ab) !important;
 }
 
 .detailSelectContent {
@@ -1523,6 +1544,10 @@
   color: var(--td-muted);
 }
 
+.servicosBarLabelEditing {
+  color: var(--td-text);
+}
+
 .servicosChevron {
   width: 20px;
   height: 20px;
@@ -2118,7 +2143,7 @@
   border: none;
   border-radius: var(--td-radius);
   background: var(--td-btn-secondary);
-  color: var(--td-muted);
+  color: #fff;
   font-family: inherit;
   font-size: 14px;
   font-weight: 600;
@@ -2131,7 +2156,7 @@
 }
 
 .parecerSubmit:hover:not(:disabled) {
-  color: var(--td-text);
+  color: #fff;
   filter: brightness(1.08);
 }
 
@@ -2310,6 +2335,12 @@
 
 .servicoAnexosReadOnly {
   margin-top: 24px;
+}
+
+.servicoAnexosBlocked {
+  margin-top: 24px;
+  padding-top: 16px;
+  border-top: 1px solid var(--td-border);
 }
 
 .servicoAnexosHeader {

--- a/src/app/(app)/chamados/caixa-entrada/components/email-preview-sheet.tsx
+++ b/src/app/(app)/chamados/caixa-entrada/components/email-preview-sheet.tsx
@@ -24,6 +24,7 @@ import {
   SheetContent,
   SheetTitle,
 } from '@/components/ui/sheet'
+import { EMAIL_NAO_LIDOS_COUNT_QUERY_KEY } from '@/hooks/useQueries/useEmailNaoLidosCount'
 import { downloadEmailAttachmentFile } from '@/http/emails/download-email-attachment'
 import { type AttachmentOut, getEmailById } from '@/http/emails/get-email'
 import { markEmailAsSpam } from '@/http/emails/mark-email-spam'
@@ -87,6 +88,9 @@ export function EmailPreviewSheet({
     onSuccess: () => {
       toast.success('E-mail marcado como spam.')
       queryClient.invalidateQueries({ queryKey: ['emails-inbox-nao-lidos'] })
+      queryClient.invalidateQueries({
+        queryKey: EMAIL_NAO_LIDOS_COUNT_QUERY_KEY,
+      })
       queryClient.invalidateQueries({
         queryKey: ['emails-inbox-aguardando-resposta'],
       })

--- a/src/app/(app)/chamados/caixa-entrada/responder/[emailId]/components/responder-email-view.tsx
+++ b/src/app/(app)/chamados/caixa-entrada/responder/[emailId]/components/responder-email-view.tsx
@@ -29,6 +29,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { EMAIL_NAO_LIDOS_COUNT_QUERY_KEY } from '@/hooks/useQueries/useEmailNaoLidosCount'
 import { downloadEmailAttachmentFile } from '@/http/emails/download-email-attachment'
 import { type AttachmentOut, getEmailById } from '@/http/emails/get-email'
 import { sendStandardizedTemplatedEmail } from '@/http/emails/send-standardized-templated-email'
@@ -79,6 +80,9 @@ export function ResponderEmailView() {
     onSuccess: () => {
       toast.success('E-mail enviado.')
       queryClient.invalidateQueries({ queryKey: ['emails-inbox-nao-lidos'] })
+      queryClient.invalidateQueries({
+        queryKey: EMAIL_NAO_LIDOS_COUNT_QUERY_KEY,
+      })
       queryClient.invalidateQueries({
         queryKey: ['emails-inbox-aguardando-resposta'],
       })

--- a/src/app/(app)/chamados/chamados-impersonation-context.tsx
+++ b/src/app/(app)/chamados/chamados-impersonation-context.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import { useQueryClient } from '@tanstack/react-query'
 import {
   createContext,
   useCallback,
@@ -33,7 +32,6 @@ export function ChamadosImpersonationProvider({
 }: {
   children: React.ReactNode
 }) {
-  const queryClient = useQueryClient()
   const [subjectUserId, setSubjectUserId] = useState<string | null>(null)
   const [subjectLabel, setSubjectLabel] = useState<string | null>(null)
 
@@ -43,43 +41,23 @@ export function ChamadosImpersonationProvider({
     setSubjectLabel(getChamadosImpersonateUserLabel())
   }, [])
 
-  const invalidateChamadosQueries = useCallback(() => {
-    queryClient
-      .invalidateQueries({
-        queryKey: ['tickets'],
-        refetchType: 'active',
-      })
-      .catch(() => {})
-    queryClient
-      .invalidateQueries({
-        queryKey: ['tickets', 'module-screen-permissions'],
-        refetchType: 'active',
-      })
-      .catch(() => {})
-  }, [queryClient])
-
-  const setImpersonation = useCallback(
-    (id: string, label: string) => {
-      setChamadosImpersonationStorage(id, label)
-      setSubjectUserId(id)
-      setSubjectLabel(label)
-      invalidateChamadosQueries()
-      if (typeof window !== 'undefined') {
-        window.location.reload()
-      }
-    },
-    [invalidateChamadosQueries],
-  )
+  const setImpersonation = useCallback((id: string, label: string) => {
+    setChamadosImpersonationStorage(id, label)
+    setSubjectUserId(id)
+    setSubjectLabel(label)
+    if (typeof window !== 'undefined') {
+      window.location.reload()
+    }
+  }, [])
 
   const clearImpersonation = useCallback(() => {
     clearChamadosImpersonationStorage()
     setSubjectUserId(null)
     setSubjectLabel(null)
-    invalidateChamadosQueries()
     if (typeof window !== 'undefined') {
       window.location.reload()
     }
-  }, [invalidateChamadosQueries])
+  }, [])
 
   const value = useMemo(
     () => ({

--- a/src/app/(app)/chamados/converter/components/email-to-ticket-view.tsx
+++ b/src/app/(app)/chamados/converter/components/email-to-ticket-view.tsx
@@ -48,12 +48,15 @@ import {
 } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
+import { EMAIL_NAO_LIDOS_COUNT_QUERY_KEY } from '@/hooks/useQueries/useEmailNaoLidosCount'
 import { type EmailOut, getEmailById } from '@/http/emails/get-email'
 import { markEmailAsAguardandoResposta } from '@/http/emails/mark-email-aguardando-resposta'
 import { getFirstFormErrorMessage } from '@/utils/form-errors'
 import {
   maskDigitsOnly,
+  maskNumeroOficio,
   maskPhoneBR,
+  normalizeNumeroOficio,
   padDigitsLeft,
 } from '@/utils/string-formatters'
 
@@ -296,6 +299,9 @@ export function EmailToTicketView() {
       .then(() => {
         if (cancelled) return
         queryClient.invalidateQueries({ queryKey: ['emails-inbox-nao-lidos'] })
+        queryClient.invalidateQueries({
+          queryKey: EMAIL_NAO_LIDOS_COUNT_QUERY_KEY,
+        })
         queryClient.invalidateQueries({
           queryKey: ['emails-inbox-aguardando-resposta'],
         })
@@ -703,7 +709,7 @@ export function EmailToTicketView() {
                               >
                                 <span className="truncate">
                                   {vm.selectedTicketLabel ||
-                                    'Digite para buscar um chamado'}
+                                    'Selecione ou busque um chamado'}
                                 </span>
                                 <ChevronDown className="h-4 w-4 opacity-50" />
                               </Button>
@@ -730,14 +736,6 @@ export function EmailToTicketView() {
                                   )}
 
                                   {!vm.isTicketsLoading &&
-                                    vm.ticketSearch.trim().length === 0 && (
-                                      <div className="px-3 py-2 text-sm text-muted-foreground">
-                                        Digite para pesquisar.
-                                      </div>
-                                    )}
-
-                                  {!vm.isTicketsLoading &&
-                                    vm.ticketSearch.trim().length > 0 &&
                                     vm.tickets.length === 0 && (
                                       <CommandEmpty>
                                         Nenhum chamado encontrado.
@@ -935,10 +933,33 @@ export function EmailToTicketView() {
                         <Label className={styles.fieldLabel}>
                           Nº do ofício
                         </Label>
-                        <Input
-                          className={`h-11 ${styles.inputBg}`}
-                          disabled={vm.isLoading}
-                          {...vm.register('numero_oficio')}
+                        <Controller
+                          control={vm.control}
+                          name="numero_oficio"
+                          render={({ field }) => (
+                            <Input
+                              className={`h-11 ${styles.inputBg}`}
+                              disabled={vm.isLoading}
+                              inputMode="numeric"
+                              autoComplete="off"
+                              value={field.value ?? ''}
+                              onBlur={() => {
+                                field.onBlur()
+                                const raw = (field.value ?? '').trim()
+                                if (raw === '') return
+                                const normalized = normalizeNumeroOficio(raw)
+                                if (normalized !== field.value) {
+                                  field.onChange(normalized || null)
+                                }
+                              }}
+                              ref={field.ref}
+                              onChange={(e) =>
+                                field.onChange(
+                                  maskNumeroOficio(e.target.value) || null,
+                                )
+                              }
+                            />
+                          )}
                         />
                         <FieldStringError
                           value={vm.watch('numero_oficio')}

--- a/src/app/(app)/chamados/criar/hooks/use-create-controller.ts
+++ b/src/app/(app)/chamados/criar/hooks/use-create-controller.ts
@@ -8,6 +8,7 @@ import { useMemo, useState } from 'react'
 import { useFieldArray, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 
+import { useDebounce } from '@/components/custom/multiselect-with-search'
 import { getTicketNatures } from '@/http/get-ticket-natures/get-ticket-natures'
 import { getOperations } from '@/http/operations/get-operations'
 import { getTeamsList } from '@/http/teams/get-teams'
@@ -70,6 +71,7 @@ export function useTicketCreateController() {
   )
 
   const [ticketSearch, setTicketSearch] = useState('')
+  const debouncedTicketSearch = useDebounce(ticketSearch, 350)
   const [ticketPopoverOpen, setTicketPopoverOpen] = useState(false)
   const [selectedTicketLabel, setSelectedTicketLabel] = useState('')
 
@@ -159,9 +161,9 @@ export function useTicketCreateController() {
   })
 
   const ticketsQuery = useQuery({
-    queryKey: ['tickets', 'search', ticketSearch],
-    queryFn: () => getTicketsSelect({ search: ticketSearch }),
-    enabled: ticketPopoverOpen && ticketSearch.trim().length > 0,
+    queryKey: ['tickets', 'search', debouncedTicketSearch],
+    queryFn: () => getTicketsSelect({ search: debouncedTicketSearch.trim() }),
+    enabled: ticketPopoverOpen,
   })
 
   const teamsQuery = useQuery({

--- a/src/app/(app)/chamados/criar/ticket-create/ticket-create-form.tsx
+++ b/src/app/(app)/chamados/criar/ticket-create/ticket-create-form.tsx
@@ -40,7 +40,9 @@ import { Textarea } from '@/components/ui/textarea'
 import { getFirstFormErrorMessage } from '@/utils/form-errors'
 import {
   maskDigitsOnly,
+  maskNumeroOficio,
   maskPhoneBR,
+  normalizeNumeroOficio,
   padDigitsLeft,
 } from '@/utils/string-formatters'
 
@@ -189,7 +191,7 @@ export function TicketCreateForm() {
                       >
                         <span className="truncate">
                           {vm.selectedTicketLabel ||
-                            'Digite para buscar um chamado'}
+                            'Selecione ou busque um chamado'}
                         </span>
                         <ChevronDown className="h-4 w-4 opacity-50" />
                       </Button>
@@ -215,20 +217,11 @@ export function TicketCreateForm() {
                             </div>
                           )}
 
-                          {!vm.isTicketsLoading &&
-                            vm.ticketSearch.trim().length === 0 && (
-                              <div className="px-3 py-2 text-sm text-muted-foreground">
-                                Digite para pesquisar.
-                              </div>
-                            )}
-
-                          {!vm.isTicketsLoading &&
-                            vm.ticketSearch.trim().length > 0 &&
-                            vm.tickets.length === 0 && (
-                              <CommandEmpty>
-                                Nenhum chamado encontrado.
-                              </CommandEmpty>
-                            )}
+                          {!vm.isTicketsLoading && vm.tickets.length === 0 && (
+                            <CommandEmpty>
+                              Nenhum chamado encontrado.
+                            </CommandEmpty>
+                          )}
 
                           <CommandGroup>
                             {vm.tickets.map((ticket) => (
@@ -399,10 +392,31 @@ export function TicketCreateForm() {
 
             <div className="space-y-1.5">
               <Label className={styles.fieldLabel}>Nº do ofício</Label>
-              <Input
-                className={`h-11 ${styles.inputBg}`}
-                disabled={fieldDisabled}
-                {...vm.register('numero_oficio')}
+              <Controller
+                control={vm.control}
+                name="numero_oficio"
+                render={({ field }) => (
+                  <Input
+                    className={`h-11 ${styles.inputBg}`}
+                    disabled={fieldDisabled}
+                    inputMode="numeric"
+                    autoComplete="off"
+                    value={field.value ?? ''}
+                    onBlur={() => {
+                      field.onBlur()
+                      const raw = (field.value ?? '').trim()
+                      if (raw === '') return
+                      const normalized = normalizeNumeroOficio(raw)
+                      if (normalized !== field.value) {
+                        field.onChange(normalized || null)
+                      }
+                    }}
+                    ref={field.ref}
+                    onChange={(e) =>
+                      field.onChange(maskNumeroOficio(e.target.value) || null)
+                    }
+                  />
+                )}
               />
               <FieldStringError
                 value={vm.watch('numero_oficio')}

--- a/src/app/(app)/chamados/criar/ticket-create/ticket-create-schema.ts
+++ b/src/app/(app)/chamados/criar/ticket-create/ticket-create-schema.ts
@@ -137,7 +137,11 @@ export const ticketCreateSchema = z.object({
     .string()
     .max(L.numero_oficio, maxMsg(L.numero_oficio))
     .optional()
-    .nullable(),
+    .nullable()
+    .refine(
+      (v) => v == null || v === '' || /^\d{5}\/\d{4}$/.test(v),
+      'Use o formato 00000/0000 (ex.: 00123/2026)',
+    ),
   data_base: z.string().optional().nullable(),
   natureza_id: z.string().min(1, 'Campo obrigatório'),
 

--- a/src/app/(app)/chamados/criar/ticket-create/ticket-create.constant.ts
+++ b/src/app/(app)/chamados/criar/ticket-create/ticket-create.constant.ts
@@ -75,10 +75,9 @@ export type OutrosDraft = {
   orientation: string
 }
 
-/** Limites de caracteres alinhados ao schema de criação de chamado. */
 export const TICKET_CREATE_STRING_LIMITS = {
   numero_procedimento: 12,
-  numero_oficio: 60,
+  numero_oficio: 10,
   apelido_imprensa: 120,
   link_materia: 2048,
   bairro_correspondencia: 120,
@@ -90,7 +89,7 @@ export const TICKET_CREATE_STRING_LIMITS = {
   ponto_focal_nome: 120,
   ponto_focal_telefone: 120,
   ponto_focal_email: 255,
-  comentario_inicial: 500,
+  comentario_inicial: 2000,
 } as const
 
 export const SERVICE_CONFIG = {

--- a/src/app/(app)/chamados/criar/ticket-create/ticket-create.mapper.ts
+++ b/src/app/(app)/chamados/criar/ticket-create/ticket-create.mapper.ts
@@ -1,5 +1,9 @@
 import type { TicketOut } from '@/http/tickets/get-ticket-by-id'
-import { padDigitsLeft, unmaskPlateBR } from '@/utils/string-formatters'
+import {
+  normalizeNumeroOficio,
+  padDigitsLeft,
+  unmaskPlateBR,
+} from '@/utils/string-formatters'
 
 import { TICKET_CREATE_STRING_LIMITS as L } from './ticket-create.constant'
 import type { TicketCreateForm } from './ticket-create-schema'
@@ -41,7 +45,7 @@ export function buildTicketCreatePayload(
     numero_procedimento: emptyToNull(
       padDigitsLeft(data.numero_procedimento, L.numero_procedimento),
     ),
-    numero_oficio: emptyToNull(data.numero_oficio),
+    numero_oficio: emptyToNull(normalizeNumeroOficio(data.numero_oficio ?? '')),
     data_base: emptyToNull(data.data_base),
     natureza_id: data.natureza_id.trim(),
     apelido_imprensa: emptyToNull(data.apelido_imprensa),
@@ -166,7 +170,12 @@ export function mapTicketOutToCreateForm(
     numero_procedimento: ticket.numero_procedimento
       ? padDigitsLeft(ticket.numero_procedimento, L.numero_procedimento)
       : null,
-    numero_oficio: ticket.numero_oficio ?? null,
+    numero_oficio: (() => {
+      const raw = ticket.numero_oficio?.trim()
+      if (!raw) return null
+      const normalized = normalizeNumeroOficio(raw)
+      return normalized || null
+    })(),
     data_base: apiDateToDataBaseString(ticket.data_base),
     natureza_id: ticket.natureza_id ?? '',
     possui_apelido_imprensa: ticket.possui_apelido_imprensa,
@@ -194,7 +203,9 @@ export function mapTicketOutToCreateForm(
       if (raw == null) return null
       const t = raw.trim()
       if (!t) return null
-      return t.length > 500 ? t.slice(0, 500) : t
+      return t.length > L.comentario_inicial
+        ? t.slice(0, L.comentario_inicial)
+        : t
     })(),
     busca_por_placa: (ticket.busca_por_placa ?? []).map((s) => ({
       plates: (s.plates ?? []).map((p) => p.plate).filter((p) => p?.trim()),

--- a/src/app/(app)/chamados/list/components/filter/tickets-general-list-filters.module.css
+++ b/src/app/(app)/chamados/list/components/filter/tickets-general-list-filters.module.css
@@ -3,9 +3,9 @@
   inset: 0;
   z-index: 80;
   display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  padding: 42px 24px;
+  align-items: stretch;
+  justify-content: stretch;
+  padding: 16px;
   background: rgba(7, 14, 22, 0.62);
   backdrop-filter: blur(3px);
 }
@@ -14,10 +14,14 @@
   display: flex;
   flex-direction: column;
   width: 100%;
-  max-width: 1220px;
-  /* Altura mínima maior na vertical; não ultrapassa a área útil do overlay */
-  min-height: min(75vh, calc(100vh - 84px));
-  max-height: calc(100vh - 84px);
+  min-width: 0;
+  /* Ocupa toda a área útil do overlay (padding 16px × 2) */
+  min-height: calc(100vh - 32px);
+  height: calc(100vh - 32px);
+  max-height: calc(100vh - 32px);
+  min-height: calc(100dvh - 32px);
+  height: calc(100dvh - 32px);
+  max-height: calc(100dvh - 32px);
   overflow: auto;
   border: 1px solid rgba(74, 107, 138, 0.35);
   border-radius: 14px;

--- a/src/app/(app)/chamados/list/components/filter/tickets-general-list-filters.tsx
+++ b/src/app/(app)/chamados/list/components/filter/tickets-general-list-filters.tsx
@@ -33,7 +33,7 @@ export type FilterFormState = {
   status: string[]
   prioridade: SearchOption[]
   equipe: SearchOption[]
-  servicos_realizados: string[]
+  servicos: SearchOption[]
 }
 
 const priorityOptions = ['URGENTE', 'ALTA', 'ROTINA', 'SEM PRIORIDADE']
@@ -57,7 +57,7 @@ export function emptyFilters(): FilterFormState {
     status: [],
     prioridade: [],
     equipe: [],
-    servicos_realizados: [],
+    servicos: [],
   }
 }
 
@@ -87,6 +87,19 @@ const prioritySearchOptions: SearchOption[] = priorityOptions.map((p) => ({
   value: p,
   label: formatLabel(p),
 }))
+
+/** Labels em português; `value` é o enviado no body (`servicos`). */
+export const dashboardServicosFilterOptions: SearchOption[] = [
+  { value: 'plate_search_services', label: 'Busca por placa' },
+  { value: 'radar_search_services', label: 'Busca por radar' },
+  { value: 'electronic_fence_services', label: 'Cerco eletrônico' },
+  { value: 'image_search_services', label: 'Busca por imagem' },
+  { value: 'correlated_plate_services', label: 'Placas correlatas' },
+  { value: 'joint_plate_services', label: 'Placas conjuntas' },
+  { value: 'image_reservation_services', label: 'Reserva de imagem' },
+  { value: 'image_analysis_services', label: 'Análise de imagem' },
+  { value: 'other_services', label: 'Outros' },
+]
 
 function SearchMultiSelect({
   label,
@@ -387,6 +400,19 @@ export function TicketsDashboardFilterModal({
               }
               staticOptions={teamSearchOptions ?? []}
               optionsLoading={isTeamsLoading}
+            />
+
+            <SearchMultiSelect
+              label="SERVIÇOS"
+              placeholder="Selecione"
+              value={draftFilters.servicos}
+              onChange={(value) =>
+                setDraftFilters((current) => ({
+                  ...current,
+                  servicos: value,
+                }))
+              }
+              staticOptions={dashboardServicosFilterOptions}
             />
           </div>
         </div>

--- a/src/app/(app)/chamados/list/tickets-general-list.module.css
+++ b/src/app/(app)/chamados/list/tickets-general-list.module.css
@@ -282,6 +282,17 @@
   flex-shrink: 0;
 }
 
+.levantamentoPrevioTooltipTrigger {
+  display: inline-flex;
+  align-items: center;
+  cursor: help;
+}
+
+.levantamentoPrevioIcon {
+  color: #6eb5ff;
+  flex-shrink: 0;
+}
+
 .servicesCell {
   display: flex;
   align-items: center;
@@ -397,7 +408,7 @@
 }
 
 /* Largura mínima no rótulo para alinhar os badges de count na mesma coluna */
-.priorityCell > span:first-child {
+.priorityLabel {
   min-width: 72px;
 }
 

--- a/src/app/(app)/chamados/list/tickets-general-list.tsx
+++ b/src/app/(app)/chamados/list/tickets-general-list.tsx
@@ -5,6 +5,7 @@ import {
   AlertTriangle,
   ChevronDown,
   ChevronUp,
+  ClipboardList,
   Search,
   Tag,
 } from 'lucide-react'
@@ -12,6 +13,7 @@ import Link from 'next/link'
 import { useMemo, useState } from 'react'
 
 import { useDebounce } from '@/components/custom/multiselect-with-search'
+import { Tooltip } from '@/components/custom/tooltip'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import {
@@ -19,7 +21,6 @@ import {
   type TicketDashboardFilters,
 } from '@/http/tickets/get-tickets-dashboard'
 
-import { useChamadosImpersonation } from '../chamados-impersonation-context'
 import {
   emptyFilters,
   type FilterFormState,
@@ -30,6 +31,8 @@ import styles from './tickets-general-list.module.css'
 type DashboardServiceTag = {
   label: string
 }
+
+const LEVANTAMENTO_PREVIO_TIPO_NOME = 'Levantamento Prévio'
 
 type DashboardItem = {
   id: string
@@ -43,6 +46,7 @@ type DashboardItem = {
   prioridade: string
   dias_atraso: number
   servicos: DashboardServiceTag[]
+  tipo_chamado_nome?: string | null
 }
 
 type DashboardSection = {
@@ -51,14 +55,14 @@ type DashboardSection = {
 }
 
 type TicketDashboardResponse = {
-  pendentes: DashboardSection
-  restritos: DashboardSection
-  aguardando_revisao_adjunto: DashboardSection
-  aguardando_revisao_administrativo: DashboardSection
-  bloqueados: DashboardSection
+  pendentes: DashboardSection | null
+  restritos: DashboardSection | null
+  aguardando_revisao_adjunto: DashboardSection | null
+  aguardando_revisao_administrativo: DashboardSection | null
+  bloqueados: DashboardSection | null
   concluidos_total: number
-  urgentes: DashboardSection
-  em_atraso: DashboardSection
+  urgentes: DashboardSection | null
+  em_atraso: DashboardSection | null
   total: number
   period_days: number
   overdue_after_days: number
@@ -118,6 +122,10 @@ function getPriorityCountBadgeClass(count: number) {
   if (count <= 15) return styles.prioritySuccessBadge
   if (count <= 24) return styles.priorityWarningBadge
   return styles.priorityDangerBadge
+}
+
+function isLevantamentoPrevioTipo(item: DashboardItem) {
+  return item.tipo_chamado_nome?.trim() === LEVANTAMENTO_PREVIO_TIPO_NOME
 }
 
 function getServiceClassName(label: string) {
@@ -220,7 +228,22 @@ function DashboardSectionTable({
                           <AlertTriangle
                             className={styles.warningIcon}
                             size={14}
+                            aria-hidden
                           />
+                        ) : isLevantamentoPrevioTipo(item) ? (
+                          <Tooltip asChild text={LEVANTAMENTO_PREVIO_TIPO_NOME}>
+                            <span
+                              className={
+                                styles.levantamentoPrevioTooltipTrigger
+                              }
+                            >
+                              <ClipboardList
+                                className={styles.levantamentoPrevioIcon}
+                                size={14}
+                                aria-hidden
+                              />
+                            </span>
+                          </Tooltip>
                         ) : null}
                         <span>{item.responsavel}</span>
                       </div>
@@ -270,8 +293,6 @@ function DashboardSectionTable({
                     </td>
                     <td>
                       <div className={styles.priorityCell}>
-                        <span>{normalizePriority(item.prioridade)}</span>
-
                         {badgeValue ? (
                           <span
                             className={getPriorityCountBadgeClass(badgeValue)}
@@ -279,6 +300,9 @@ function DashboardSectionTable({
                             {badgeValue}
                           </span>
                         ) : null}
+                        <span className={styles.priorityLabel}>
+                          {normalizePriority(item.prioridade)}
+                        </span>
                       </div>
                     </td>
                   </tr>
@@ -293,7 +317,6 @@ function DashboardSectionTable({
 }
 
 export function TicketsGeneralList() {
-  const { subjectUserId } = useChamadosImpersonation()
   const [periodDays, setPeriodDays] = useState<number>(30)
   const [search, setSearch] = useState<string>('')
   const debouncedSearch = useDebounce(search, 350)
@@ -343,25 +366,32 @@ export function TicketsGeneralList() {
       equipe: appliedFilters.equipe.length
         ? appliedFilters.equipe.map((item) => item.value)
         : undefined,
-      servicos_realizados: appliedFilters.servicos_realizados.length
-        ? appliedFilters.servicos_realizados
+      servicos: appliedFilters.servicos.length
+        ? appliedFilters.servicos.map((item) => item.value)
         : undefined,
     }
   }, [appliedFilters, periodDays, debouncedSearch])
 
   const { data, isLoading, isFetching } = useQuery<TicketDashboardResponse>({
-    queryKey: ['tickets-dashboard', subjectUserId ?? null, dashboardPayload],
+    queryKey: ['tickets-dashboard', dashboardPayload],
     queryFn: () => getTicketsDashboard(dashboardPayload),
     staleTime: 1000 * 60,
   })
 
   const cards = useMemo(() => {
-    return [
+    const list: { value: number; label: string }[] = [
       { value: data?.concluidos_total ?? 0, label: 'Concluídos' },
-      { value: data?.urgentes.total ?? 0, label: 'Urgentes' },
-      { value: data?.em_atraso.total ?? 0, label: 'Em atraso' },
-      { value: data?.bloqueados.total ?? 0, label: 'Bloqueados' },
     ]
+    if (data?.urgentes != null) {
+      list.push({ value: data.urgentes.total, label: 'Urgentes' })
+    }
+    if (data?.em_atraso != null) {
+      list.push({ value: data.em_atraso.total, label: 'Em atraso' })
+    }
+    if (data?.bloqueados != null) {
+      list.push({ value: data.bloqueados.total, label: 'Bloqueados' })
+    }
+    return list
   }, [data])
 
   const activeFiltersCount = useMemo(() => {
@@ -377,7 +407,7 @@ export function TicketsGeneralList() {
       appliedFilters.status.length,
       appliedFilters.prioridade.length,
       appliedFilters.equipe.length,
-      appliedFilters.servicos_realizados.length,
+      appliedFilters.servicos.length,
       appliedFilters.data_base_inicio ? 1 : 0,
       appliedFilters.data_base_fim ? 1 : 0,
       appliedFilters.data_entrada_inicio ? 1 : 0,
@@ -472,17 +502,22 @@ export function TicketsGeneralList() {
 
         {!isLoading && data ? (
           <>
-            {sections.map((section) => (
-              <DashboardSectionTable
-                key={section.key}
-                title={section.label}
-                total={data[section.key].total}
-                items={data[section.key].items}
-                isOpen={openSections[section.key]}
-                onToggle={() => toggleSection(section.key)}
-                showWarningIcon={section.key === 'bloqueados'}
-              />
-            ))}
+            {sections
+              .filter((section) => data[section.key] != null)
+              .map((section) => {
+                const block = data[section.key]!
+                return (
+                  <DashboardSectionTable
+                    key={section.key}
+                    title={section.label}
+                    total={block.total}
+                    items={block.items}
+                    isOpen={openSections[section.key]}
+                    onToggle={() => toggleSection(section.key)}
+                    showWarningIcon={section.key === 'bloqueados'}
+                  />
+                )
+              })}
           </>
         ) : null}
 

--- a/src/app/(app)/chamados/perfis/components/profile-access-form-dialog.tsx
+++ b/src/app/(app)/chamados/perfis/components/profile-access-form-dialog.tsx
@@ -31,6 +31,7 @@ const roleOptions = [
   { value: 'Coordenador', label: 'Coordenador' },
   { value: 'Administrativo', label: 'Administrativo' },
   { value: 'Adjunto', label: 'Adjunto' },
+  { value: 'Assessor', label: 'Assessor' },
   { value: 'Líder de Ilha', label: 'Líder de Ilha' },
   { value: 'Operador', label: 'Operador' },
 ] as const satisfies { value: UserRoleEnum; label: string }[]
@@ -41,6 +42,7 @@ const profileAccessFormSchema = z.object({
       'Coordenador',
       'Administrativo',
       'Adjunto',
+      'Assessor',
       'Líder de Ilha',
       'Operador',
     ])

--- a/src/app/(app)/chamados/perfis/components/profile-access-table.tsx
+++ b/src/app/(app)/chamados/perfis/components/profile-access-table.tsx
@@ -19,6 +19,7 @@ const roleLabelMap: Record<UserRoleEnum, string> = {
   Coordenador: 'Coordenador',
   Administrativo: 'Administrativo',
   Adjunto: 'Adjunto',
+  Assessor: 'Assessor',
   'Líder de Ilha': 'Líder de Ilha',
   Operador: 'Operador',
 }
@@ -27,6 +28,7 @@ const roleBadgeStyleMap: Record<UserRoleEnum, string> = {
   Coordenador: styles.perfisBadgeCoordenador,
   Administrativo: styles.perfisBadgeAdministrativo,
   Adjunto: styles.perfisBadgeAdjunto,
+  Assessor: styles.perfisBadgeAssessor,
   'Líder de Ilha': styles.perfisBadgeLiderIlha,
   Operador: styles.perfisBadgeOperador,
 }

--- a/src/app/(app)/chamados/perfis/perfis.module.css
+++ b/src/app/(app)/chamados/perfis/perfis.module.css
@@ -234,6 +234,11 @@
   color: #5b4db2;
 }
 
+.perfisBadgeAssessor {
+  background: rgba(220, 140, 24, 0.1);
+  color: #dc8c18;
+}
+
 .perfisBadgeLiderIlha {
   background: rgba(140, 62, 122, 0.1);
   color: #8c3e7a;

--- a/src/app/(app)/components/sidebar/components/sidebar-accordion.tsx
+++ b/src/app/(app)/components/sidebar/components/sidebar-accordion.tsx
@@ -6,6 +6,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from '@/components/ui/accordion'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import {
   Collapsible,
@@ -13,12 +14,15 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
 import { Separator } from '@/components/ui/separator'
+import { useEmailNaoLidosCount } from '@/hooks/useQueries/useEmailNaoLidosCount'
 
 import type { Category, ModuleWithChildren } from './constants'
 import { isModuleWithChildren } from './constants'
 import { SidebarButton } from './sidebar-button'
 
 function SidebarNestedModule({ module }: { module: ModuleWithChildren }) {
+  const showUnreadBadge = module.ticketScreenCode === 'inbox'
+  const { data: unreadCount } = useEmailNaoLidosCount(showUnreadBadge)
   const LucideIcon = icons[module.icon]
   return (
     <Collapsible className="w-full">
@@ -30,11 +34,25 @@ function SidebarNestedModule({ module }: { module: ModuleWithChildren }) {
               className="min-w-0 flex-1 justify-start px-2 group-hover:w-full"
               asChild
             >
-              <Link href={module.path} className="flex items-center gap-2">
+              <Link
+                href={module.path}
+                className="flex min-w-0 flex-1 items-center gap-2"
+              >
                 <LucideIcon className="shrink-0 text-muted-foreground" />
-                <span className="opacity-0 transition-all duration-300 group-hover:opacity-100">
+                <span className="min-w-0 truncate opacity-0 transition-all duration-300 group-hover:opacity-100">
                   {module.title}
                 </span>
+                {showUnreadBadge &&
+                unreadCount != null &&
+                unreadCount.total > 0 ? (
+                  <Badge
+                    variant="secondary"
+                    className="ml-auto shrink-0 px-1.5 py-0 text-[10px] tabular-nums opacity-0 transition-all duration-300 group-hover:opacity-100"
+                    aria-label={`${unreadCount.total} não lidos`}
+                  >
+                    {unreadCount.total > 99 ? '99+' : unreadCount.total}
+                  </Badge>
+                ) : null}
               </Link>
             </Button>
             <CollapsibleTrigger asChild>

--- a/src/hooks/useQueries/useEmailNaoLidosCount.ts
+++ b/src/hooks/useQueries/useEmailNaoLidosCount.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { getEmailNaoLidosCount } from '@/http/emails/get-emails'
+
+const REFETCH_MS = 1 * 60 * 1000
+
+export const EMAIL_NAO_LIDOS_COUNT_QUERY_KEY = [
+  'emails-nao-lidos-contagem',
+] as const
+
+export function useEmailNaoLidosCount(enabled: boolean) {
+  return useQuery({
+    queryKey: EMAIL_NAO_LIDOS_COUNT_QUERY_KEY,
+    queryFn: getEmailNaoLidosCount,
+    enabled,
+    refetchInterval: enabled ? REFETCH_MS : false,
+  })
+}

--- a/src/http/emails/get-emails.ts
+++ b/src/http/emails/get-emails.ts
@@ -19,6 +19,10 @@ export interface EmailPageOut {
   total: number
 }
 
+export interface EmailUnreadCountOut {
+  total: number
+}
+
 export function getEmails({
   page,
   pageSize,
@@ -41,6 +45,13 @@ export function getEmailsNaoLidos({
   return api.get<EmailPageOut>('/emails/nao-lidos', {
     params: { page, pageSize },
   })
+}
+
+export async function getEmailNaoLidosCount() {
+  const response = await api.get<EmailUnreadCountOut>(
+    '/emails/nao-lidos/contagem',
+  )
+  return response.data
 }
 
 export function getEmailsAguardandoResposta({

--- a/src/http/tickets/apply-ticket-workflow-action.ts
+++ b/src/http/tickets/apply-ticket-workflow-action.ts
@@ -5,12 +5,18 @@ export type ApplyTicketWorkflowActionOut = {
   is_actor_responsible: boolean
 }
 
+export type ApplyTicketWorkflowActionIn = {
+  comentario?: string | null
+}
+
 export async function applyTicketWorkflowAction(
   ticketId: string,
   actionId: string,
+  payload: ApplyTicketWorkflowActionIn,
 ) {
   const { data } = await api.post<ApplyTicketWorkflowActionOut>(
     `/tickets/${encodeURIComponent(ticketId)}/workflow/actions/${encodeURIComponent(actionId)}`,
+    payload,
   )
   return data
 }

--- a/src/http/tickets/get-ticket-cabecalho.ts
+++ b/src/http/tickets/get-ticket-cabecalho.ts
@@ -3,6 +3,7 @@ import { api } from '@/lib/api'
 export type TicketCabecalhoOut = {
   internal_number: string
   status: string
+  tipo_chamado_nome?: string | null
   prioridade?: string | null
   data_base?: string | null
   equipe?: string | null

--- a/src/http/tickets/get-tickets-dashboard.ts
+++ b/src/http/tickets/get-tickets-dashboard.ts
@@ -23,7 +23,8 @@ export type TicketDashboardFilters = {
   status?: string[]
   prioridade?: string[]
   equipe?: string[]
-  servicos_realizados?: string[]
+  /** Valores da API, ex.: plate_search_services */
+  servicos?: string[]
 }
 
 export async function getTicketsDashboard(filters: TicketDashboardFilters) {
@@ -50,7 +51,7 @@ export async function getTicketsDashboard(filters: TicketDashboardFilters) {
     status: filters.status,
     prioridade: filters.prioridade,
     equipe: filters.equipe,
-    servicos_realizados: filters.servicos_realizados,
+    servicos: filters.servicos,
   })
 
   return response.data

--- a/src/http/user-roles/get-users-with-roles.ts
+++ b/src/http/user-roles/get-users-with-roles.ts
@@ -4,6 +4,7 @@ export type UserRoleEnum =
   | 'Coordenador'
   | 'Administrativo'
   | 'Adjunto'
+  | 'Assessor'
   | 'Líder de Ilha'
   | 'Operador'
 

--- a/src/utils/string-formatters.ts
+++ b/src/utils/string-formatters.ts
@@ -86,6 +86,35 @@ export function unmaskPlateBR(value: string): string {
   return value.replace(/[^a-zA-Z0-9]/g, '').toUpperCase()
 }
 
+const NUMERO_OFICIO_NUM_LEN = 5
+const NUMERO_OFICIO_YEAR_LEN = 4
+const NUMERO_OFICIO_MAX_DIGITS = NUMERO_OFICIO_NUM_LEN + NUMERO_OFICIO_YEAR_LEN
+
+/** Máscara visual: até 5 dígitos do número + / + até 4 dígitos do ano (ex.: 00123/2026). */
+export function maskNumeroOficio(value: string): string {
+  const d = value.replace(/\D/g, '').slice(0, NUMERO_OFICIO_MAX_DIGITS)
+  const num = d.slice(0, NUMERO_OFICIO_NUM_LEN)
+  const year = d.slice(NUMERO_OFICIO_NUM_LEN)
+  if (!year) return num
+  return `${num}/${year}`
+}
+
+/**
+ * Normaliza no blur: número com 5 dígitos (zeros à esquerda) e, se houver ano, / + 4 dígitos.
+ */
+export function normalizeNumeroOficio(value: string): string {
+  const d = value.replace(/\D/g, '').slice(0, NUMERO_OFICIO_MAX_DIGITS)
+  if (!d) return ''
+  const num = padDigitsLeft(
+    d.slice(0, NUMERO_OFICIO_NUM_LEN),
+    NUMERO_OFICIO_NUM_LEN,
+  )
+  const yearDigits = d.slice(NUMERO_OFICIO_NUM_LEN)
+  if (!yearDigits) return num
+  const year = padDigitsLeft(yearDigits, NUMERO_OFICIO_YEAR_LEN)
+  return `${num}/${year}`
+}
+
 export function maskPhoneBR(value: string) {
   const n = value.replace(/\D/g, '').slice(0, 11)
   if (n.length === 0) return ''


### PR DESCRIPTION
## Description

This branch bundles improvements across the **Tickets (Chamados)** module, focused on **ticket detail**, **attachments**, **workflow**, **create / email conversion**, **dashboard listing**, and **inbox**.

**Ticket detail (`ticket-detail-view` and tabs)**  
- Header title now includes the **ticket type name** (`tipo_chamado_nome` on the header payload).  
- **Send for review** opens a dialog with a **required comment**, sent in the workflow action body.  
- Support for the **DESBLOQUEAR** action (confirmation + toast).  
- `applyTicketWorkflowAction` now sends a payload (`comentario`); finalize sends `comentario: null`.  
- After several workflow mutations, query invalidation includes `tickets-dashboard` with `refetchType: 'all'` so the dashboard updates even when the list view is unmounted.  
- Redirect to `/chamados` after some actions with a **~1.5s delay** (unified behavior vs. previous `is_actor_responsible` branching).

**Attachments**  
- **View** attachment (eye icon): fetches blob and opens in a new tab; used on the **Documents** tab and **service attachments** (scoped fetch when a service scope is set).  
- **Services** tab: for rows that still have a **local draft id**, files are **queued** until save; after replacing services, uploads run (multipart + **video** flow via signed URL + complete). Service attachments are **hidden** for `cerco_eletronico`. CSS updates for blocked / editing states.

**Ticket / Requester tabs**  
- **Office number (Nº de ofício)**: mask and normalization to `00000/0000`, format validation aligned with create flow; CSS classes for read vs edit (select/value contrast).

**Create ticket / email → ticket**  
- Same office-number mask/normalization; Zod schema `refine` for format.  
- Limits: `numero_oficio` max length **10**; `comentario_inicial` **2000**; mapper normalizes office number and truncates comment to the limit.  
- Ticket search in popover: **350ms debounce**, query enabled while popover is open (initial list without forcing typing); placeholder / empty-state copy updated.

**General list / dashboard**  
- Filters: **`servicos`** multi-select (API values, e.g. `plate_search_services`) replaces `servicos_realizados`; HTTP payload aligned.  
- Dashboard response treats **optional sections** (`null`); summary cards only show Urgent / Overdue / Blocked when that section exists.  
- Dashboard `queryKey` **without** `subjectUserId` (impersonation no longer splits this query cache).  
- **Levantamento Prévio** row hint with **tooltip**; **priority** cell layout (badge + label).  
- Filter modal: overlay/panel uses **near full viewport** height (`100dvh` / `100vh`).

**Impersonation**  
- Removed manual query invalidation before **full page reload** (simpler flow).

**Inbox / sidebar**  
- New **`GET /emails/nao-lidos/contagem`** endpoint, `useEmailNaoLidosCount` with periodic refetch, **badge** on inbox entry in the accordion; count query invalidated on spam, reply send, and related converter flows.

**Access profiles**  
- **Assessor** role in form, table, badge styles, and `UserRoleEnum`.

**Utilities**  
- `maskNumeroOficio` / `normalizeNumeroOficio` in `string-formatters.ts`.

## Related Issue

<!-- Issue link if applicable -->

## Motivation and Context

Improve Chamados UX and business rules: standardized office number, attachments on newly created services, file preview, workflow with review comment and unblock, dashboard aligned with API (service filter and optional sections), and unread email visibility in navigation.

## How has this been tested?

<!-- Describe manual scenarios: detail, create, email conversion, list filters, inbox/badge, regressions -->

_Automated tests were not run in the agent environment._

## Screenshots (if appropriate):

<!-- Attach: detail header, Send for review dialog, view attachment, inbox badge, service filter, Levantamento Prévio tooltip -->

## Types of changes

- [x] fix: used when there is correction of errors that are generating bugs in the system.
- [x] feat: indicates the development of a new feature for the project.
- [ ] perf: indicates a change that improved system performance.
- [ ] test: indicates any type of creation or change of test codes.
- [x] refactor: used when there is a code refactoring that does not have any type of impact on the system's business logic/rules.
- [x] style: used when there are formatting and code style changes that do not alter the system in any way.
- [ ] chore: indicates changes to the project that do not affect the system or test files.
- [ ] docs: used when there are changes to the project documentation.
- [ ] build: used to indicate changes that affect the project's build process or external dependencies.
- [ ] ci: used for changes to CI configuration files.
- [ ] revert: indicates the revert of a previous commit

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.