### PR TITLE
feat: enhance ticket detail view with new report section options and …

### DIFF
--- a/src/app/(app)/demandas/[ticketId]/components/ticket-detail-view.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-detail-view.tsx
@@ -49,7 +49,11 @@ import { fetchTicketAttachmentBlob } from '@/http/tickets/download-ticket-attach
 import { getTicketAllowedActions } from '@/http/tickets/get-ticket-allowed-actions'
 import { getTicketCabecalho } from '@/http/tickets/get-ticket-cabecalho'
 import { getTicketNotificationEmails } from '@/http/tickets/get-ticket-notification-emails'
-import { getTicketRelatorioCompleto } from '@/http/tickets/get-ticket-relatorio-completo'
+import {
+  defaultTicketRelatorioCompletoTopics,
+  getTicketRelatorioCompleto,
+  type TicketRelatorioCompletoTopics,
+} from '@/http/tickets/get-ticket-relatorio-completo'
 import { type TicketReassignPriority } from '@/http/tickets/reassign-ticket'
 import { getTicketAttachments } from '@/http/tickets/ticket-attachments'
 import { cn } from '@/lib/utils'
@@ -114,6 +118,21 @@ function formatReassignPriorityLabel(priority: TicketReassignPriority) {
   return 'Rotina'
 }
 
+type RelatorioCompletoTopicKey = keyof TicketRelatorioCompletoTopics
+
+const RELATORIO_COMPLETO_TOPIC_ITEMS: {
+  key: RelatorioCompletoTopicKey
+  title: string
+}[] = [
+  { key: 't1', title: 'Solicitação Original' },
+  { key: 't2', title: 'Registro do Chamado no Sistema' },
+  { key: 't3', title: 'Relatório Técnico de Atendimento' },
+  { key: 't4', title: 'Parecer Interno' },
+  { key: 't5', title: 'Relatório da Demanda' },
+  { key: 't6', title: 'Histórico de Movimentações' },
+  { key: 't7', title: 'Conclusão Administrativa' },
+]
+
 type Props = {
   ticketId: string
 }
