### PR TITLE
feat: enhance team form dialog success messages with dynamic team nam…

### DIFF
--- a/src/app/(app)/demandas/equipes/components/team-form-dialog.tsx
+++ b/src/app/(app)/demandas/equipes/components/team-form-dialog.tsx
@@ -78,10 +78,16 @@ export function TeamFormDialog({
   const { mutateAsync: createTeamMutation, isPending: isPendingCreate } =
     useMutation({
       mutationFn: createTeam,
-      onSuccess: ({ data }) => {
+      onSuccess: (response, variables) => {
         queryClient.invalidateQueries({ queryKey: ['teams'] })
         queryClient.invalidateQueries({ queryKey: ['islands'] })
-        toast.success(`Equipe ${data.name} criada com sucesso.`)
+        const teamName =
+          variables.name?.trim() || response.data.name?.trim() || ''
+        toast.success(
+          teamName
+            ? `Equipe ${teamName} criada com sucesso.`
+            : 'Equipe criada com sucesso.',
+        )
       },
       onError: (error) => {
         toast.error(getApiErrorMessage(error))
@@ -91,10 +97,16 @@ export function TeamFormDialog({
   const { mutateAsync: updateTeamMutation, isPending: isPendingUpdate } =
     useMutation({
       mutationFn: updateTeam,
-      onSuccess: ({ data }) => {
+      onSuccess: (response, variables) => {
         queryClient.invalidateQueries({ queryKey: ['teams'] })
         queryClient.invalidateQueries({ queryKey: ['islands'] })
-        toast.success(`Equipe ${data.name} atualizada com sucesso.`)
+        const teamName =
+          variables.name?.trim() || response.data.name?.trim() || ''
+        toast.success(
+          teamName
+            ? `Equipe ${teamName} atualizada com sucesso.`
+            : 'Equipe atualizada com sucesso.',
+        )
       },
       onError: (error) => {
         toast.error(getApiErrorMessage(error))

--- a/src/app/(app)/demandas/permissoes-telas/page.tsx
+++ b/src/app/(app)/demandas/permissoes-telas/page.tsx
@@ -7,6 +7,14 @@ import { toast } from 'sonner'
 
 import { MultiSelectWithSearch } from '@/components/custom/multi-select-with-search'
 import { Spinner } from '@/components/custom/spinner'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
 import { useTicketScreenPermissionGate } from '@/hooks/useTicketScreenPermissionGate'
 import {
@@ -18,6 +26,7 @@ import {
 import type { UserRoleEnum } from '@/http/user-roles/get-users-with-roles'
 import { getApiErrorMessage } from '@/utils/error-handlers'
 
+import tcFormStyles from '../criar/ticket-create/ticket-create-form.module.css'
 import styles from './permissoes-por-role.module.css'
 
 const SCREEN_PERMISSIONS_SCREEN_CODE = 'screen_permissions'
@@ -130,7 +139,7 @@ function TicketModulePermissionsByRolePageContent() {
 
   return (
     <div className={`${styles.page} page-content flex flex-col px-6 py-6`}>
-      <div className={`content ${styles.content}`}>
+      <div className={`${tcFormStyles.root} content ${styles.content}`}>
         <header className="flex flex-col gap-2">
           <h1 className={styles.title}>Permissões de Tela por Role</h1>
           <p className={styles.subtitle}>
@@ -140,24 +149,30 @@ function TicketModulePermissionsByRolePageContent() {
 
         <section className={styles.card}>
           <div className="flex flex-wrap items-center justify-between gap-3">
-            <div className="w-full max-w-xs">
-              <label className="mb-2 block text-xs uppercase text-[var(--perm-text-subtle)]">
-                Role
-              </label>
-              <select
-                className={styles.select}
+            <div className="w-full max-w-xs space-y-1.5">
+              <Label className={tcFormStyles.fieldLabel}>Role</Label>
+              <Select
                 value={role}
-                onChange={(event) =>
-                  setRole(event.target.value as UserRoleEnum)
-                }
+                onValueChange={(value) => setRole(value as UserRoleEnum)}
                 disabled={isLoading || saveMutation.isPending}
               >
-                {ROLE_OPTIONS.map((roleOption) => (
-                  <option key={roleOption} value={roleOption}>
-                    {roleOption}
-                  </option>
-                ))}
-              </select>
+                <SelectTrigger
+                  className={`h-11 w-full ${tcFormStyles.inputBg}`}
+                >
+                  <SelectValue placeholder="Selecione" />
+                </SelectTrigger>
+                <SelectContent className={tcFormStyles.selectContentForm}>
+                  {ROLE_OPTIONS.map((roleOption) => (
+                    <SelectItem
+                      key={roleOption}
+                      value={roleOption}
+                      className={tcFormStyles.selectItemForm}
+                    >
+                      {roleOption}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
 
             <div className="flex items-center gap-2 self-end">

--- a/src/app/(app)/demandas/permissoes-telas/permissoes-por-role.module.css
+++ b/src/app/(app)/demandas/permissoes-telas/permissoes-por-role.module.css
@@ -68,16 +68,6 @@
   font-size: 13px;
 }
 
-.select {
-  width: 100%;
-  height: 38px;
-  border-radius: 8px;
-  border: 1px solid var(--perm-border);
-  background: #0d1822;
-  color: var(--perm-text-default);
-  padding: 0 10px;
-}
-
 .button {
   border: 1px solid var(--perm-border);
   background: var(--perm-bg-button);

--- a/src/app/(app)/demandas/workflow/page.tsx
+++ b/src/app/(app)/demandas/workflow/page.tsx
@@ -56,6 +56,7 @@ const ROLE_OPTIONS: WorkflowRoleEnum[] = [
 /** Perfis destino garantidos no seletor além do catálogo da API. */
 const WORKFLOW_TARGET_PROFILE_FALLBACKS: WorkflowCatalogItem[] = [
   { code: 'EXECUTOR_DA_ACAO', label: 'Executor da ação' },
+  { code: 'MANTER_ATUAL', label: 'Manter Atual' },
 ]
 
 function createTransition(): WorkflowTransition {


### PR DESCRIPTION
## Description

This branch bundles a large set of changes around **tickets**, **workflow scoped by ticket type**, **dossier PDF**, **response report with service attachments**, **completion timestamps**, **email** flows, and **database migrations**.

Main areas:

- **Workflow:** permissions and transitions now respect `ticket_type_id` (with global fallback where applicable). Workflow config endpoints by ticket type + role; transitions support **multiple destination profiles** (`target_profile_codes`); support for **Executor of the action** and the new **Keep current** destination (`MANTER_ATUAL`), which preserves current assignees when resolving targets. Removal of obsolete workflow actions/states (seed/cleanup migration).
- **Tickets:** **completion date** surfaced across DTOs/listings/archive; `completed_at` logic aligned with archived/finalized/blocked states; dashboard/archive filters by **`responsavel_id`**; service index DTO (`TicketServicoIndiceOut`) and related flows in `ticket_service`.
- **PDF:** legacy flow (`ticket_pdf_report` / `ticket_full_report.html`) replaced by **`ticket_dossier_pdf`** and **`document.html`** template; new logo assets.
- **Response report:** **service attachment** links on the response (DTOs `anexos_servico` / `anexos_servico_ids`); integration with standardized workflow email sending.
- **Attachments:** increased max upload size for video attachments (`MAX_TICKET_VIDEO_ATTACHMENT_BYTES`).
- **Model/DTOs:** removal of **`orgao_procedimento_id`** from ticket create/ficha/list outputs.
- **Teams:** migration drops `UNIQUE` on `teams.name` and seeds the **`MANTER_ATUAL`** / **Manter Atual** workflow profile (combined into migration `37`).
- **Emails:** user dependency alignment (`resolve_subject_user`) and respondidos listing service; related router/service updates.
- **Infra:** minor Gmail client and entity updates as in the diff.

Rough diff vs `staging`: **~27 files**, **+3393 / -859** lines (includes binaries and large HTML template).

## Related Issue

<!-- Add issue link if applicable -->

## Motivation and Context

Improve **ticket view/dossier**, **workflow configuration per ticket type**, **completion and archive behaviour**, **response + attachments for email**, and **consistent auth dependencies** on email endpoints, while dropping obsolete fields (`orgao_procedimento`) and allowing non-globally-unique team names.

## How has this been tested?

No new or updated automated tests are evident in the diff for this scope. Recommended manual checks: `aerich upgrade`, **workflow** flows (GET/PUT by type and role, actions with destinations including `MANTER_ATUAL` / `EXECUTOR_DA_ACAO`), **ticket create/update**, **dossier PDF**, **response report + attachments**, **responsible filters**, and **email endpoints**.

## Screenshots (if appropriate):

<!-- N/A or attach PDF/UI screenshots -->

## Types of changes

- [x] fix: used when there is correction of errors that are generating bugs in the system.
- [x] feat: indicates the development of a new feature for the project.
- [ ] perf: indicates a change that improved system performance.
- [ ] test: indicates any type of creation or change of test codes.
- [x] refactor: used when there is a code refactoring that does not have any type of impact on the system's business logic/rules.
- [ ] style: used when there are formatting and code style changes that do not alter the system in any way.
- [ ] chore: indicates changes to the project that do not affect the system or test files.
- [ ] docs: used when there are changes to the project documentation.
- [ ] build: used to indicate changes that affect the project's build process or external dependencies.
- [ ] ci: used for changes to CI configuration files.
- [ ] revert: indicates the revert of a previous commit

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.