### PR TITLE
feat: enhance ticket detail components with video upload progress UI,…

### DIFF
--- a/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-servicos.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-servicos.tsx
@@ -47,6 +47,8 @@ import {
 import { TicketServicoAnexos } from './ticket-servico-anexos'
 import { ServicosExpandedForm } from './ticket-servicos-expanded-form'
 
+const SERVICOS_SAVE_VIDEO_TOAST_ID = 'servicos-save-video-upload'
+
 const SERVICE_KINDS = [
   'busca_por_placa',
   'busca_por_radar',
@@ -271,11 +273,13 @@ export function TicketDetailTabServicos({ ticketId }: Props) {
 
           for (let index = 0; index < preRows.length; index++) {
             const preRow = preRows[index]
-            if (!preRow?.id || !isLocalDraftServiceId(preRow.id)) continue
+            if (!preRow?.id) continue
             const files = pendingFilesByRowId[preRow.id] ?? []
             if (!files.length) continue
 
-            const persistedServiceId = savedRows[index]?.id
+            const persistedServiceId = isLocalDraftServiceId(preRow.id)
+              ? savedRows[index]?.id
+              : (savedRows[index]?.id ?? preRow.id)
             if (!persistedServiceId) {
               pendingUploadFailures += files.length
               nextPending[preRow.id] = files
@@ -302,27 +306,58 @@ export function TicketDetailTabServicos({ ticketId }: Props) {
               }
               for (const file of videoFiles) {
                 const contentType = file.type || 'video/mp4'
-                const uploadMeta = await requestTicketVideoUploadUrl(ticketId, {
-                  filename: file.name,
-                  content_type: contentType,
-                  file_size: file.size,
-                  resumable: true,
-                  service_type: kind,
-                  service_id: persistedServiceId,
+                toast.loading(`A enviar vídeo: ${file.name} — 0%`, {
+                  id: SERVICOS_SAVE_VIDEO_TOAST_ID,
+                  duration: Infinity,
                 })
-                await putVideoToGcsSignedUrl(
-                  uploadMeta.signed_url,
-                  file,
-                  contentType,
-                )
-                await completeTicketVideoAttachment(ticketId, {
-                  storage_key: uploadMeta.storage_key,
-                  filename: file.name,
-                  content_type: contentType,
-                  size_bytes: file.size,
-                  service_type: kind,
-                  service_id: persistedServiceId,
-                })
+                try {
+                  const uploadMeta = await requestTicketVideoUploadUrl(
+                    ticketId,
+                    {
+                      filename: file.name,
+                      content_type: contentType,
+                      file_size: file.size,
+                      resumable: true,
+                      service_type: kind,
+                      service_id: persistedServiceId,
+                    },
+                  )
+                  await putVideoToGcsSignedUrl(
+                    uploadMeta.signed_url,
+                    file,
+                    contentType,
+                    {
+                      onProgress: ({ loaded, total }) => {
+                        const t = total > 0 ? total : file.size
+                        const pct =
+                          t > 0
+                            ? Math.min(100, Math.round((loaded / t) * 100))
+                            : 0
+                        toast.loading(
+                          `A enviar vídeo: ${file.name} — ${pct}%`,
+                          {
+                            id: SERVICOS_SAVE_VIDEO_TOAST_ID,
+                            duration: Infinity,
+                          },
+                        )
+                      },
+                    },
+                  )
+                  toast.loading(`A finalizar: ${file.name}…`, {
+                    id: SERVICOS_SAVE_VIDEO_TOAST_ID,
+                    duration: Infinity,
+                  })
+                  await completeTicketVideoAttachment(ticketId, {
+                    storage_key: uploadMeta.storage_key,
+                    filename: file.name,
+                    content_type: contentType,
+                    size_bytes: file.size,
+                    service_type: kind,
+                    service_id: persistedServiceId,
+                  })
+                } finally {
+                  toast.dismiss(SERVICOS_SAVE_VIDEO_TOAST_ID)
+                }
               }
             } catch {
               pendingUploadFailures += files.length
@@ -395,13 +430,12 @@ export function TicketDetailTabServicos({ ticketId }: Props) {
       if (!prev) return prev
       return removeServiceAt(prev, kind, index)
     })
-    if (isLocalDraftServiceId(rowId)) {
-      setPendingFilesByRowId((prev) => {
-        const next = { ...prev }
-        delete next[rowId]
-        return next
-      })
-    }
+    setPendingFilesByRowId((prev) => {
+      if (!(rowId in prev)) return prev
+      const next = { ...prev }
+      delete next[rowId]
+      return next
+    })
     if (expandedId === rowId) {
       setExpandedId(null)
     }
@@ -550,17 +584,14 @@ export function TicketDetailTabServicos({ ticketId }: Props) {
                             service_type: row.kind,
                             service_id: row.rowId,
                           }}
-                          uploadBlocked={isLocalDraftServiceId(row.rowId)}
+                          uploadBlocked={isEditing}
+                          uploadBlockedMessage="Os anexos serão enviados ao salvar as alterações dos serviços."
                           pendingFiles={pendingFilesByRowId[row.rowId] ?? []}
-                          onQueuePendingFiles={
-                            isLocalDraftServiceId(row.rowId)
-                              ? (files) => queuePendingFiles(row.rowId, files)
-                              : undefined
+                          onQueuePendingFiles={(files) =>
+                            queuePendingFiles(row.rowId, files)
                           }
-                          onRemovePendingFile={
-                            isLocalDraftServiceId(row.rowId)
-                              ? (index) => removePendingFile(row.rowId, index)
-                              : undefined
+                          onRemovePendingFile={(index) =>
+                            removePendingFile(row.rowId, index)
                           }
                         />
                       ) : null}

--- a/src/app/(app)/demandas/[ticketId]/components/ticket-servico-anexos.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-servico-anexos.tsx
@@ -139,6 +139,12 @@ export function TicketServicoAnexos({
   const [videoPlaybackOverrides, setVideoPlaybackOverrides] = useState<
     Record<string, { signedUrl?: string; expiresAt?: string }>
   >({})
+  const [videoUploadUi, setVideoUploadUi] = useState<{
+    fileName: string
+    phase: 'preparing' | 'uploading' | 'finalizing'
+    percent: number
+  } | null>(null)
+  const lastReportedVideoPercent = useRef(-1)
 
   const deleteMutation = useMutation({
     mutationFn: ({ attachmentId }: { attachmentId: string }) =>
@@ -179,6 +185,14 @@ export function TicketServicoAnexos({
   })
 
   const videoMutation = useMutation({
+    onMutate: (file) => {
+      lastReportedVideoPercent.current = -1
+      setVideoUploadUi({
+        fileName: file.name,
+        phase: 'preparing',
+        percent: 0,
+      })
+    },
     mutationFn: async (file: File) => {
       const contentType = file.type || 'video/mp4'
       const scope =
@@ -195,7 +209,32 @@ export function TicketServicoAnexos({
         resumable: true,
         ...scope,
       })
-      await putVideoToGcsSignedUrl(uploadMeta.signed_url, file, contentType)
+      setVideoUploadUi({
+        fileName: file.name,
+        phase: 'uploading',
+        percent: 0,
+      })
+      lastReportedVideoPercent.current = 0
+      await putVideoToGcsSignedUrl(uploadMeta.signed_url, file, contentType, {
+        onProgress: ({ loaded, total }) => {
+          const t = total > 0 ? total : file.size
+          if (t <= 0) return
+          const raw = Math.floor((loaded / t) * 100)
+          const pct = Math.min(99, raw)
+          if (pct === lastReportedVideoPercent.current) return
+          lastReportedVideoPercent.current = pct
+          setVideoUploadUi({
+            fileName: file.name,
+            phase: 'uploading',
+            percent: pct,
+          })
+        },
+      })
+      setVideoUploadUi({
+        fileName: file.name,
+        phase: 'finalizing',
+        percent: 100,
+      })
       await completeTicketVideoAttachment(ticketId, {
         storage_key: uploadMeta.storage_key,
         filename: file.name,
@@ -219,6 +258,10 @@ export function TicketServicoAnexos({
       toast.error(
         getApiDetailUnless500(err) ?? 'Não foi possível enviar o vídeo.',
       )
+    },
+    onSettled: () => {
+      setVideoUploadUi(null)
+      lastReportedVideoPercent.current = -1
     },
   })
 
@@ -463,6 +506,47 @@ export function TicketServicoAnexos({
           </div>
         ) : null}
       </div>
+
+      {videoUploadUi ? (
+        <div
+          className={styles.servicoAnexosUploadProgress}
+          role="status"
+          aria-live="polite"
+          aria-busy={videoMutation.isPending}
+        >
+          <div className={styles.servicoAnexosUploadProgressTop}>
+            <span className={styles.servicoAnexosUploadProgressLabel}>
+              {videoUploadUi.phase === 'preparing' && 'A preparar envio…'}
+              {videoUploadUi.phase === 'uploading' &&
+                `A enviar vídeo — ${videoUploadUi.percent}%`}
+              {videoUploadUi.phase === 'finalizing' &&
+                'A concluir no servidor…'}
+            </span>
+            <span
+              className={styles.servicoAnexosUploadProgressName}
+              title={videoUploadUi.fileName}
+            >
+              {videoUploadUi.fileName}
+            </span>
+          </div>
+          <div
+            className={`${styles.servicoAnexosUploadProgressTrack} ${
+              videoUploadUi.phase === 'preparing'
+                ? styles.servicoAnexosUploadProgressIndeterminate
+                : ''
+            }`}
+          >
+            <div
+              className={styles.servicoAnexosUploadProgressFill}
+              style={
+                videoUploadUi.phase === 'preparing'
+                  ? undefined
+                  : { width: `${videoUploadUi.percent}%` }
+              }
+            />
+          </div>
+        </div>
+      ) : null}
 
       {uploadBlocked && !readOnly ? (
         <p className={styles.servicoAnexosHint}>

--- a/src/app/(app)/demandas/[ticketId]/ticket-detail.constants.ts
+++ b/src/app/(app)/demandas/[ticketId]/ticket-detail.constants.ts
@@ -31,15 +31,24 @@ export const TICKET_RESPOSTA_TAB = {
 }
 
 const RESPOSTA_TAB_STATE_ID = 'AGUARDANDO_REVISAO_ADMINISTRATIVO'
+const RESPOSTA_TAB_STATUS_RESTRITO = 'RESTRITO'
 
 export function shouldShowTicketRespostaTab(
   stateId: string | null | undefined,
   status: string | null | undefined,
 ) {
   const normalizedStateId = stateId?.trim().toUpperCase() ?? ''
-  if (normalizedStateId === RESPOSTA_TAB_STATE_ID) return true
+  if (
+    normalizedStateId === RESPOSTA_TAB_STATE_ID ||
+    normalizedStateId === RESPOSTA_TAB_STATUS_RESTRITO
+  ) {
+    return true
+  }
 
   const normalizedStatus = status?.trim().toUpperCase() ?? ''
   if (!normalizedStatus) return false
-  return normalizedStatus === RESPOSTA_TAB_STATE_ID
+  return (
+    normalizedStatus === RESPOSTA_TAB_STATE_ID ||
+    normalizedStatus === RESPOSTA_TAB_STATUS_RESTRITO
+  )
 }

--- a/src/app/(app)/demandas/[ticketId]/ticket-detail.module.css
+++ b/src/app/(app)/demandas/[ticketId]/ticket-detail.module.css
@@ -2582,6 +2582,68 @@
   background-color: var(--td-page-bg, #0c161f);
 }
 
+.servicoAnexosUploadProgress {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px;
+  background: var(--td-card-bg);
+  border-radius: var(--td-radius);
+  border: 1px solid var(--td-border);
+}
+
+.servicoAnexosUploadProgressTop {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+
+.servicoAnexosUploadProgressLabel {
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 18px;
+  color: var(--td-text);
+}
+
+.servicoAnexosUploadProgressName {
+  font-size: 12px;
+  line-height: 16px;
+  color: var(--td-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.servicoAnexosUploadProgressTrack {
+  height: 8px;
+  background: var(--td-badge-bg);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.servicoAnexosUploadProgressFill {
+  height: 100%;
+  width: 0%;
+  background: var(--td-btn-primary);
+  border-radius: inherit;
+  transition: width 0.15s ease-out;
+}
+
+.servicoAnexosUploadProgressIndeterminate .servicoAnexosUploadProgressFill {
+  width: 40%;
+  animation: servicoAnexosUploadIndeterminate 1.1s ease-in-out infinite;
+}
+
+@keyframes servicoAnexosUploadIndeterminate {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(350%);
+  }
+}
+
 .servicoAnexosHeaderActions {
   display: inline-flex;
   align-items: center;

--- a/src/app/(app)/demandas/criar/hooks/use-create-controller.ts
+++ b/src/app/(app)/demandas/criar/hooks/use-create-controller.ts
@@ -4,7 +4,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import type { AxiosResponse } from 'axios'
 import { useRouter } from 'next/navigation'
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useFieldArray, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 
@@ -37,6 +37,13 @@ import {
 
 const MAX_ATTACHMENT_BYTES = 10 * 1024 * 1024
 const ALLOWED_ATTACHMENT_EXT = new Set(['.pdf', '.doc', '.docx'])
+
+const TICKET_TYPE_RESTRITA_LABEL = 'requisição restrita'
+const TEAM_COORDENADORES_LABEL = 'coordenadores'
+
+function normalizeCatalogLabel(value: string) {
+  return value.trim().toLowerCase()
+}
 
 function attachmentExtension(name: string): string {
   const dot = name.lastIndexOf('.')
@@ -132,6 +139,7 @@ export function useTicketCreateController() {
 
   const possuiApelido = watch('possui_apelido_imprensa')
   const possuiEnderecoCorrespondencia = watch('possui_endereco_correspondencia')
+  const tipoChamadoId = watch('tipo_chamado_id')
 
   const focalPoints = useFieldArray({ control, name: 'pontos_focais' })
   const buscaPorPlaca = useFieldArray({ control, name: 'busca_por_placa' })
@@ -282,6 +290,30 @@ export function useTicketCreateController() {
   const ticketNatures = ticketNaturesQuery.data?.data ?? []
   const tickets = ticketsQuery.data?.data ?? []
   const teams = teamsQuery.data?.data ?? []
+
+  useEffect(() => {
+    if (!tipoChamadoId || ticketTypes.length === 0 || teams.length === 0) return
+
+    const selectedType = ticketTypes.find((t) => t.id === tipoChamadoId)
+    if (!selectedType) return
+
+    const isRestrita =
+      normalizeCatalogLabel(selectedType.name) === TICKET_TYPE_RESTRITA_LABEL
+    if (!isRestrita) return
+
+    const coordTeam = teams.find(
+      (team) => normalizeCatalogLabel(team.name) === TEAM_COORDENADORES_LABEL,
+    )
+    if (!coordTeam) return
+
+    const currentEquipeId = getValues('equipe_id')
+    if (currentEquipeId === coordTeam.id) return
+
+    setValue('equipe_id', coordTeam.id, {
+      shouldValidate: true,
+      shouldDirty: true,
+    })
+  }, [tipoChamadoId, ticketTypes, teams, getValues, setValue])
 
   const isOperationsLoading = operationsQuery.isLoading
   const isTicketTypesLoading = ticketTypesQuery.isLoading

--- a/src/app/(app)/demandas/workflow/page.tsx
+++ b/src/app/(app)/demandas/workflow/page.tsx
@@ -239,7 +239,7 @@ function WorkflowRolesPageContent() {
                 className="font-semibold leading-10 text-[var(--tc-heading,#f9fafa)]"
                 style={{ fontSize: '20px' }}
               >
-                Configuração de Workflow por Role
+                Configuração de Workflow por Tipo de Demanda e Role
               </h1>
               <p className="mt-0 text-[length:12px] leading-4 text-[var(--tc-muted,#97a2ab)]">
                 Defina permissões por estado e transições para o tipo de demanda

--- a/src/http/tickets/ticket-attachments.ts
+++ b/src/http/tickets/ticket-attachments.ts
@@ -151,7 +151,6 @@ export type PutVideoToGcsProgress = {
 }
 
 export type PutVideoToGcsSignedUrlOptions = {
-  /** Só disponível com envio via XMLHttpRequest (necessário para progresso). */
   onProgress?: (p: PutVideoToGcsProgress) => void
 }
 

--- a/src/http/tickets/ticket-attachments.ts
+++ b/src/http/tickets/ticket-attachments.ts
@@ -145,11 +145,76 @@ export async function getTicketServiceAttachmentPlaybackUrl(
   return data
 }
 
+export type PutVideoToGcsProgress = {
+  loaded: number
+  total: number
+}
+
+export type PutVideoToGcsSignedUrlOptions = {
+  /** Só disponível com envio via XMLHttpRequest (necessário para progresso). */
+  onProgress?: (p: PutVideoToGcsProgress) => void
+}
+
+function putVideoToGcsSignedUrlWithProgress(
+  signedUrl: string,
+  file: File,
+  contentType: string,
+  onProgress: (p: PutVideoToGcsProgress) => void,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest()
+    xhr.open('PUT', signedUrl)
+    xhr.setRequestHeader('Content-Type', contentType)
+
+    xhr.upload.onprogress = (ev) => {
+      const total =
+        ev.lengthComputable && ev.total > 0 ? ev.total : Math.max(file.size, 1)
+      onProgress({ loaded: ev.loaded, total })
+    }
+
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        resolve()
+        return
+      }
+      const text = (xhr.responseText ?? '').slice(0, 200)
+      reject(
+        new Error(
+          text
+            ? `Envio do vídeo falhou (${xhr.status}): ${text}`
+            : `Envio do vídeo falhou (${xhr.status}).`,
+        ),
+      )
+    }
+
+    xhr.onerror = () => {
+      reject(new Error('Envio do vídeo falhou (rede ou CORS).'))
+    }
+
+    xhr.onabort = () => {
+      reject(new Error('Envio do vídeo cancelado.'))
+    }
+
+    xhr.send(file)
+  })
+}
+
 export async function putVideoToGcsSignedUrl(
   signedUrl: string,
   file: File,
   contentType: string,
+  options?: PutVideoToGcsSignedUrlOptions,
 ): Promise<void> {
+  if (options?.onProgress) {
+    await putVideoToGcsSignedUrlWithProgress(
+      signedUrl,
+      file,
+      contentType,
+      options.onProgress,
+    )
+    return
+  }
+
   const res = await fetch(signedUrl, {
     method: 'PUT',
     headers: {


### PR DESCRIPTION
## Description

This PR adds **video upload progress** for service attachments on tickets, extends the **signed PUT to GCS** with an optional progress callback via **XMLHttpRequest**, and updates the **Services** tab flow so pending file queues and uploads work when the service row is **no longer a local draft**.

Changes by file:

- **`src/http/tickets/ticket-attachments.ts`**: `putVideoToGcsSignedUrl` accepts `options?.onProgress`; when set, upload uses XHR with `upload.onprogress`; otherwise the existing `fetch` PUT path is unchanged. Exported types `PutVideoToGcsProgress` and `PutVideoToGcsSignedUrlOptions`.
- **`ticket-servico-anexos.tsx`**: `videoUploadUi` state (preparing / uploading / finalizing), progress UI and accessible copy (`role="status"`, `aria-live`); `onMutate` / `onSettled` on the video mutation; wires `onProgress` to the HTTP helper.
- **`ticket-detail-tab-servicos.tsx`**: Sonner toasts with percentage during batch save of videos; `putVideoToGcsSignedUrl` with `onProgress`; correct `persistedServiceId` for already-persisted rows; attachments in edit mode use `uploadBlocked` when `isEditing` with a fixed hint message; queue/remove pending handlers for any `rowId` with pending files; clearing `pendingFilesByRowId` on service removal no longer depends only on draft IDs.
- **`ticket-detail.module.css`**: styles for the upload progress block (including indeterminate animation for the “preparing” phase).
- **`ticket-detail.constants.ts`**: `shouldShowTicketRespostaTab` also treats **`RESTRITO`** (in addition to `AGUARDANDO_REVISAO_ADMINISTRATIVO`) for both normalized state and status checks.
- **`use-create-controller.ts`**: `useEffect` that, when the selected ticket type name normalizes to **“requisição restrita”**, sets **`equipe_id`** to the team whose name normalizes to **“coordenadores”** (if present in the catalog).
- **`demandas/workflow/page.tsx`**: page title updated to **“Configuração de Workflow por Tipo de Demanda e Role”**.

## Related Issue

<!-- Add issue link if applicable -->

## Motivation and Context

Improve **video upload UX** (progress and phases), fix alignment between **persisted services** and **pending uploads** while editing, align **response tab** visibility with **restricted** state, and **pre-select the “Coordenadores” team** when creating a restricted-type ticket, based on catalog naming.

## How has this been tested?

<!-- Fill in: manual / automated -->

- Create or edit a ticket, attach a service video, and verify progress UI and completion.
- Save services with pending videos (draft and persisted rows) and verify toasts and no regressions.
- Verify response tab behavior for tickets in **RESTRITO** state.
- Select restricted request type on create and confirm **equipe** switches to **Coordenadores** when that team exists.

Environment: <!-- e.g. browser, local build -->

## Screenshots (if appropriate):

<!-- Add screenshots of progress UI and toasts if helpful -->

## Types of changes

- [x] feat: indicates the development of a new feature for the project.
- [x] fix: used when there is correction of errors that are generating bugs in the system.
- [ ] perf: indicates a change that improved system performance.
- [ ] test: indicates any type of creation or change of test codes.
- [ ] refactor: used when there is a code refactoring that does not have any type of impact on the system's business logic/rules.
- [ ] style: used when there are formatting and code style changes that do not alter the system in any way.
- [ ] chore: indicates changes to the project that do not affect the system or test files.
- [ ] docs: used when there are changes to the project documentation.
- [ ] build: used to indicate changes that affect the project's build process or external dependencies.
- [ ] ci: used for changes to CI configuration files.
- [ ] revert: indicates the revert of a previous commit

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.