@@ -132,6 +151,17 @@ export function TicketDetailView({ ticketId }: Props) {
   const [oficioOpen, setOficioOpen] = useState(false)
   const [oficioAttachmentIndex, setOficioAttachmentIndex] = useState(0)
   const [oficioPreviewUrl, setOficioPreviewUrl] = useState<string | null>(null)
+  const [relatorioTopicsModalOpen, setRelatorioTopicsModalOpen] =
+    useState(false)
+  const [relatorioTopicsDraft, setRelatorioTopicsDraft] =
+    useState<TicketRelatorioCompletoTopics>(() =>
+      defaultTicketRelatorioCompletoTopics(),
+    )
+  const [relatorioFetchTopics, setRelatorioFetchTopics] =
+    useState<TicketRelatorioCompletoTopics>(() =>
+      defaultTicketRelatorioCompletoTopics(),
+    )
+  const [relatorioRequestId, setRelatorioRequestId] = useState(0)
   const [relatorioOpen, setRelatorioOpen] = useState(false)
   const [relatorioPreviewUrl, setRelatorioPreviewUrl] = useState<string | null>(
     null,
@@ -351,11 +381,22 @@ export function TicketDetailView({ ticketId }: Props) {
   }, [oficioOpen, oficioBlobQuery.data])
 
   const relatorioQuery = useQuery({
-    queryKey: ['ticket', ticketId, 'relatorio-completo'],
-    queryFn: () => getTicketRelatorioCompleto(ticketId),
+    queryKey: [
+      'ticket',
+      ticketId,
+      'relatorio-completo',
+      relatorioFetchTopics,
+      relatorioRequestId,
+    ],
+    queryFn: () => getTicketRelatorioCompleto(ticketId, relatorioFetchTopics),
     enabled: relatorioOpen,
     retry: false,
   })
+
+  useEffect(() => {
+    if (!relatorioTopicsModalOpen) return
+    setRelatorioTopicsDraft(defaultTicketRelatorioCompletoTopics())
+  }, [relatorioTopicsModalOpen])
 
   useEffect(() => {
     let created: string | null = null
@@ -541,7 +582,7 @@ export function TicketDetailView({ ticketId }: Props) {
           <button
             type="button"
             className={`${styles.actionSlot} ${styles.actionTertiary}`}
-            onClick={() => setRelatorioOpen(true)}
+            onClick={() => setRelatorioTopicsModalOpen(true)}
           >
             Gerar Relatório
           </button>
@@ -860,6 +901,18 @@ export function TicketDetailView({ ticketId }: Props) {
                         </p>
                       ) : null}
                     </div>
+                    <div className={styles.reassignField}>
+                      <span className={styles.reassignLabel}>Despacho</span>
+                      <Textarea
+                        value={workflowComment}
+                        onChange={(event) =>
+                          setWorkflowComment(event.target.value)
+                        }
+                        placeholder="Digite o despacho"
+                        className={styles.reassignTextarea}
+                        disabled={workflowActionMutation.isPending}
+                      />
+                    </div>
                   </div>
                 ) : (
                   <div className={styles.reassignField}>
@@ -893,8 +946,7 @@ export function TicketDetailView({ ticketId }: Props) {
                   className={`${styles.footerBtn} ${styles.footerBtnPrimary}`}
                   disabled={
                     workflowActionMutation.isPending ||
-                    (!isWorkflowEmailAction &&
-                      workflowComment.trim().length === 0) ||
+                    workflowComment.trim().length === 0 ||
                     (isWorkflowEmailAction &&
                       (notificationEmailsQuery.isLoading ||
                         (notificationEmailsQuery.data ?? []).length === 0))
@@ -903,16 +955,16 @@ export function TicketDetailView({ ticketId }: Props) {
                     if (workflowCommentAction) {
                       workflowActionMutation.mutate({
                         actionId: workflowCommentAction,
-                        comentario: isWorkflowEmailAction
-                          ? undefined
-                          : workflowComment.trim(),
+                        comentario: workflowComment.trim(),
                       })
                     }
                   }}
                 >
                   {workflowActionMutation.isPending
                     ? 'Aplicando ação…'
-                    : 'Confirmar'}
+                    : isWorkflowEmailAction
+                      ? 'Enviar E-mail'
+                      : 'Confirmar'}
                 </button>
               </DialogFooter>
             </div>
@@ -1018,6 +1070,110 @@ export function TicketDetailView({ ticketId }: Props) {
                   Não foi possível exibir o arquivo neste navegador.
                 </p>
               )}
+            </div>
+          </DialogContent>
+        </Dialog>
+
+        <Dialog
+          open={relatorioTopicsModalOpen}
+          onOpenChange={setRelatorioTopicsModalOpen}
+        >
+          <DialogContent
+            className={styles.reassignDialogContent}
+            aria-describedby={undefined}
+          >
+            <div className={styles.reassignDialogInner}>
+              <DialogHeader className={styles.reassignDialogHeader}>
+                <DialogTitle className={styles.reassignDialogTitle}>
+                  Conteúdo do relatório PDF
+                </DialogTitle>
+              </DialogHeader>
+              <div className={styles.reassignFields}>
+                <div className={styles.reassignField}>
+                  <p className={styles.reassignFieldMessage}>
+                    Escolha quais seções incluir no relatório completo. Por
+                    padrão, todas vêm marcadas.
+                  </p>
+                  <div className={styles.relatorioTopicsActionsRow}>
+                    <button
+                      type="button"
+                      className={styles.relatorioTopicsToggleBtn}
+                      onClick={() =>
+                        setRelatorioTopicsDraft(
+                          defaultTicketRelatorioCompletoTopics(),
+                        )
+                      }
+                    >
+                      Marcar todos
+                    </button>
+                    <button
+                      type="button"
+                      className={styles.relatorioTopicsToggleBtn}
+                      onClick={() =>
+                        setRelatorioTopicsDraft({
+                          t1: false,
+                          t2: false,
+                          t3: false,
+                          t4: false,
+                          t5: false,
+                          t6: false,
+                          t7: false,
+                        })
+                      }
+                    >
+                      Desmarcar todos
+                    </button>
+                  </div>
+                  <div className={styles.relatorioTopicsList}>
+                    {RELATORIO_COMPLETO_TOPIC_ITEMS.map((item, index) => (
+                      <label
+                        key={item.key}
+                        className={styles.relatorioTopicCheckLabel}
+                      >
+                        <Checkbox
+                          checked={relatorioTopicsDraft[item.key]}
+                          onCheckedChange={(value) => {
+                            setRelatorioTopicsDraft((prev) => ({
+                              ...prev,
+                              [item.key]: value === true,
+                            }))
+                          }}
+                        />
+                        <span className={styles.relatorioTopicCheckTitle}>
+                          {`Tópico ${index + 1} — ${item.title}`}
+                        </span>
+                      </label>
+                    ))}
+                  </div>
+                </div>
+              </div>
+              <DialogFooter className={styles.footerActions}>
+                <button
+                  type="button"
+                  className={`${styles.footerBtn} ${styles.footerBtnDefault}`}
+                  onClick={() => setRelatorioTopicsModalOpen(false)}
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="button"
+                  className={`${styles.footerBtn} ${styles.footerBtnPrimary}`}
+                  onClick={() => {
+                    const anySelected =
+                      Object.values(relatorioTopicsDraft).some(Boolean)
+                    if (!anySelected) {
+                      toast.error('Selecione pelo menos um tópico.')
+                      return
+                    }
+                    setRelatorioFetchTopics({ ...relatorioTopicsDraft })
+                    setRelatorioRequestId((n) => n + 1)
+                    setRelatorioTopicsModalOpen(false)
+                    setRelatorioOpen(true)
+                  }}
+                >
+                  Gerar relatório
+                </button>
+              </DialogFooter>
             </div>
           </DialogContent>
         </Dialog>

--- a/src/app/(app)/demandas/[ticketId]/ticket-detail.module.css
+++ b/src/app/(app)/demandas/[ticketId]/ticket-detail.module.css
@@ -2647,3 +2647,59 @@
   line-height: 20px;
   color: var(--td-muted);
 }
+
+.relatorioTopicsActionsRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 20px;
+  align-items: center;
+  margin-bottom: 4px;
+}
+
+.relatorioTopicsToggleBtn {
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--td-text);
+  font-size: 13px;
+  text-decoration: underline;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.relatorioTopicsToggleBtn:hover {
+  color: #fff;
+}
+
+.relatorioTopicsList {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  max-height: min(50vh, 360px);
+  overflow-y: auto;
+  border: 1px solid var(--td-border);
+  border-radius: 8px;
+  padding: 6px 0;
+  background: var(--td-card-bg);
+}
+
+.relatorioTopicCheckLabel {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  margin: 0;
+  color: var(--td-text);
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.relatorioTopicCheckLabel:hover {
+  background: rgba(21, 37, 52, 0.65);
+}
+
+.relatorioTopicCheckTitle {
+  font-weight: 600;
+  line-height: 1.3;
+  min-width: 0;
+}

--- a/src/http/tickets/apply-ticket-workflow-action.ts
+++ b/src/http/tickets/apply-ticket-workflow-action.ts
@@ -23,7 +23,7 @@ export async function applyTicketWorkflowAction(
   payload: ApplyTicketWorkflowActionIn,
 ) {
   const { data } = await api.post<ApplyTicketWorkflowActionOut>(
-    `/tickets/${encodeURIComponent(ticketId)}/workflow/actions/${encodeURIComponent(actionId)}`,
+    `/workflow/${encodeURIComponent(ticketId)}/actions/${encodeURIComponent(actionId)}`,
     payload,
   )
   return data

--- a/src/http/tickets/get-ticket-allowed-actions.ts
+++ b/src/http/tickets/get-ticket-allowed-actions.ts
@@ -11,7 +11,7 @@ export type TicketAllowedActionsOut = {
 /** GET `/tickets/{ticket_id}/workflow/allowed-actions` */
 export async function getTicketAllowedActions(ticketId: string) {
   const { data } = await api.get<TicketAllowedActionsOut>(
-    `/tickets/${encodeURIComponent(ticketId)}/workflow/allowed-actions`,
+    `/workflow/${encodeURIComponent(ticketId)}/allowed-actions`,
   )
   return data
 }

--- a/src/http/tickets/get-ticket-relatorio-completo.ts
+++ b/src/http/tickets/get-ticket-relatorio-completo.ts
@@ -7,6 +7,29 @@ export type TicketRelatorioCompletoPayload = {
   contentType: string
 }
 
+/** Query params do GET `/tickets/{id}/relatorio-completo` — quais seções incluir no PDF. */
+export type TicketRelatorioCompletoTopics = {
+  t1: boolean
+  t2: boolean
+  t3: boolean
+  t4: boolean
+  t5: boolean
+  t6: boolean
+  t7: boolean
+}
+
+export function defaultTicketRelatorioCompletoTopics(): TicketRelatorioCompletoTopics {
+  return {
+    t1: true,
+    t2: true,
+    t3: true,
+    t4: true,
+    t5: true,
+    t6: true,
+    t7: true,
+  }
+}
+
 function headerContentType(headers: RawAxiosResponseHeaders): string {
   const raw = headers['content-type']
   if (typeof raw === 'string' && raw.trim()) {
@@ -18,10 +41,11 @@ function headerContentType(headers: RawAxiosResponseHeaders): string {
 /** GET `/tickets/{id}/relatorio-completo` — PDF com dados completos do chamado. */
 export async function getTicketRelatorioCompleto(
   ticketId: string,
+  topics: TicketRelatorioCompletoTopics,
 ): Promise<TicketRelatorioCompletoPayload> {
   const response = await api.get<Blob>(
     `/tickets/${encodeURIComponent(ticketId)}/relatorio-completo`,
-    { responseType: 'blob' },
+    { responseType: 'blob', params: topics },
   )
   const fromHeader = headerContentType(
     response.headers as RawAxiosResponseHeaders,


### PR DESCRIPTION
# feat(tickets): workflow API paths, relatorio PDF section picker, and detail modal

## Description

This PR updates ticket workflow HTTP clients to use the `/workflow/{ticketId}/...` API paths and enhances the ticket detail view so users can choose which sections to include in the full PDF report (`t1`–`t7` query parameters), including a confirmation modal and related styles.

**Changes**

- `src/app/(app)/demandas/[ticketId]/components/ticket-detail-view.tsx` — UI for report section selection, modal flow, and integration with full-report download.
- `src/http/tickets/get-ticket-relatorio-completo.ts` — Adds `TicketRelatorioCompletoTopics`, `defaultTicketRelatorioCompletoTopics()`, and passes topics as query params on `GET /tickets/{id}/relatorio-completo`.
- `src/http/tickets/apply-ticket-workflow-action.ts` / `src/http/tickets/get-ticket-allowed-actions.ts` — Endpoints updated from `/tickets/.../workflow/...` to `/workflow/{ticketId}/...`.
- `src/app/(app)/demandas/[ticketId]/ticket-detail.module.css` — Styles supporting the new report/modal UI.

## Related Issue

<!-- Add issue link if applicable -->

## Motivation and Context

The API exposes workflow under `/workflow/...`, and the full report endpoint accepts section flags via the query string. The frontend must call the correct routes and let users control PDF content from the ticket (demanda) detail page.

## How has this been tested?

<!-- Describe your testing -->

- [ ] Ticket detail: open the full-report flow, toggle sections, generate/download PDF; verify query params match backend expectations.
- [ ] Regression: workflow actions and allowed-actions still work after URL changes (against an API serving the new routes).

## Screenshots (if appropriate)
<img width="1700" height="924" alt="image" src="https://github.com/user-attachments/assets/e75b7be8-104a-4b4a-a585-6c7df0e6dffb" />
<img width="1181" height="866" alt="image" src="https://github.com/user-attachments/assets/a3509309-e5b7-450c-9bf6-051f751813a3" />


<!-- Add screenshots of the section picker / modal -->

## Types of changes

- [ ] fix: used when there is correction of errors that are generating bugs in the system.
- [x] feat: indicates the development of a new feature for the project.
- [ ] perf: indicates a change that improved system performance.
- [ ] test: indicates any type of creation or change of test codes.
- [ ] refactor: used when there is a code refactoring that does not have any type of impact on the system's business logic/rules.
- [ ] style: used when there are formatting and code style changes that do not alter the system in any way.
- [ ] chore: indicates changes to the project that do not affect the system or test files.
- [ ] docs: used when there are changes to the project documentation.
- [ ] build: used to indicate changes that affect the project's build process or external dependencies.
- [ ] ci: used for changes to CI configuration files.
- [ ] revert: indicates the revert of a previous commit

## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.