### PR TITLE
feat: update ticket detail components with new date picker integratio…

### DIFF
--- a/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-resposta.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-resposta.tsx
@@ -147,12 +147,12 @@ export function TicketDetailTabResposta({ ticketId }: Props) {
     queryKey: [
       'standardized-responses',
       'list',
-      { isActive: true, category: 'RECEBIMENTO_SOLICITACOES' as const },
+      { isActive: true, category: 'RESPOSTAS_POSITIVAS' as const },
     ],
     queryFn: async () => {
       const r = await listStandardizedResponses({
         isActive: true,
-        category: 'RECEBIMENTO_SOLICITACOES',
+        category: 'RESPOSTAS_POSITIVAS',
       })
       return r.data
     },

--- a/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-servicos.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-servicos.tsx
@@ -533,7 +533,8 @@ export function TicketDetailTabServicos({ ticketId }: Props) {
                             : null
                         }
                       />
-                      {row.kind !== 'cerco_eletronico' ? (
+                      {row.kind !== 'cerco_eletronico' &&
+                      row.kind !== 'reserva_de_imagem' ? (
                         <TicketServicoAnexos
                           ticketId={ticketId}
                           title="Anexos deste serviço"

--- a/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-solicitante.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-solicitante.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/http/tickets/ticket-solicitante'
 import { isApiError } from '@/lib/api'
 import { getApiErrorMessage } from '@/utils/error-handlers'
+import { maskPhoneBR } from '@/utils/string-formatters'
 
 import styles from '../ticket-detail.module.css'
 
@@ -469,10 +470,11 @@ export function TicketDetailTabSolicitante({ ticketId }: Props) {
                         </div>
                         <input
                           className={`${styles.editableField} ${styles.solicitanteEditField}`}
+                          inputMode="tel"
                           value={fp.telefone ?? ''}
                           onChange={(e) =>
                             setFocal(index, {
-                              telefone: e.target.value || null,
+                              telefone: maskPhoneBR(e.target.value) || null,
                             })
                           }
                           autoComplete="tel"

--- a/src/app/(app)/demandas/[ticketId]/components/ticket-detail-view.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-detail-view.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useMutation, useQuery } from '@tanstack/react-query'
-import { ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react'
+import { Check, ChevronDown, ChevronLeft, ChevronRight } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useEffect, useMemo, useRef, useState } from 'react'
@@ -177,7 +177,6 @@ export function TicketDetailView({ ticketId }: Props) {
   const [workflowCommentAction, setWorkflowCommentAction] =
     useState<TicketWorkflowConfirmableAction | null>(null)
   const [workflowComment, setWorkflowComment] = useState('')
-  const [selectedNotificationEmail, setSelectedNotificationEmail] = useState('')
   const [reassignOpen, setReassignOpen] = useState(false)
   const [selectedTeamId, setSelectedTeamId] = useState('')
   const [selectedResponsibleIds, setSelectedResponsibleIds] = useState<
@@ -459,15 +458,6 @@ export function TicketDetailView({ ticketId }: Props) {
   useEffect(() => {
     setSelectedResponsibleIds([])
   }, [selectedTeamId])
-
-  useEffect(() => {
-    if (workflowCommentAction !== 'ENVIAR_EMAIL') {
-      setSelectedNotificationEmail('')
-      return
-    }
-    const firstEmail = notificationEmailsQuery.data?.[0] ?? ''
-    setSelectedNotificationEmail(firstEmail)
-  }, [workflowCommentAction, notificationEmailsQuery.data])
 
   useEffect(() => {
     if (showRespostaTab || activeTab !== 'resposta') return
@@ -881,38 +871,67 @@ export function TicketDetailView({ ticketId }: Props) {
                       para:
                     </h3>
                     <div className={styles.workflowEmailSelectWrap}>
-                      <Select
-                        value={selectedNotificationEmail || undefined}
-                        onValueChange={() => {}}
-                        disabled={
-                          workflowActionMutation.isPending ||
-                          notificationEmailsQuery.isLoading
-                        }
-                      >
-                        <SelectTrigger
-                          className={styles.workflowEmailSelectTrigger}
-                        >
-                          <SelectValue
-                            placeholder={
-                              notificationEmailsQuery.isLoading
-                                ? 'Carregando e-mails...'
-                                : 'Sem e-mails para exibir'
+                      <Popover>
+                        <PopoverTrigger asChild>
+                          <button
+                            type="button"
+                            className={cn(
+                              styles.workflowEmailSelectTrigger,
+                              'flex w-full cursor-pointer items-center justify-between gap-2 text-left outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50',
+                            )}
+                            disabled={
+                              workflowActionMutation.isPending ||
+                              notificationEmailsQuery.isLoading ||
+                              (notificationEmailsQuery.data ?? []).length === 0
                             }
-                          />
-                        </SelectTrigger>
-                        <SelectContent className={styles.detailSelectContent}>
+                          >
+                            <span className="min-w-0 flex-1 truncate">
+                              {notificationEmailsQuery.isLoading
+                                ? 'Carregando e-mails...'
+                                : (notificationEmailsQuery.data ?? [])
+                                      .length === 0
+                                  ? 'Sem e-mails para exibir'
+                                  : (notificationEmailsQuery.data ?? [])[0]}
+                            </span>
+                            <ChevronDown
+                              size={16}
+                              className="shrink-0"
+                              aria-hidden
+                            />
+                          </button>
+                        </PopoverTrigger>
+                        <PopoverContent
+                          align="center"
+                          sideOffset={4}
+                          onOpenAutoFocus={(event) => event.preventDefault()}
+                          className={cn(
+                            styles.detailSelectContent,
+                            styles.workflowEmailRecipientPopover,
+                            'w-[var(--radix-popover-trigger-width)] max-w-none p-1',
+                          )}
+                          role="listbox"
+                          aria-label="Destinatários do e-mail"
+                        >
                           {(notificationEmailsQuery.data ?? []).map((email) => (
-                            <SelectItem
+                            <div
                               key={email}
-                              value={email}
-                              disabled
-                              className={styles.detailSelectItem}
+                              className={styles.workflowEmailRecipientRow}
+                              role="option"
+                              aria-selected="true"
                             >
-                              {email}
-                            </SelectItem>
+                              <Check
+                                className={styles.workflowEmailRecipientCheck}
+                                aria-hidden
+                              />
+                              <span
+                                className={styles.workflowEmailRecipientText}
+                              >
+                                {email}
+                              </span>
+                            </div>
                           ))}
-                        </SelectContent>
-                      </Select>
+                        </PopoverContent>
+                      </Popover>
                       {notificationEmailsQuery.isError ? (
                         <p className={styles.reassignFieldMessageError}>
                           {getApiErrorMessage(notificationEmailsQuery.error)}

--- a/src/app/(app)/demandas/[ticketId]/components/ticket-servicos-expanded-form.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-servicos-expanded-form.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import { Plus, Trash } from 'lucide-react'
-import { Fragment, type ReactNode } from 'react'
+import { Fragment, type ReactNode, type SetStateAction } from 'react'
 
 import type { OpenServiceKey } from '@/app/(app)/demandas/criar/ticket-create/ticket-create.constant'
 import { Button } from '@/components/ui/button'
+import { DatePicker } from '@/components/ui/date-picker'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import type { TicketDetection } from '@/http/tickets/get-ticket-by-id'
@@ -14,8 +15,6 @@ import { maskPlateBR } from '@/utils/string-formatters'
 import styles from '../ticket-detail.module.css'
 import {
   cloneTicketServicos,
-  datetimeLocalToIso,
-  isoToDatetimeLocal,
   newNestedEntityId,
 } from '../ticket-servicos-mapper'
 
@@ -47,6 +46,22 @@ type ServicosPeriodPatch = {
   period_end: string | null
 }
 
+function isoToDateValue(iso: string | null | undefined): Date | undefined {
+  if (iso == null || iso === '') return undefined
+  const date = new Date(iso)
+  return Number.isNaN(date.getTime()) ? undefined : date
+}
+
+function datePickerValueToIso(
+  value: SetStateAction<Date | undefined>,
+  previousIso: string | null | undefined,
+): string | null {
+  const previousDate = isoToDateValue(previousIso)
+  const nextDate = typeof value === 'function' ? value(previousDate) : value
+  if (!nextDate || Number.isNaN(nextDate.getTime())) return null
+  return nextDate.toISOString()
+}
+
 function ServicosSearchPeriodInputs({
   periodStart,
   periodEnd,
@@ -58,14 +73,17 @@ function ServicosSearchPeriodInputs({
   readOnly?: boolean
   onPatch: (next: ServicosPeriodPatch) => void
 }) {
+  const startDate = isoToDateValue(periodStart)
+  const endDate = isoToDateValue(periodEnd)
+
   return (
     <div className="grid w-full grid-cols-1 gap-2 sm:grid-cols-2">
-      <Input
+      <DatePicker
         type="datetime-local"
-        className={styles.servicosInput}
-        value={isoToDatetimeLocal(periodStart)}
-        onChange={(e) => {
-          const newPeriodStart = datetimeLocalToIso(e.target.value)
+        className={styles.servicosDateTimeInput}
+        value={startDate}
+        onChange={(value) => {
+          const newPeriodStart = datePickerValueToIso(value, periodStart)
           let nextPeriodEnd: string | null =
             periodEnd != null && periodEnd !== '' ? periodEnd : null
           if (
@@ -77,15 +95,17 @@ function ServicosSearchPeriodInputs({
           }
           onPatch({ period_start: newPeriodStart, period_end: nextPeriodEnd })
         }}
+        toDate={endDate}
+        timePickerDisableFuture={false}
         disabled={readOnly}
-        aria-label="Início do período da busca"
+        placeholder="Início"
       />
-      <Input
+      <DatePicker
         type="datetime-local"
-        className={styles.servicosInput}
-        value={isoToDatetimeLocal(periodEnd)}
-        onChange={(e) => {
-          const newPeriodEnd = datetimeLocalToIso(e.target.value)
+        className={styles.servicosDateTimeInput}
+        value={endDate}
+        onChange={(value) => {
+          const newPeriodEnd = datePickerValueToIso(value, periodEnd)
           let nextPeriodStart: string | null =
             periodStart != null && periodStart !== '' ? periodStart : null
           if (
@@ -97,8 +117,10 @@ function ServicosSearchPeriodInputs({
           }
           onPatch({ period_start: nextPeriodStart, period_end: newPeriodEnd })
         }}
+        fromDate={startDate}
+        timePickerDisableFuture={false}
         disabled={readOnly}
-        aria-label="Fim do período da busca"
+        placeholder="Fim"
       />
     </div>
   )

--- a/src/app/(app)/demandas/[ticketId]/ticket-detail.constants.ts
+++ b/src/app/(app)/demandas/[ticketId]/ticket-detail.constants.ts
@@ -32,16 +32,6 @@ export const TICKET_RESPOSTA_TAB = {
 
 const RESPOSTA_TAB_STATE_ID = 'AGUARDANDO_REVISAO_ADMINISTRATIVO'
 
-/** Alinha rótulos humanos ou snake_case do cabeçalho ao id de estado do workflow. */
-function normalizeTicketStatusKey(value: string): string {
-  return value
-    .trim()
-    .toUpperCase()
-    .normalize('NFD')
-    .replace(/[\u0300-\u036f]/g, '')
-    .replace(/\s+/g, '_')
-}
-
 export function shouldShowTicketRespostaTab(
   stateId: string | null | undefined,
   status: string | null | undefined,
@@ -49,7 +39,7 @@ export function shouldShowTicketRespostaTab(
   const normalizedStateId = stateId?.trim().toUpperCase() ?? ''
   if (normalizedStateId === RESPOSTA_TAB_STATE_ID) return true
 
-  const raw = status?.trim() ?? ''
-  if (!raw) return false
-  return normalizeTicketStatusKey(raw) === RESPOSTA_TAB_STATE_ID
+  const normalizedStatus = status?.trim().toUpperCase() ?? ''
+  if (!normalizedStatus) return false
+  return normalizedStatus === RESPOSTA_TAB_STATE_ID
 }

--- a/src/app/(app)/demandas/[ticketId]/ticket-detail.constants.ts
+++ b/src/app/(app)/demandas/[ticketId]/ticket-detail.constants.ts
@@ -30,23 +30,26 @@ export const TICKET_RESPOSTA_TAB = {
   label: 'Resposta',
 }
 
-const TICKET_STATE_IDS_WITH_RESPOSTA_TAB = new Set([
-  'AGUARDANDO_REVISAO_ADMINISTRATIVO',
-  'AGUARDANDO_REVISAO_ADJUNTO',
-  'ADJUNTO',
-  'ADMINISTRATIVO',
-])
+const RESPOSTA_TAB_STATE_ID = 'AGUARDANDO_REVISAO_ADMINISTRATIVO'
+
+/** Alinha rótulos humanos ou snake_case do cabeçalho ao id de estado do workflow. */
+function normalizeTicketStatusKey(value: string): string {
+  return value
+    .trim()
+    .toUpperCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/\s+/g, '_')
+}
 
 export function shouldShowTicketRespostaTab(
   stateId: string | null | undefined,
   status: string | null | undefined,
 ) {
   const normalizedStateId = stateId?.trim().toUpperCase() ?? ''
-  if (TICKET_STATE_IDS_WITH_RESPOSTA_TAB.has(normalizedStateId)) return true
+  if (normalizedStateId === RESPOSTA_TAB_STATE_ID) return true
 
-  const normalizedStatus = status?.trim().toUpperCase() ?? ''
-  return (
-    normalizedStatus === 'AGUARDANDO_REVISAO_ADMINISTRATIVO' ||
-    normalizedStatus === 'AGUARDANDO_REVISAO_ADJUNTO'
-  )
+  const raw = status?.trim() ?? ''
+  if (!raw) return false
+  return normalizeTicketStatusKey(raw) === RESPOSTA_TAB_STATE_ID
 }

--- a/src/app/(app)/demandas/[ticketId]/ticket-detail.module.css
+++ b/src/app/(app)/demandas/[ticketId]/ticket-detail.module.css
@@ -165,16 +165,17 @@
 }
 
 .actionsRow {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 16px;
+  display: grid;
   width: 100%;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
 }
 
 .actionSlot {
-  flex: 1 1 160px;
+  width: 100%;
   min-height: 40px;
   min-width: 0;
+  box-sizing: border-box;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1278,6 +1279,7 @@
 
   max-width: min(620px, calc(100vw - 32px)) !important;
   width: 100%;
+  min-width: 0;
   border: 1px solid var(--td-border) !important;
   border-radius: 16px;
   background: var(--td-section-bg) !important;
@@ -1293,6 +1295,9 @@
   flex-direction: column;
   gap: 40px;
   padding: 24px;
+  min-width: 0;
+  max-width: 100%;
+  box-sizing: border-box;
 }
 
 .workflowEmailDialogInner {
@@ -1320,6 +1325,8 @@
   flex-direction: column;
   gap: 24px;
   width: 100%;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .workflowEmailContent {
@@ -1363,11 +1370,45 @@
   color: var(--td-muted, #97a2ab);
 }
 
+.workflowEmailRecipientPopover {
+  max-height: min(240px, 40vh);
+  overflow-y: auto;
+  box-sizing: border-box;
+}
+
+.workflowEmailRecipientRow {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 6px 10px 6px 8px;
+  border-radius: 4px;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 16px;
+  color: #f9fafa;
+}
+
+.workflowEmailRecipientCheck {
+  height: 16px;
+  width: 16px;
+  flex-shrink: 0;
+  margin-top: 1px;
+  color: #f9fafa;
+}
+
+.workflowEmailRecipientText {
+  min-width: 0;
+  flex: 1;
+  overflow-wrap: anywhere;
+}
+
 .reassignField {
   display: flex;
   flex-direction: column;
   gap: 6px;
   width: 100%;
+  min-width: 0;
+  max-width: 100%;
 }
 
 .reassignLabel {
@@ -1421,8 +1462,11 @@
 
 .reassignMultiTrigger {
   width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
   min-height: 44px;
-  padding: 0 16px;
+  padding: 10px 16px;
   border-radius: 8px;
   border: 1px solid var(--td-border);
   background: var(--td-card-bg);
@@ -1436,20 +1480,36 @@
   font-size: 14px;
 }
 
+.reassignMultiTrigger > svg {
+  flex-shrink: 0;
+  align-self: flex-start;
+  margin-top: 2px;
+}
+
 .reassignMultiTrigger:disabled {
   opacity: 0.75;
   cursor: not-allowed;
 }
 
 .reassignMultiValue {
+  flex: 1 1 0%;
+  min-width: 0;
   color: var(--td-text);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  line-height: 1.35;
+  max-height: 7.5rem;
+  overflow-y: auto;
 }
 
 .reassignMultiPlaceholder {
+  flex: 1 1 0%;
+  min-width: 0;
   color: var(--td-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .reassignPopoverContent {
@@ -1512,10 +1572,13 @@
   display: flex;
   flex-wrap: wrap;
   gap: 16px;
+  width: 100%;
+  min-width: 0;
 }
 
 .reassignPriorityBtn {
-  flex: 1 1 120px;
+  flex: 1 1 min(120px, 100%);
+  min-width: 0;
   min-height: 40px;
   border: none;
   border-radius: 8px;
@@ -1536,6 +1599,9 @@
   display: flex;
   justify-content: flex-end;
   width: 100%;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
 .servicosIntro {
@@ -1818,6 +1884,35 @@
 .servicosInput:focus {
   outline: 2px solid rgba(116, 169, 189, 0.45);
   outline-offset: 0;
+}
+
+.servicosDateTimeInput {
+  min-height: 44px !important;
+  height: 44px;
+  padding: 0 16px !important;
+  border-radius: var(--td-radius) !important;
+  border: 1px solid var(--td-border) !important;
+  background-color: var(--td-label-bg) !important;
+  color: var(--td-text) !important;
+  font-family: inherit;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.servicosDateTimeInput:hover:not(:disabled) {
+  background-color: var(--td-label-bg) !important;
+  filter: brightness(1.06);
+}
+
+.servicosDateTimeInput:focus-visible {
+  outline: 2px solid rgba(116, 169, 189, 0.45);
+  outline-offset: 0;
+  box-shadow: none;
+}
+
+.servicosDateTimeInput:disabled {
+  opacity: 0.75;
+  cursor: not-allowed;
 }
 
 .servicosTextarea {

--- a/src/app/(app)/demandas/criar/components/shared/period-fields.tsx
+++ b/src/app/(app)/demandas/criar/components/shared/period-fields.tsx
@@ -1,5 +1,6 @@
-import { FilterDateRangeField } from '@/app/(app)/demandas/components/filter-date-range-field'
-import { Input } from '@/components/ui/input'
+import type { SetStateAction } from 'react'
+
+import { DatePicker } from '@/components/ui/date-picker'
 import { Label } from '@/components/ui/label'
 
 import styles from '../../ticket-create/ticket-create-form.module.css'
@@ -12,6 +13,89 @@ type BaseProps = {
   disabled?: boolean
 }
 
+function stringToDateValue(value: string | null | undefined): Date | undefined {
+  if (!value?.trim()) return undefined
+  const date = new Date(value)
+  return Number.isNaN(date.getTime()) ? undefined : date
+}
+
+function datePickerValueToIso(
+  value: SetStateAction<Date | undefined>,
+  previousValue: string,
+): string {
+  const previousDate = stringToDateValue(previousValue)
+  const nextDate = typeof value === 'function' ? value(previousDate) : value
+  if (!nextDate || Number.isNaN(nextDate.getTime())) return ''
+  return nextDate.toISOString()
+}
+
+function SearchPeriodDateTimeFields({
+  startValue,
+  endValue,
+  onChangeStart,
+  onChangeEnd,
+  disabled = false,
+}: BaseProps) {
+  const startDate = stringToDateValue(startValue)
+  const endDate = stringToDateValue(endValue)
+
+  return (
+    <div className="w-full min-w-0 space-y-1.5">
+      <Label className={styles.fieldLabel}>Período da busca</Label>
+      <div className="grid w-full grid-cols-1 gap-3 md:grid-cols-2">
+        <DatePicker
+          type="datetime-local"
+          className={styles.servicePeriodDateTimeInput}
+          value={startDate}
+          onChange={(value) => {
+            const nextStart = datePickerValueToIso(value, startValue)
+            let nextEnd = endValue
+            if (
+              nextStart &&
+              nextEnd &&
+              new Date(nextEnd) < new Date(nextStart)
+            ) {
+              nextEnd = nextStart
+            }
+            onChangeStart(nextStart)
+            if (nextEnd !== endValue) onChangeEnd(nextEnd)
+          }}
+          toDate={endDate}
+          timePickerDisableFuture={false}
+          disabled={disabled}
+          placeholder="Início"
+          popoverContentClassName="z-[120]"
+          timePickerContentClassName="z-[140]"
+        />
+        <DatePicker
+          type="datetime-local"
+          className={styles.servicePeriodDateTimeInput}
+          value={endDate}
+          onChange={(value) => {
+            const nextEnd = datePickerValueToIso(value, endValue)
+            let nextStart = startValue
+            if (
+              nextStart &&
+              nextEnd &&
+              new Date(nextEnd) < new Date(nextStart)
+            ) {
+              nextStart = nextEnd
+            }
+            if (nextStart !== startValue) onChangeStart(nextStart)
+            onChangeEnd(nextEnd)
+          }}
+          fromDate={startDate}
+          timePickerDisableFuture={false}
+          disabled={disabled}
+          placeholder="Fim"
+          popoverContentClassName="z-[120]"
+          timePickerContentClassName="z-[140]"
+        />
+      </div>
+    </div>
+  )
+}
+
 export function PeriodFields({
   startValue,
   endValue,
@@ -20,25 +104,13 @@ export function PeriodFields({
   disabled = false,
 }: BaseProps) {
   return (
-    <div className="w-full min-w-0 space-y-1.5">
-      <Label className={styles.fieldLabel}>Período da busca</Label>
-      <div className="grid w-full grid-cols-1 gap-3 md:grid-cols-2">
-        <Input
-          className={`h-11 min-w-0 ${styles.inputBg}`}
-          type="datetime-local"
-          value={startValue}
-          onChange={(e) => onChangeStart(e.target.value)}
-          disabled={disabled}
-        />
-        <Input
-          className={`h-11 min-w-0 ${styles.inputBg}`}
-          type="datetime-local"
-          value={endValue}
-          onChange={(e) => onChangeEnd(e.target.value)}
-          disabled={disabled}
-        />
-      </div>
-    </div>
+    <SearchPeriodDateTimeFields
+      startValue={startValue}
+      endValue={endValue}
+      onChangeStart={onChangeStart}
+      onChangeEnd={onChangeEnd}
+      disabled={disabled}
+    />
   )
 }
 
@@ -50,16 +122,12 @@ export function PeriodFieldsCalendarStyle({
   disabled = false,
 }: BaseProps) {
   return (
-    <div className="w-full min-w-0 space-y-1.5">
-      <Label className={styles.fieldLabel}>Período da busca</Label>
-      <FilterDateRangeField
-        startValue={startValue}
-        endValue={endValue}
-        onChangeStart={onChangeStart}
-        onChangeEnd={onChangeEnd}
-        popoverContentClassName="z-[120] w-auto p-0"
-        disabled={disabled}
-      />
-    </div>
+    <SearchPeriodDateTimeFields
+      startValue={startValue}
+      endValue={endValue}
+      onChangeStart={onChangeStart}
+      onChangeEnd={onChangeEnd}
+      disabled={disabled}
+    />
   )
 }

--- a/src/app/(app)/demandas/criar/hooks/use-create-controller.ts
+++ b/src/app/(app)/demandas/criar/hooks/use-create-controller.ts
@@ -237,7 +237,7 @@ export function useTicketCreateController() {
         setFiles([])
         closeServiceModal()
       } else {
-        router.push('/chamados')
+        router.push('/demandas')
       }
     },
     onError: (error) => toast.error(getApiErrorMessage(error)),
@@ -271,7 +271,7 @@ export function useTicketCreateController() {
         setFiles([])
         closeServiceModal()
       } else {
-        router.push('/chamados')
+        router.push('/demandas')
       }
     },
     onError: (error) => toast.error(getApiErrorMessage(error)),

--- a/src/app/(app)/demandas/criar/ticket-create/ticket-create-form.module.css
+++ b/src/app/(app)/demandas/criar/ticket-create/ticket-create-form.module.css
@@ -126,6 +126,35 @@
   color: var(--tc-text-subtle);
 }
 
+.servicePeriodDateTimeInput {
+  min-height: 44px !important;
+  height: 44px;
+  padding: 0 16px !important;
+  border-radius: var(--tc-border-radius) !important;
+  border: 1px solid var(--tc-input-border) !important;
+  background-color: var(--tc-input-bg) !important;
+  color: var(--tc-text-subtle) !important;
+  font-family: inherit;
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.servicePeriodDateTimeInput:hover:not(:disabled) {
+  border-color: var(--tc-input-border-hover) !important;
+  background-color: var(--tc-input-bg) !important;
+}
+
+.servicePeriodDateTimeInput:focus-visible {
+  outline: 2px solid rgba(80, 114, 144, 0.45);
+  outline-offset: 0;
+  box-shadow: none;
+}
+
+.servicePeriodDateTimeInput:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 /* Data base – mesmo padrão dos outros inputs; input e calendário conectados quando aberto */
 .datePickerWrap {
   width: 100%;

--- a/src/app/(app)/demandas/workflow/page.tsx
+++ b/src/app/(app)/demandas/workflow/page.tsx
@@ -17,7 +17,17 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { useTicketScreenPermissionGate } from '@/hooks/useTicketScreenPermissionGate'
+import { getTicketTypes } from '@/http/ticket-types/get-ticket.types'
 import {
   getWorkflowRoleConfig,
   updateWorkflowRoleConfig,
@@ -29,6 +39,7 @@ import {
 } from '@/http/workflow/workflow-role-config'
 import { getApiErrorMessage } from '@/utils/error-handlers'
 
+import tcFormStyles from '../criar/ticket-create/ticket-create-form.module.css'
 import styles from './workflow-roles.module.css'
 
 const WORKFLOW_SCREEN_CODE = 'workflow'
@@ -57,10 +68,28 @@ function createTransition(): WorkflowTransition {
 }
 
 function WorkflowRolesPageContent() {
+  const [ticketTypeId, setTicketTypeId] = useState<string | null>(null)
   const [role, setRole] = useState<WorkflowRoleEnum>('Coordenador')
   const [permissions, setPermissions] = useState<WorkflowPermission[]>([])
   const [transitions, setTransitions] = useState<WorkflowTransition[]>([])
   const [confirmOpen, setConfirmOpen] = useState(false)
+
+  const ticketTypesQuery = useQuery({
+    queryKey: ['ticket-types', 'select', 'workflow'],
+    queryFn: () => getTicketTypes({ isActive: true }),
+  })
+
+  const ticketTypes = ticketTypesQuery.data?.data ?? []
+
+  useEffect(() => {
+    if (ticketTypes.length === 0) return
+    setTicketTypeId((current) => {
+      if (current && ticketTypes.some((t) => t.id === current)) {
+        return current
+      }
+      return ticketTypes[0]?.id ?? null
+    })
+  }, [ticketTypes])
 
   const {
     data,
@@ -70,8 +99,9 @@ function WorkflowRolesPageContent() {
     isFetching,
     refetch: refetchConfig,
   } = useQuery({
-    queryKey: ['workflow-role-config', role],
-    queryFn: () => getWorkflowRoleConfig(role),
+    queryKey: ['workflow-role-config', ticketTypeId, role],
+    queryFn: () => getWorkflowRoleConfig(ticketTypeId!, role),
+    enabled: Boolean(ticketTypeId),
   })
 
   useEffect(() => {
@@ -177,7 +207,13 @@ function WorkflowRolesPageContent() {
       return
     }
 
+    if (!ticketTypeId) {
+      toast.error('Selecione um tipo de demanda.')
+      return
+    }
+
     await saveMutation.mutateAsync({
+      ticket_type_id: ticketTypeId,
       role,
       permissions,
       transitions,
@@ -190,239 +226,398 @@ function WorkflowRolesPageContent() {
   }
 
   return (
-    <div className={`${styles.page} page-content flex flex-col px-6 py-6`}>
-      <div className={`content ${styles.content}`}>
-        <header className="flex flex-col gap-2">
-          <h1 className={styles.title}>Configuração de Workflow por Role</h1>
-          <p className={styles.subtitle}>
-            Defina permissões por estado e transições permitidas para o role
-            selecionado.
-          </p>
-        </header>
-
-        <section className={styles.card}>
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div className="w-full max-w-xs">
-              <label className="mb-2 block text-xs uppercase text-[var(--workflow-text-subtle)]">
-                Role
-              </label>
-              <select
-                className={styles.select}
-                value={role}
-                onChange={(event) =>
-                  setRole(event.target.value as WorkflowRoleEnum)
-                }
-                disabled={isLoading || saveMutation.isPending}
+    <div
+      className="page-content space-y-4 overflow-y-scroll pb-24"
+      style={{ backgroundColor: '#0c161f' }}
+    >
+      <div className="content">
+        <div className={tcFormStyles.root}>
+          <div className="w-full space-y-8">
+            <header className="w-full space-y-2">
+              <h1
+                className="font-semibold leading-10 text-[var(--tc-heading,#f9fafa)]"
+                style={{ fontSize: '20px' }}
               >
-                {ROLE_OPTIONS.map((roleOption) => (
-                  <option key={roleOption} value={roleOption}>
-                    {roleOption}
-                  </option>
-                ))}
-              </select>
-            </div>
+                Configuração de Workflow por Role
+              </h1>
+              <p className="mt-0 text-[length:12px] leading-4 text-[var(--tc-muted,#97a2ab)]">
+                Defina permissões por estado e transições para o tipo de demanda
+                e role selecionados. A API mescla com a configuração global
+                quando não houver linhas específicas daquele tipo.
+              </p>
+            </header>
 
-            <div className="flex items-center gap-2 self-end">
-              <button
-                type="button"
-                className={`${styles.button} ${styles.buttonSecondary} flex items-center gap-2`}
-                onClick={handleReload}
-                disabled={isFetching || saveMutation.isPending}
-              >
-                <RefreshCw className="size-4" />
-                Recarregar
-              </button>
-              <button
-                type="button"
-                className={`${styles.button} flex items-center gap-2`}
-                onClick={() => setConfirmOpen(true)}
-                disabled={isLoading || saveMutation.isPending}
-              >
-                {saveMutation.isPending ? <Spinner /> : 'Salvar alterações'}
-              </button>
-            </div>
-          </div>
-        </section>
-
-        <section className={styles.card}>
-          <h2 className={styles.sectionTitle}>Permissões por estado</h2>
-
-          {isLoading ? (
-            <div className="flex h-24 items-center justify-center">
-              <Spinner />
-            </div>
-          ) : (
-            <table className={styles.table}>
-              <thead>
-                <tr>
-                  <th>Estado</th>
-                  <th>Ações permitidas</th>
-                </tr>
-              </thead>
-              <tbody>
-                {permissions.map((permission, index) => (
-                  <tr key={permission.state_code}>
-                    <td>{permission.state_code}</td>
-                    <td className="min-w-[320px]">
-                      <MultiSelectWithSearch
-                        options={actionOptions}
-                        onValueChange={(values) =>
-                          updatePermission(index, {
-                            ...permission,
-                            allowed_action_codes: values,
-                          })
-                        }
-                        defaultValue={permission.allowed_action_codes}
-                        placeholder="Selecione ações"
-                        className="min-h-9 bg-transparent text-white"
-                      />
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
-        </section>
-
-        <section className={styles.card}>
-          <div className="mb-3 flex items-center justify-between gap-3">
-            <h2 className={styles.sectionTitle}>Transições</h2>
-            <button
-              type="button"
-              className={`${styles.button} flex items-center gap-2`}
-              onClick={() =>
-                setTransitions((current) => [...current, createTransition()])
-              }
-              disabled={saveMutation.isPending}
+            <div
+              className={`${tcFormStyles.sectionCard} ${tcFormStyles.sectionCardFirst}`}
             >
-              <Plus className="size-4" />
-              Adicionar transição
-            </button>
-          </div>
+              <div className="flex flex-col gap-4 lg:flex-row lg:flex-wrap lg:items-end lg:justify-between">
+                <div className="grid w-full max-w-2xl grid-cols-1 gap-4 md:grid-cols-2">
+                  <div className="space-y-1.5">
+                    <Label className={tcFormStyles.fieldLabel}>
+                      Tipo de demanda
+                    </Label>
+                    <Select
+                      value={ticketTypeId ?? ''}
+                      onValueChange={(value) => setTicketTypeId(value || null)}
+                      disabled={
+                        ticketTypesQuery.isLoading ||
+                        saveMutation.isPending ||
+                        ticketTypes.length === 0
+                      }
+                    >
+                      <SelectTrigger
+                        className={`h-11 w-full ${tcFormStyles.inputBg}`}
+                      >
+                        <SelectValue
+                          placeholder={
+                            ticketTypesQuery.isLoading
+                              ? 'Carregando…'
+                              : ticketTypes.length === 0
+                                ? 'Nenhum tipo disponível'
+                                : 'Selecione'
+                          }
+                        />
+                      </SelectTrigger>
+                      <SelectContent className={tcFormStyles.selectContentForm}>
+                        {ticketTypes.map((type) => (
+                          <SelectItem
+                            key={type.id}
+                            value={type.id}
+                            className={tcFormStyles.selectItemForm}
+                          >
+                            {type.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
 
-          <table className={styles.table}>
-            <thead>
-              <tr>
-                <th>From</th>
-                <th>Action</th>
-                <th>To</th>
-                <th>Perfis destino</th>
-                <th />
-              </tr>
-            </thead>
-            <tbody>
-              {transitions.length === 0 && (
-                <tr>
-                  <td
-                    colSpan={5}
-                    className="text-center text-[var(--workflow-text-subtle)]"
+                  <div className="space-y-1.5">
+                    <Label className={tcFormStyles.fieldLabel}>Role</Label>
+                    <Select
+                      value={role}
+                      onValueChange={(value) =>
+                        setRole(value as WorkflowRoleEnum)
+                      }
+                      disabled={
+                        !ticketTypeId || isLoading || saveMutation.isPending
+                      }
+                    >
+                      <SelectTrigger
+                        className={`h-11 w-full ${tcFormStyles.inputBg}`}
+                      >
+                        <SelectValue placeholder="Selecione" />
+                      </SelectTrigger>
+                      <SelectContent className={tcFormStyles.selectContentForm}>
+                        {ROLE_OPTIONS.map((roleOption) => (
+                          <SelectItem
+                            key={roleOption}
+                            value={roleOption}
+                            className={tcFormStyles.selectItemForm}
+                          >
+                            {roleOption}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    className={`${tcFormStyles.cancelButton} !min-w-0 gap-2`}
+                    onClick={handleReload}
+                    disabled={
+                      !ticketTypeId ||
+                      isFetching ||
+                      saveMutation.isPending ||
+                      ticketTypesQuery.isLoading
+                    }
                   >
-                    Nenhuma transição cadastrada.
-                  </td>
-                </tr>
+                    <RefreshCw className="size-4" />
+                    Recarregar
+                  </Button>
+                  <Button
+                    type="button"
+                    className={`${tcFormStyles.saveButton} gap-2`}
+                    onClick={() => setConfirmOpen(true)}
+                    disabled={
+                      !ticketTypeId ||
+                      isLoading ||
+                      saveMutation.isPending ||
+                      ticketTypesQuery.isLoading
+                    }
+                  >
+                    {saveMutation.isPending ? <Spinner /> : 'Salvar alterações'}
+                  </Button>
+                </div>
+              </div>
+            </div>
+
+            <div
+              className={`${tcFormStyles.sectionCard} ${tcFormStyles.sectionCardFirst}`}
+            >
+              <h2 className={styles.sectionTitle}>Permissões por estado</h2>
+
+              {ticketTypesQuery.isError && (
+                <p className={`mb-3 ${styles.errorText}`}>
+                  {getApiErrorMessage(ticketTypesQuery.error)}
+                </p>
               )}
 
-              {transitions.map((transition, index) => (
-                <tr
-                  key={`${transition.from_state_code}-${transition.action_code}-${index}`}
+              {isLoading ? (
+                <div className="flex h-24 items-center justify-center">
+                  <Spinner />
+                </div>
+              ) : (
+                <table className={styles.table}>
+                  <thead>
+                    <tr>
+                      <th>Estado</th>
+                      <th>Ações permitidas</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {permissions.map((permission, index) => (
+                      <tr key={permission.state_code}>
+                        <td>{permission.state_code}</td>
+                        <td className="min-w-[320px]">
+                          <MultiSelectWithSearch
+                            options={actionOptions}
+                            onValueChange={(values) =>
+                              updatePermission(index, {
+                                ...permission,
+                                allowed_action_codes: values,
+                              })
+                            }
+                            defaultValue={permission.allowed_action_codes}
+                            placeholder="Selecione ações"
+                            className="min-h-9 bg-transparent text-white"
+                          />
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              )}
+            </div>
+
+            <div
+              className={`${tcFormStyles.sectionCard} ${tcFormStyles.sectionCardFirst}`}
+            >
+              <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+                <h2 className={styles.sectionTitle}>Transições</h2>
+                <Button
+                  type="button"
+                  className={`${tcFormStyles.saveButton} gap-2`}
+                  onClick={() =>
+                    setTransitions((current) => [
+                      ...current,
+                      createTransition(),
+                    ])
+                  }
+                  disabled={saveMutation.isPending}
                 >
-                  <td className="min-w-[170px]">
-                    <select
-                      className={styles.select}
-                      value={transition.from_state_code}
-                      onChange={(event) =>
-                        updateTransition(index, {
-                          ...transition,
-                          from_state_code: event.target.value,
-                        })
-                      }
-                      disabled={saveMutation.isPending}
-                    >
-                      <option value="">Selecione</option>
-                      {(data?.states ?? []).map((state) => (
-                        <option key={state.code} value={state.code}>
-                          {state.label ?? state.code}
-                        </option>
-                      ))}
-                    </select>
-                  </td>
+                  <Plus className="size-4" />
+                  Adicionar transição
+                </Button>
+              </div>
 
-                  <td className="min-w-[170px]">
-                    <select
-                      className={styles.select}
-                      value={transition.action_code}
-                      onChange={(event) =>
-                        updateTransition(index, {
-                          ...transition,
-                          action_code: event.target.value,
-                        })
-                      }
-                      disabled={saveMutation.isPending}
-                    >
-                      <option value="">Selecione</option>
-                      {(data?.actions ?? []).map((action) => (
-                        <option key={action.code} value={action.code}>
-                          {action.label ?? action.code}
-                        </option>
-                      ))}
-                    </select>
-                  </td>
+              <table className={styles.table}>
+                <thead>
+                  <tr>
+                    <th>From</th>
+                    <th>Action</th>
+                    <th>To</th>
+                    <th>Perfis destino</th>
+                    <th />
+                  </tr>
+                </thead>
+                <tbody>
+                  {transitions.length === 0 && (
+                    <tr>
+                      <td
+                        colSpan={5}
+                        className="text-center text-[var(--tc-muted,#97a2ab)]"
+                      >
+                        Nenhuma transição cadastrada.
+                      </td>
+                    </tr>
+                  )}
 
-                  <td className="min-w-[170px]">
-                    <select
-                      className={styles.select}
-                      value={transition.to_state_code}
-                      onChange={(event) =>
-                        updateTransition(index, {
-                          ...transition,
-                          to_state_code: event.target.value,
-                        })
-                      }
-                      disabled={saveMutation.isPending}
+                  {transitions.map((transition, index) => (
+                    <tr
+                      key={`${transition.from_state_code}-${transition.action_code}-${index}`}
                     >
-                      <option value="">Selecione</option>
-                      {(data?.states ?? []).map((state) => (
-                        <option key={state.code} value={state.code}>
-                          {state.label ?? state.code}
-                        </option>
-                      ))}
-                    </select>
-                  </td>
+                      <td className="min-w-[170px]">
+                        <Select
+                          value={
+                            transition.from_state_code
+                              ? transition.from_state_code
+                              : '__none__'
+                          }
+                          onValueChange={(value) =>
+                            updateTransition(index, {
+                              ...transition,
+                              from_state_code:
+                                value === '__none__' ? '' : value,
+                            })
+                          }
+                          disabled={saveMutation.isPending}
+                        >
+                          <SelectTrigger
+                            className={`h-11 w-full ${tcFormStyles.inputBg} ${styles.transitionSelectTrigger}`}
+                          >
+                            <SelectValue placeholder="Selecione" />
+                          </SelectTrigger>
+                          <SelectContent
+                            className={tcFormStyles.selectContentForm}
+                          >
+                            <SelectItem
+                              value="__none__"
+                              className={tcFormStyles.selectItemForm}
+                            >
+                              Selecione
+                            </SelectItem>
+                            {(data?.states ?? []).map((state) => (
+                              <SelectItem
+                                key={state.code}
+                                value={state.code}
+                                className={tcFormStyles.selectItemForm}
+                              >
+                                {state.label ?? state.code}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </td>
 
-                  <td className="min-w-[320px]">
-                    <MultiSelectWithSearch
-                      options={profileOptions}
-                      onValueChange={(values) =>
-                        updateTransition(index, {
-                          ...transition,
-                          target_profile_codes: values,
-                        })
-                      }
-                      defaultValue={transition.target_profile_codes}
-                      placeholder="Selecione perfis"
-                      className="min-h-9 bg-transparent text-white"
-                    />
-                  </td>
+                      <td className="min-w-[170px]">
+                        <Select
+                          value={
+                            transition.action_code
+                              ? transition.action_code
+                              : '__none__'
+                          }
+                          onValueChange={(value) =>
+                            updateTransition(index, {
+                              ...transition,
+                              action_code: value === '__none__' ? '' : value,
+                            })
+                          }
+                          disabled={saveMutation.isPending}
+                        >
+                          <SelectTrigger
+                            className={`h-11 w-full ${tcFormStyles.inputBg} ${styles.transitionSelectTrigger}`}
+                          >
+                            <SelectValue placeholder="Selecione" />
+                          </SelectTrigger>
+                          <SelectContent
+                            className={tcFormStyles.selectContentForm}
+                          >
+                            <SelectItem
+                              value="__none__"
+                              className={tcFormStyles.selectItemForm}
+                            >
+                              Selecione
+                            </SelectItem>
+                            {(data?.actions ?? []).map((action) => (
+                              <SelectItem
+                                key={action.code}
+                                value={action.code}
+                                className={tcFormStyles.selectItemForm}
+                              >
+                                {action.label ?? action.code}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </td>
 
-                  <td>
-                    <button
-                      type="button"
-                      className={`${styles.button} ${styles.buttonSecondary}`}
-                      onClick={() => removeTransition(index)}
-                      disabled={saveMutation.isPending}
-                      aria-label="Remover transição"
-                    >
-                      <Trash2 className="size-4" />
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-          {validationMessage && (
-            <p className={`mt-3 ${styles.errorText}`}>{validationMessage}</p>
-          )}
-        </section>
+                      <td className="min-w-[170px]">
+                        <Select
+                          value={
+                            transition.to_state_code
+                              ? transition.to_state_code
+                              : '__none__'
+                          }
+                          onValueChange={(value) =>
+                            updateTransition(index, {
+                              ...transition,
+                              to_state_code: value === '__none__' ? '' : value,
+                            })
+                          }
+                          disabled={saveMutation.isPending}
+                        >
+                          <SelectTrigger
+                            className={`h-11 w-full ${tcFormStyles.inputBg} ${styles.transitionSelectTrigger}`}
+                          >
+                            <SelectValue placeholder="Selecione" />
+                          </SelectTrigger>
+                          <SelectContent
+                            className={tcFormStyles.selectContentForm}
+                          >
+                            <SelectItem
+                              value="__none__"
+                              className={tcFormStyles.selectItemForm}
+                            >
+                              Selecione
+                            </SelectItem>
+                            {(data?.states ?? []).map((state) => (
+                              <SelectItem
+                                key={state.code}
+                                value={state.code}
+                                className={tcFormStyles.selectItemForm}
+                              >
+                                {state.label ?? state.code}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </td>
+
+                      <td className="min-w-[320px]">
+                        <MultiSelectWithSearch
+                          options={profileOptions}
+                          onValueChange={(values) =>
+                            updateTransition(index, {
+                              ...transition,
+                              target_profile_codes: values,
+                            })
+                          }
+                          defaultValue={transition.target_profile_codes}
+                          placeholder="Selecione perfis"
+                          className="min-h-9 bg-transparent text-white"
+                        />
+                      </td>
+
+                      <td>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="h-11 w-11 shrink-0 text-[var(--tc-icon-subtle,#97a2ab)] hover:bg-[var(--tc-soft,#18344d)] hover:text-[var(--tc-text,#f9fafa)]"
+                          onClick={() => removeTransition(index)}
+                          disabled={saveMutation.isPending}
+                          aria-label="Remover transição"
+                        >
+                          <Trash2 className="size-4" />
+                        </Button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {validationMessage && (
+                <p className={`mt-3 ${styles.errorText}`}>
+                  {validationMessage}
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
       </div>
 
       <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
@@ -430,7 +625,8 @@ function WorkflowRolesPageContent() {
           <AlertDialogHeader>
             <AlertDialogTitle>Salvar alterações?</AlertDialogTitle>
             <AlertDialogDescription>
-              As regras de workflow do role {role} serão atualizadas.
+              As regras específicas do tipo selecionado e do role {role} serão
+              gravadas (a configuração global não é alterada).
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
@@ -452,7 +648,8 @@ export default function WorkflowRolesPage() {
   if (!resolved || !allowed) {
     return (
       <div
-        className={`${styles.page} flex min-h-screen flex-col items-center justify-center px-6 py-6`}
+        className="page-content flex min-h-screen flex-col items-center justify-center pb-24"
+        style={{ backgroundColor: '#0c161f' }}
       >
         <Spinner />
       </div>

--- a/src/app/(app)/demandas/workflow/workflow-roles.module.css
+++ b/src/app/(app)/demandas/workflow/workflow-roles.module.css
@@ -1,44 +1,14 @@
-.page {
-  --workflow-bg-page: #0c161f;
-  --workflow-bg-section: #101d28;
-  --workflow-bg-button: #1d3449;
-  --workflow-border: #4a5d6d;
-  --workflow-text-default: #f9fafa;
-  --workflow-text-subtle: #97a2ab;
-  background-color: var(--workflow-bg-page);
-  min-height: 100vh;
-  max-height: 100dvh;
-  overflow-y: auto;
+/* Radix SelectTrigger é um <button>; no estilo padrão do UA o texto costuma herdar alinhamento centralizado */
+.transitionSelectTrigger {
+  text-align: left;
 }
 
-.content {
-  display: flex;
-  flex-direction: column;
-  gap: 20px;
-}
-
-.title {
-  color: var(--workflow-text-default);
-  font-size: 20px;
-  font-weight: 600;
-  margin: 0;
-}
-
-.subtitle {
-  color: var(--workflow-text-subtle);
-  font-size: 12px;
-  margin-top: 4px;
-}
-
-.card {
-  border: 1px solid var(--workflow-border);
-  background: var(--workflow-bg-section);
-  border-radius: 8px;
-  padding: 16px;
+.transitionSelectTrigger span {
+  text-align: left;
 }
 
 .sectionTitle {
-  color: var(--workflow-text-default);
+  color: var(--tc-text, #f9fafa);
   font-size: 16px;
   font-weight: 600;
   margin-bottom: 12px;
@@ -51,50 +21,21 @@
 
 .table th,
 .table td {
-  border-bottom: 1px solid var(--workflow-border);
+  border-bottom: 1px solid var(--tc-card-border, #4a5d6d);
   padding: 8px;
   text-align: left;
   vertical-align: middle;
 }
 
 .table th {
-  color: var(--workflow-text-subtle);
+  color: var(--tc-muted, #97a2ab);
   font-size: 12px;
   text-transform: uppercase;
 }
 
 .table td {
-  color: var(--workflow-text-default);
+  color: var(--tc-text, #f9fafa);
   font-size: 13px;
-}
-
-.select,
-.input {
-  width: 100%;
-  height: 38px;
-  border-radius: 8px;
-  border: 1px solid var(--workflow-border);
-  background: #0d1822;
-  color: var(--workflow-text-default);
-  padding: 0 10px;
-}
-
-.button {
-  border: 1px solid var(--workflow-border);
-  background: var(--workflow-bg-button);
-  color: var(--workflow-text-default);
-  border-radius: 8px;
-  padding: 8px 14px;
-  font-size: 13px;
-  font-weight: 600;
-}
-
-.button:disabled {
-  opacity: 0.6;
-}
-
-.buttonSecondary {
-  background: transparent;
 }
 
 .errorText {

--- a/src/components/custom/time-picker.tsx
+++ b/src/components/custom/time-picker.tsx
@@ -1,5 +1,7 @@
 import { Clock } from 'lucide-react'
 
+import { cn } from '@/lib/utils'
+
 import {
   Select,
   SelectContent,
@@ -21,6 +23,7 @@ interface TimePickerProps {
   onChange: (date: Date) => void
   disableFuture?: boolean
   disabled?: boolean
+  selectContentClassName?: string
 }
 
 export function TimePicker({
@@ -29,6 +32,7 @@ export function TimePicker({
   onChange,
   disabled = false,
   disableFuture = false,
+  selectContentClassName,
 }: TimePickerProps) {
   const today = new Date()
   const todayAtMidnight = new Date()
@@ -71,7 +75,9 @@ export function TimePicker({
           <SelectTrigger className="h-9 w-16">
             <SelectValue placeholder="--" />
           </SelectTrigger>
-          <SelectContent className="h-72 w-16 min-w-0">
+          <SelectContent
+            className={cn('h-72 w-16 min-w-0', selectContentClassName)}
+          >
             {hours.map((item, index) => (
               <SelectItem
                 key={index}
@@ -103,7 +109,7 @@ export function TimePicker({
           <SelectTrigger className="h-9 w-16">
             <SelectValue placeholder="--" />
           </SelectTrigger>
-          <SelectContent className="w-16 min-w-0">
+          <SelectContent className={cn('w-16 min-w-0', selectContentClassName)}>
             {minutes.map((item, index) => (
               <SelectItem
                 key={index}

--- a/src/components/ui/date-picker.tsx
+++ b/src/components/ui/date-picker.tsx
@@ -28,6 +28,8 @@ interface DatePickerProps {
   timePickerDisableFuture?: boolean
   disabled?: boolean
   placeholder?: string
+  popoverContentClassName?: string
+  timePickerContentClassName?: string
 }
 
 export function DatePicker({
@@ -40,11 +42,14 @@ export function DatePicker({
   timePickerDisableFuture = true,
   disabled = false,
   placeholder = 'Escolha uma data', // Default placeholder
+  popoverContentClassName,
+  timePickerContentClassName,
 }: DatePickerProps) {
   return (
     <Popover modal={false}>
       <PopoverTrigger asChild>
         <Button
+          type="button"
           variant={'outline'}
           className={cn(
             'w-full justify-start text-left font-normal',
@@ -61,7 +66,7 @@ export function DatePicker({
           )}
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-auto p-0">
+      <PopoverContent className={cn('w-auto p-0', popoverContentClassName)}>
         <Calendar
           mode="single"
           selected={value}
@@ -102,6 +107,7 @@ export function DatePicker({
                 defaultValue={value}
                 onChange={onChange}
                 disabled={!value}
+                selectContentClassName={timePickerContentClassName}
               />
             </div>
           </>

--- a/src/http/standardized-responses/standardized-responses.ts
+++ b/src/http/standardized-responses/standardized-responses.ts
@@ -2,6 +2,7 @@ import { api } from '@/lib/api'
 
 export type StandardizedResponseCategory =
   | 'RECEBIMENTO_SOLICITACOES'
+  | 'RESPOSTAS_POSITIVAS'
   | 'RELATORIOS_PLACAS_RADARES'
   | 'INSERCAO_PLACAS_CERCO'
   | 'SOLICITACAO_IMAGENS'

--- a/src/http/workflow/workflow-role-config.ts
+++ b/src/http/workflow/workflow-role-config.ts
@@ -21,6 +21,8 @@ export interface WorkflowTransition {
 }
 
 export interface WorkflowRoleConfigResponse {
+  ticket_type_id?: string | null
+  ticket_type_name?: string | null
   states: WorkflowCatalogItem[]
   actions: WorkflowCatalogItem[]
   profiles: WorkflowCatalogItem[]
@@ -29,25 +31,30 @@ export interface WorkflowRoleConfigResponse {
 }
 
 export interface UpdateWorkflowRoleConfigRequest {
+  ticket_type_id: string
   role: WorkflowRoleEnum
   permissions: WorkflowPermission[]
   transitions: WorkflowTransition[]
 }
 
-export async function getWorkflowRoleConfig(role: WorkflowRoleEnum) {
+export async function getWorkflowRoleConfig(
+  ticketTypeId: string,
+  role: WorkflowRoleEnum,
+) {
   const { data } = await api.get<WorkflowRoleConfigResponse>(
-    `/workflow/roles/${encodeURIComponent(role)}`,
+    `/workflow/ticket-types/${encodeURIComponent(ticketTypeId)}/roles/${encodeURIComponent(role)}`,
   )
   return data
 }
 
 export async function updateWorkflowRoleConfig({
+  ticket_type_id: ticketTypeId,
   role,
   permissions,
   transitions,
 }: UpdateWorkflowRoleConfigRequest) {
   const { data } = await api.put<WorkflowRoleConfigResponse>(
-    `/workflow/roles/${encodeURIComponent(role)}`,
+    `/workflow/ticket-types/${encodeURIComponent(ticketTypeId)}/roles/${encodeURIComponent(role)}`,
     {
       permissions,
       transitions,


### PR DESCRIPTION
## Description

This branch (`feat/view-ticket`) introduces a large set of changes compared to `staging`, focused on the **Demands** module (migration from **Chamados**), a full **ticket detail** experience (tabs, services, attachments, internal notes, demand report, reply, workflow), **archived demands**, **impersonation** scoped to `/demandas`, **ticket module / screen permissions** (sidebar, gates, permissions UI, workflow roles), and **teams/profiles** updates (including the **Assessor** role). It also includes **map / LPR / SENTRY** UI and contract updates (equipment wording, layers, icons, plate search), **standardized responses** query improvements, many new or extended **HTTP clients** under `src/http`, and **Docker / Cloud Build / pnpm** housekeeping.

## Related Issue

<!-- Add issue link if applicable -->

## Motivation and Context

Deliver end-to-end demand management (inbox, conversion, creation, rich detail, archive), align permissions and impersonation with product rules, and keep map and reporting flows consistent with the current backend contract (LPR, SENTRY, collection points / equipment naming).

## How has this been tested?

- Existing automated tests were updated across map, reports, layer toggles, and search flows (see diff).
- A full local CI run was not executed in this review; run `pnpm lint` / `pnpm test` (or your pipeline) before merge.

## Screenshots (if appropriate)

<!-- Add screenshots for ticket detail, archived list, impersonation bar, map layers, permissions screens -->

## Types of changes

- [x] fix
- [x] feat
- [ ] perf
- [x] test
- [x] refactor
- [ ] style
- [x] chore
- [ ] docs
- [x] build
- [ ] ci
- [ ] revert

## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.