### PR TITLE
feat: add reassign input styles and enhance ticket detail components …

### DIFF
--- a/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-servicos.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-servicos.tsx
@@ -44,6 +44,11 @@ import {
   setServiceConcluido,
   ticketServicosToReplacePayload,
 } from '../ticket-servicos-mapper'
+import {
+  createPendingServiceAttachments,
+  pendingAttachmentAsUploadFile,
+  type PendingServiceAttachment,
+} from './ticket-pending-attachment'
 import { TicketServicoAnexos } from './ticket-servico-anexos'
 import { ServicosExpandedForm } from './ticket-servicos-expanded-form'
 
@@ -125,7 +130,7 @@ type Props = {
   ticketId: string
 }
 
-type PendingServiceFilesByRowId = Record<string, File[]>
+type PendingServiceFilesByRowId = Record<string, PendingServiceAttachment[]>
 
 export function TicketDetailTabServicos({ ticketId }: Props) {
   const queryClient = useQueryClient()
@@ -200,9 +205,27 @@ export function TicketDetailTabServicos({ ticketId }: Props) {
     if (!files.length) return
     setPendingFilesByRowId((prev) => ({
       ...prev,
-      [rowId]: [...(prev[rowId] ?? []), ...files],
+      [rowId]: [
+        ...(prev[rowId] ?? []),
+        ...createPendingServiceAttachments(files),
+      ],
     }))
   }, [])
+
+  const renamePendingFile = useCallback(
+    (rowId: string, index: number, filename: string) => {
+      setPendingFilesByRowId((prev) => {
+        const rowFiles = prev[rowId] ?? []
+        const item = rowFiles[index]
+        if (!item) return prev
+        const nextRowFiles = rowFiles.map((entry, i) =>
+          i === index ? { ...entry, filename } : entry,
+        )
+        return { ...prev, [rowId]: nextRowFiles }
+      })
+    },
+    [],
+  )
 
   const removePendingFile = useCallback((rowId: string, index: number) => {
     setPendingFilesByRowId((prev) => {
@@ -274,37 +297,38 @@ export function TicketDetailTabServicos({ ticketId }: Props) {
           for (let index = 0; index < preRows.length; index++) {
             const preRow = preRows[index]
             if (!preRow?.id) continue
-            const files = pendingFilesByRowId[preRow.id] ?? []
-            if (!files.length) continue
+            const pendingItems = pendingFilesByRowId[preRow.id] ?? []
+            if (!pendingItems.length) continue
 
             const persistedServiceId = isLocalDraftServiceId(preRow.id)
               ? savedRows[index]?.id
               : (savedRows[index]?.id ?? preRow.id)
             if (!persistedServiceId) {
-              pendingUploadFailures += files.length
-              nextPending[preRow.id] = files
+              pendingUploadFailures += pendingItems.length
+              nextPending[preRow.id] = pendingItems
               continue
             }
 
-            const videoFiles = files.filter((file) =>
-              file.type.startsWith('video/'),
+            const videoItems = pendingItems.filter((item) =>
+              item.file.type.startsWith('video/'),
             )
-            const nonVideoFiles = files.filter(
-              (file) => !file.type.startsWith('video/'),
+            const nonVideoItems = pendingItems.filter(
+              (item) => !item.file.type.startsWith('video/'),
             )
 
             try {
-              if (nonVideoFiles.length > 0) {
+              if (nonVideoItems.length > 0) {
                 await uploadTicketServiceAttachmentsMultipart(
                   ticketId,
-                  nonVideoFiles,
+                  nonVideoItems.map(pendingAttachmentAsUploadFile),
                   {
                     service_type: kind,
                     service_id: persistedServiceId,
                   },
                 )
               }
-              for (const file of videoFiles) {
+              for (const item of videoItems) {
+                const file = pendingAttachmentAsUploadFile(item)
                 const contentType = file.type || 'video/mp4'
                 toast.loading(`A enviar vídeo: ${file.name} — 0%`, {
                   id: SERVICOS_SAVE_VIDEO_TOAST_ID,
@@ -360,8 +384,8 @@ export function TicketDetailTabServicos({ ticketId }: Props) {
                 }
               }
             } catch {
-              pendingUploadFailures += files.length
-              nextPending[preRow.id] = files
+              pendingUploadFailures += pendingItems.length
+              nextPending[preRow.id] = pendingItems
             }
           }
         }
@@ -567,8 +591,7 @@ export function TicketDetailTabServicos({ ticketId }: Props) {
                             : null
                         }
                       />
-                      {row.kind !== 'cerco_eletronico' &&
-                      row.kind !== 'reserva_de_imagem' ? (
+                      {row.kind !== 'cerco_eletronico' ? (
                         <TicketServicoAnexos
                           ticketId={ticketId}
                           title="Anexos deste serviço"
@@ -589,6 +612,9 @@ export function TicketDetailTabServicos({ ticketId }: Props) {
                           pendingFiles={pendingFilesByRowId[row.rowId] ?? []}
                           onQueuePendingFiles={(files) =>
                             queuePendingFiles(row.rowId, files)
+                          }
+                          onRenamePendingFile={(index, filename) =>
+                            renamePendingFile(row.rowId, index, filename)
                           }
                           onRemovePendingFile={(index) =>
                             removePendingFile(row.rowId, index)

--- a/src/app/(app)/demandas/[ticketId]/components/ticket-pending-attachment.ts
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-pending-attachment.ts
@@ -1,0 +1,78 @@
+export type PendingServiceAttachment = {
+  id: string
+  file: File
+  filename: string
+}
+
+export function getFilenameExtension(name: string): string {
+  const i = name.lastIndexOf('.')
+  if (i <= 0 || i === name.length - 1) return ''
+  return name.slice(i)
+}
+
+export function getFilenameBase(name: string): string {
+  const ext = getFilenameExtension(name)
+  if (!ext) return name
+  return name.slice(0, -ext.length)
+}
+
+export function buildFilenameWithExtension(
+  base: string,
+  extension: string,
+): string {
+  const trimmedBase = base.trim()
+  if (!extension) {
+    return trimmedBase.length > 0 ? trimmedBase : ''
+  }
+  const basePart = trimmedBase.length > 0 ? trimmedBase : 'arquivo'
+  return `${basePart}${extension}`
+}
+
+/** Extensão fixa do ficheiro original; só o nome base é editável. */
+export function normalizePendingFilename(
+  filename: string,
+  originalFilename: string,
+): string {
+  const ext = getFilenameExtension(originalFilename)
+  const fallbackBase = getFilenameBase(originalFilename).trim() || 'arquivo'
+  const base = getFilenameBase(filename).trim() || fallbackBase
+  return buildFilenameWithExtension(base, ext)
+}
+
+export function getPendingAttachmentBaseName(
+  item: PendingServiceAttachment,
+): string {
+  return getFilenameBase(
+    normalizePendingFilename(item.filename, item.file.name),
+  )
+}
+
+export function renamePendingAttachmentBase(
+  item: PendingServiceAttachment,
+  base: string,
+): string {
+  const ext = getFilenameExtension(item.file.name)
+  return buildFilenameWithExtension(base, ext)
+}
+
+export function createPendingServiceAttachments(
+  files: File[],
+): PendingServiceAttachment[] {
+  return files.map((file) => ({
+    id: crypto.randomUUID(),
+    file,
+    filename: file.name,
+  }))
+}
+
+/** File com o nome escolhido no rascunho, para envio multipart / vídeo. */
+export function pendingAttachmentAsUploadFile(
+  item: PendingServiceAttachment,
+): File {
+  const name = normalizePendingFilename(item.filename, item.file.name)
+  if (name === item.file.name) return item.file
+  return new File([item.file], name, {
+    type: item.file.type,
+    lastModified: item.file.lastModified,
+  })
+}

--- a/src/app/(app)/demandas/[ticketId]/components/ticket-servico-anexos.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-servico-anexos.tsx
@@ -8,13 +8,22 @@ import {
   FileText,
   Loader2,
   Paperclip,
+  Pencil,
   RefreshCw,
   Trash2,
   X,
 } from 'lucide-react'
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
 import {
   downloadTicketAttachmentFile,
   fetchTicketAttachmentBlob,
@@ -34,10 +43,21 @@ import {
 import { isApiError } from '@/lib/api'
 
 import styles from '../ticket-detail.module.css'
+import {
+  getFilenameExtension,
+  getPendingAttachmentBaseName,
+  normalizePendingFilename,
+  type PendingServiceAttachment,
+  renamePendingAttachmentBase,
+} from './ticket-pending-attachment'
+
+export type { PendingServiceAttachment } from './ticket-pending-attachment'
 
 const MAX_MULTIPART_BYTES = 10 * 1024 * 1024
 const MAX_VIDEO_GB = 20
 const MAX_VIDEO_BYTES = MAX_VIDEO_GB * 1024 * 1024 * 1024
+/** Validade do link de reprodução ao atualizar (7 h, em minutos). */
+const VIDEO_PLAYBACK_EXPIRATION_MINUTES = 7 * 60
 
 const MULTIPART_ACCEPT = [
   'application/pdf',
@@ -110,8 +130,9 @@ type Props = {
   serviceScope: TicketAttachmentMultipartMetadata | null
   uploadBlocked?: boolean
   uploadBlockedMessage?: string
-  pendingFiles?: File[]
+  pendingFiles?: PendingServiceAttachment[]
   onQueuePendingFiles?: (files: File[]) => void
+  onRenamePendingFile?: (index: number, filename: string) => void
   onRemovePendingFile?: (index: number) => void
 }
 
@@ -125,6 +146,7 @@ export function TicketServicoAnexos({
   uploadBlockedMessage = 'Guarde os serviços para anexar ficheiros a este serviço.',
   pendingFiles = [],
   onQueuePendingFiles,
+  onRenamePendingFile,
   onRemovePendingFile,
 }: Props) {
   const queryClient = useQueryClient()
@@ -145,6 +167,42 @@ export function TicketServicoAnexos({
     percent: number
   } | null>(null)
   const lastReportedVideoPercent = useRef(-1)
+  const renameInputRef = useRef<HTMLInputElement>(null)
+  const [renameDialog, setRenameDialog] = useState<{
+    index: number
+    item: PendingServiceAttachment
+    baseDraft: string
+  } | null>(null)
+
+  useEffect(() => {
+    if (!renameDialog) return
+    const t = window.setTimeout(() => renameInputRef.current?.focus(), 0)
+    return () => window.clearTimeout(t)
+  }, [renameDialog])
+
+  const openRenameDialog = useCallback(
+    (index: number, item: PendingServiceAttachment) => {
+      setRenameDialog({
+        index,
+        item,
+        baseDraft: getPendingAttachmentBaseName(item),
+      })
+    },
+    [],
+  )
+
+  const confirmRenameDialog = useCallback(() => {
+    if (!renameDialog || !onRenamePendingFile) return
+    const { index, item, baseDraft } = renameDialog
+    onRenamePendingFile(
+      index,
+      normalizePendingFilename(
+        renamePendingAttachmentBase(item, baseDraft),
+        item.file.name,
+      ),
+    )
+    setRenameDialog(null)
+  }, [onRenamePendingFile, renameDialog])
 
   const deleteMutation = useMutation({
     mutationFn: ({ attachmentId }: { attachmentId: string }) =>
@@ -341,7 +399,7 @@ export function TicketServicoAnexos({
     [videoPlaybackOverrides],
   )
 
-  /** URL assinada no GCS; pedimos o máximo permitido (120 min) para quem receber o link. */
+  /** URL assinada no GCS; validade de 7 h para quem receber o link. */
   const handleCopyVideoLink = useCallback(
     async (att: TicketAttachmentOut) => {
       const playbackUrl = resolvePlaybackUrl(att)
@@ -369,8 +427,14 @@ export function TicketServicoAnexos({
       setVideoRefreshingId(att.id)
       try {
         const { signed_url: signedUrl } =
-          await getTicketServiceAttachmentPlaybackUrl(ticketId, att.id, 120)
-        const expiresAt = new Date(Date.now() + 120 * 60 * 1000).toISOString()
+          await getTicketServiceAttachmentPlaybackUrl(
+            ticketId,
+            att.id,
+            VIDEO_PLAYBACK_EXPIRATION_MINUTES,
+          )
+        const expiresAt = new Date(
+          Date.now() + VIDEO_PLAYBACK_EXPIRATION_MINUTES * 60 * 1000,
+        ).toISOString()
         setVideoPlaybackOverrides((prev) => ({
           ...prev,
           [att.id]: { signedUrl, expiresAt },
@@ -464,203 +528,151 @@ export function TicketServicoAnexos({
   )
   const videoAttachments = attachments.filter((att) => isVideoAttachment(att))
 
+  const renameLockedExtension = renameDialog
+    ? getFilenameExtension(renameDialog.item.file.name)
+    : ''
+
   return (
-    <div className={styles.servicoAnexos}>
-      <div className={styles.servicoAnexosHeader}>
-        <span className={styles.servicoAnexosTitle}>{title}</span>
-        {canUpload ? (
-          <div className={styles.servicoAnexosHeaderActions}>
-            <input
-              ref={uploadRef}
-              type="file"
-              className={styles.servicoAnexosFileInput}
-              multiple
-              accept="video/*,.pdf,.jpg,.jpeg,.png,.gif,.webp,.doc,.docx"
-              onChange={onPickUpload}
-              aria-hidden
-              tabIndex={-1}
-            />
-            <button
-              type="button"
-              className={styles.servicoAnexosIconButton}
-              onClick={() => uploadRef.current?.click()}
-              disabled={busy}
-              title="Enviar anexo"
-              aria-label="Enviar anexo"
+    <>
+      <div className={styles.servicoAnexos}>
+        <div className={styles.servicoAnexosHeader}>
+          <span className={styles.servicoAnexosTitle}>{title}</span>
+          {canUpload ? (
+            <div className={styles.servicoAnexosHeaderActions}>
+              <input
+                ref={uploadRef}
+                type="file"
+                className={styles.servicoAnexosFileInput}
+                multiple
+                accept="video/*,.pdf,.jpg,.jpeg,.png,.gif,.webp,.doc,.docx"
+                onChange={onPickUpload}
+                aria-hidden
+                tabIndex={-1}
+              />
+              <button
+                type="button"
+                className={styles.servicoAnexosIconButton}
+                onClick={() => uploadRef.current?.click()}
+                disabled={busy}
+                title="Enviar anexo"
+                aria-label="Enviar anexo"
+              >
+                {busy ? (
+                  <Loader2 size={18} className="animate-spin" />
+                ) : (
+                  <Paperclip size={18} />
+                )}
+              </button>
+              <button
+                type="button"
+                className={styles.servicoAnexosIconButton}
+                disabled
+                title="Download em lote indisponível"
+                aria-label="Download em lote indisponível"
+              >
+                <Download size={18} />
+              </button>
+            </div>
+          ) : null}
+        </div>
+
+        {videoUploadUi ? (
+          <div
+            className={styles.servicoAnexosUploadProgress}
+            role="status"
+            aria-live="polite"
+            aria-busy={videoMutation.isPending}
+          >
+            <div className={styles.servicoAnexosUploadProgressTop}>
+              <span className={styles.servicoAnexosUploadProgressLabel}>
+                {videoUploadUi.phase === 'preparing' && 'A preparar envio…'}
+                {videoUploadUi.phase === 'uploading' &&
+                  `A enviar vídeo — ${videoUploadUi.percent}%`}
+                {videoUploadUi.phase === 'finalizing' &&
+                  'A concluir no servidor…'}
+              </span>
+              <span
+                className={styles.servicoAnexosUploadProgressName}
+                title={videoUploadUi.fileName}
+              >
+                {videoUploadUi.fileName}
+              </span>
+            </div>
+            <div
+              className={`${styles.servicoAnexosUploadProgressTrack} ${
+                videoUploadUi.phase === 'preparing'
+                  ? styles.servicoAnexosUploadProgressIndeterminate
+                  : ''
+              }`}
             >
-              {busy ? (
-                <Loader2 size={18} className="animate-spin" />
-              ) : (
-                <Paperclip size={18} />
-              )}
-            </button>
-            <button
-              type="button"
-              className={styles.servicoAnexosIconButton}
-              disabled
-              title="Download em lote indisponível"
-              aria-label="Download em lote indisponível"
-            >
-              <Download size={18} />
-            </button>
+              <div
+                className={styles.servicoAnexosUploadProgressFill}
+                style={
+                  videoUploadUi.phase === 'preparing'
+                    ? undefined
+                    : { width: `${videoUploadUi.percent}%` }
+                }
+              />
+            </div>
           </div>
         ) : null}
-      </div>
 
-      {videoUploadUi ? (
-        <div
-          className={styles.servicoAnexosUploadProgress}
-          role="status"
-          aria-live="polite"
-          aria-busy={videoMutation.isPending}
-        >
-          <div className={styles.servicoAnexosUploadProgressTop}>
-            <span className={styles.servicoAnexosUploadProgressLabel}>
-              {videoUploadUi.phase === 'preparing' && 'A preparar envio…'}
-              {videoUploadUi.phase === 'uploading' &&
-                `A enviar vídeo — ${videoUploadUi.percent}%`}
-              {videoUploadUi.phase === 'finalizing' &&
-                'A concluir no servidor…'}
-            </span>
-            <span
-              className={styles.servicoAnexosUploadProgressName}
-              title={videoUploadUi.fileName}
-            >
-              {videoUploadUi.fileName}
-            </span>
-          </div>
-          <div
-            className={`${styles.servicoAnexosUploadProgressTrack} ${
-              videoUploadUi.phase === 'preparing'
-                ? styles.servicoAnexosUploadProgressIndeterminate
-                : ''
-            }`}
-          >
-            <div
-              className={styles.servicoAnexosUploadProgressFill}
-              style={
-                videoUploadUi.phase === 'preparing'
-                  ? undefined
-                  : { width: `${videoUploadUi.percent}%` }
-              }
-            />
-          </div>
-        </div>
-      ) : null}
+        {uploadBlocked && !readOnly ? (
+          <p className={styles.servicoAnexosHint}>
+            {uploadBlockedMessage}
+            {pendingFiles.length > 0
+              ? ` (${pendingFiles.length} pendente${pendingFiles.length > 1 ? 's' : ''})`
+              : ''}
+          </p>
+        ) : null}
 
-      {uploadBlocked && !readOnly ? (
-        <p className={styles.servicoAnexosHint}>
-          {uploadBlockedMessage}
-          {pendingFiles.length > 0
-            ? ` (${pendingFiles.length} pendente${pendingFiles.length > 1 ? 's' : ''})`
-            : ''}
-        </p>
-      ) : null}
-
-      {pendingFiles.length > 0 ? (
-        <div className={styles.servicoAnexosList}>
-          <div className={styles.docGrid}>
-            {pendingFiles.map((file, index) => (
-              <div
-                key={`${file.name}-${file.size}-${file.lastModified}-${index}`}
-                className={styles.docCard}
-              >
-                <div className={styles.docCardLeft}>
-                  <div className={styles.docPdfIcon} aria-hidden>
-                    <FileText size={20} />
-                  </div>
-                  <div className={styles.docInfo}>
-                    <p className={styles.docName} title={file.name}>
-                      {file.name}
-                    </p>
-                    <p className={styles.docSize}>
-                      {formatBytes(file.size)} - Pendente
-                    </p>
-                  </div>
-                </div>
-                <div className={styles.docCardActions}>
-                  {!readOnly && onRemovePendingFile ? (
-                    <button
-                      type="button"
-                      className={styles.docIconBtn}
-                      aria-label={`Remover pendente ${file.name}`}
-                      title="Remover pendente"
-                      onClick={() => onRemovePendingFile(index)}
-                      disabled={busy}
-                    >
-                      <X size={16} />
-                    </button>
-                  ) : null}
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      ) : null}
-
-      {attachments.length === 0 ? (
-        <p className={styles.servicoAnexosEmpty}>Nenhum anexo.</p>
-      ) : (
-        <div className={styles.servicoAnexosList}>
-          {nonVideoAttachments.length > 0 ? (
+        {pendingFiles.length > 0 ? (
+          <div className={styles.servicoAnexosList}>
             <div className={styles.docGrid}>
-              {nonVideoAttachments.map((att) => {
+              {pendingFiles.map((item, index) => {
+                const canRename = !readOnly && !!onRenamePendingFile
+                const displayName = normalizePendingFilename(
+                  item.filename,
+                  item.file.name,
+                )
                 return (
-                  <div key={att.id} className={styles.docCard}>
+                  <div key={item.id} className={styles.docCard}>
                     <div className={styles.docCardLeft}>
                       <div className={styles.docPdfIcon} aria-hidden>
                         <FileText size={20} />
                       </div>
-                      <div className={styles.docInfo}>
-                        <p className={styles.docName} title={att.filename}>
-                          {att.filename}
+                      <div
+                        className={`${styles.docInfo} ${styles.servicoAnexosPendingDocInfo}`}
+                      >
+                        <p className={styles.docName} title={displayName}>
+                          {displayName}
                         </p>
                         <p className={styles.docSize}>
-                          {formatBytes(att.size_bytes)}
+                          {formatBytes(item.file.size)} - Pendente
                         </p>
                       </div>
                     </div>
                     <div className={styles.docCardActions}>
-                      <button
-                        type="button"
-                        className={styles.docIconBtn}
-                        aria-label={`Visualizar ${att.filename}`}
-                        title="Visualizar anexo"
-                        onClick={() => {
-                          handleView(att).catch(() => {})
-                        }}
-                        disabled={
-                          deletingId === att.id || viewingId === att.id || busy
-                        }
-                      >
-                        <Eye size={16} />
-                      </button>
-                      <button
-                        type="button"
-                        className={styles.docIconBtn}
-                        aria-label={`Baixar ${att.filename}`}
-                        title="Descarregar"
-                        onClick={() => {
-                          handleDownload(att).catch(() => {})
-                        }}
-                        disabled={
-                          deletingId === att.id || viewingId === att.id || busy
-                        }
-                      >
-                        <Download size={16} />
-                      </button>
-                      {!readOnly ? (
+                      {canRename ? (
                         <button
                           type="button"
                           className={styles.docIconBtn}
-                          aria-label={`Remover ${att.filename}`}
-                          title="Remover"
-                          onClick={() => handleDelete(att)}
-                          disabled={
-                            deletingId === att.id ||
-                            viewingId === att.id ||
-                            busy
-                          }
+                          aria-label={`Editar nome de ${displayName}`}
+                          title="Editar nome"
+                          onClick={() => openRenameDialog(index, item)}
+                          disabled={busy}
+                        >
+                          <Pencil size={16} />
+                        </button>
+                      ) : null}
+                      {!readOnly && onRemovePendingFile ? (
+                        <button
+                          type="button"
+                          className={styles.docIconBtn}
+                          aria-label={`Remover pendente ${displayName}`}
+                          title="Remover pendente"
+                          onClick={() => onRemovePendingFile(index)}
+                          disabled={busy}
                         >
                           <X size={16} />
                         </button>
@@ -670,96 +682,260 @@ export function TicketServicoAnexos({
                 )
               })}
             </div>
-          ) : null}
+          </div>
+        ) : null}
 
-          {videoAttachments.length > 0 ? (
-            <div className={styles.videoList}>
-              {videoAttachments.map((att) => {
-                const expiresAt = resolvePlaybackExpiresAt(att)
-                const expiresDate = expiresAt ? new Date(expiresAt) : null
-                const isExpired = expiresDate
-                  ? expiresDate.getTime() <= Date.now()
-                  : false
-                const expiryText = expiresAt
-                  ? `${isExpired ? 'Expirado em' : 'Expira em'} ${formatPlaybackExpiry(expiresAt)}`
-                  : 'Expiração não informada'
-                return (
-                  <div key={att.id} className={styles.videoRow}>
-                    <p className={styles.videoLabel}>Link do vídeo</p>
-                    <div className={styles.videoActionsRow}>
-                      <div
-                        className={styles.videoUrlBox}
-                        title={resolvePlaybackUrl(att)}
-                      >
-                        {resolvePlaybackUrl(att) || 'Link indisponível'}
+        {attachments.length === 0 ? (
+          <p className={styles.servicoAnexosEmpty}>Nenhum anexo.</p>
+        ) : (
+          <div className={styles.servicoAnexosList}>
+            {nonVideoAttachments.length > 0 ? (
+              <div className={styles.docGrid}>
+                {nonVideoAttachments.map((att) => {
+                  return (
+                    <div key={att.id} className={styles.docCard}>
+                      <div className={styles.docCardLeft}>
+                        <div className={styles.docPdfIcon} aria-hidden>
+                          <FileText size={20} />
+                        </div>
+                        <div className={styles.docInfo}>
+                          <p className={styles.docName} title={att.filename}>
+                            {att.filename}
+                          </p>
+                          <p className={styles.docSize}>
+                            {formatBytes(att.size_bytes)}
+                          </p>
+                        </div>
                       </div>
-                      <button
-                        type="button"
-                        className={styles.servicoAnexosIconButton}
-                        aria-label={`Copiar link do vídeo ${att.filename}`}
-                        title="Copiar link"
-                        onClick={() => {
-                          handleCopyVideoLink(att).catch(() => {})
-                        }}
-                        disabled={
-                          deletingId === att.id ||
-                          videoCopyingId === att.id ||
-                          videoRefreshingId === att.id ||
-                          busy
-                        }
-                      >
-                        {videoCopyingId === att.id ? (
-                          <Loader2 size={18} className="animate-spin" />
-                        ) : (
-                          <Copy size={18} />
-                        )}
-                      </button>
-                      <button
-                        type="button"
-                        className={styles.servicoAnexosIconButton}
-                        aria-label={`Atualizar link do vídeo ${att.filename}`}
-                        title="Atualizar link"
-                        onClick={() => {
-                          handleRefreshVideoLink(att).catch(() => {})
-                        }}
-                        disabled={
-                          deletingId === att.id ||
-                          videoCopyingId === att.id ||
-                          videoRefreshingId === att.id ||
-                          busy
-                        }
-                      >
-                        {videoRefreshingId === att.id ? (
-                          <Loader2 size={18} className="animate-spin" />
-                        ) : (
-                          <RefreshCw size={18} />
-                        )}
-                      </button>
-                      {!readOnly ? (
+                      <div className={styles.docCardActions}>
+                        <button
+                          type="button"
+                          className={styles.docIconBtn}
+                          aria-label={`Visualizar ${att.filename}`}
+                          title="Visualizar anexo"
+                          onClick={() => {
+                            handleView(att).catch(() => {})
+                          }}
+                          disabled={
+                            deletingId === att.id ||
+                            viewingId === att.id ||
+                            busy
+                          }
+                        >
+                          <Eye size={16} />
+                        </button>
+                        <button
+                          type="button"
+                          className={styles.docIconBtn}
+                          aria-label={`Baixar ${att.filename}`}
+                          title="Descarregar"
+                          onClick={() => {
+                            handleDownload(att).catch(() => {})
+                          }}
+                          disabled={
+                            deletingId === att.id ||
+                            viewingId === att.id ||
+                            busy
+                          }
+                        >
+                          <Download size={16} />
+                        </button>
+                        {!readOnly ? (
+                          <button
+                            type="button"
+                            className={styles.docIconBtn}
+                            aria-label={`Remover ${att.filename}`}
+                            title="Remover"
+                            onClick={() => handleDelete(att)}
+                            disabled={
+                              deletingId === att.id ||
+                              viewingId === att.id ||
+                              busy
+                            }
+                          >
+                            <X size={16} />
+                          </button>
+                        ) : null}
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            ) : null}
+
+            {videoAttachments.length > 0 ? (
+              <div className={styles.videoList}>
+                {videoAttachments.map((att) => {
+                  const playbackUrl = resolvePlaybackUrl(att)
+                  const expiresAt = resolvePlaybackExpiresAt(att)
+                  const expiresDate = expiresAt ? new Date(expiresAt) : null
+                  const isExpired = expiresDate
+                    ? expiresDate.getTime() <= Date.now()
+                    : false
+                  const expiryText = expiresAt
+                    ? `${isExpired ? 'Expirado em' : 'Expira em'} ${formatPlaybackExpiry(expiresAt)}`
+                    : 'Expiração não informada'
+                  const displayName = att.filename?.trim() || 'Vídeo'
+                  return (
+                    <div key={att.id} className={styles.videoRow}>
+                      <p className={styles.videoLabel}>Vídeo</p>
+                      <div className={styles.videoActionsRow}>
+                        <div
+                          className={styles.videoUrlBox}
+                          title={playbackUrl || undefined}
+                        >
+                          {displayName}
+                        </div>
                         <button
                           type="button"
                           className={styles.servicoAnexosIconButton}
-                          aria-label={`Remover ${att.filename}`}
-                          title="Remover"
-                          onClick={() => handleDelete(att)}
-                          disabled={deletingId === att.id || busy}
+                          aria-label={`Copiar link do vídeo ${displayName}`}
+                          title={
+                            playbackUrl
+                              ? 'Copiar link'
+                              : 'Link indisponível para cópia'
+                          }
+                          onClick={() => {
+                            handleCopyVideoLink(att).catch(() => {})
+                          }}
+                          disabled={
+                            !playbackUrl ||
+                            deletingId === att.id ||
+                            videoCopyingId === att.id ||
+                            videoRefreshingId === att.id ||
+                            busy
+                          }
                         >
-                          <Trash2 size={18} />
+                          {videoCopyingId === att.id ? (
+                            <Loader2 size={18} className="animate-spin" />
+                          ) : (
+                            <Copy size={18} />
+                          )}
                         </button>
-                      ) : null}
+                        <button
+                          type="button"
+                          className={styles.servicoAnexosIconButton}
+                          aria-label={`Atualizar link do vídeo ${att.filename}`}
+                          title="Atualizar link"
+                          onClick={() => {
+                            handleRefreshVideoLink(att).catch(() => {})
+                          }}
+                          disabled={
+                            deletingId === att.id ||
+                            videoCopyingId === att.id ||
+                            videoRefreshingId === att.id ||
+                            busy
+                          }
+                        >
+                          {videoRefreshingId === att.id ? (
+                            <Loader2 size={18} className="animate-spin" />
+                          ) : (
+                            <RefreshCw size={18} />
+                          )}
+                        </button>
+                        {!readOnly ? (
+                          <button
+                            type="button"
+                            className={styles.servicoAnexosIconButton}
+                            aria-label={`Remover ${att.filename}`}
+                            title="Remover"
+                            onClick={() => handleDelete(att)}
+                            disabled={deletingId === att.id || busy}
+                          >
+                            <Trash2 size={18} />
+                          </button>
+                        ) : null}
+                      </div>
+                      <p
+                        className={`${styles.videoExpiry} ${isExpired ? styles.videoExpiryExpired : ''}`}
+                      >
+                        {expiryText}
+                      </p>
                     </div>
-                    <p
-                      className={`${styles.videoExpiry} ${isExpired ? styles.videoExpiryExpired : ''}`}
-                    >
-                      {expiryText}
-                    </p>
-                  </div>
-                )
-              })}
+                  )
+                })}
+              </div>
+            ) : null}
+          </div>
+        )}
+      </div>
+
+      <Dialog
+        open={renameDialog !== null}
+        onOpenChange={(open) => {
+          if (!open) setRenameDialog(null)
+        }}
+      >
+        <DialogContent className={styles.reassignDialogContent}>
+          <div className={styles.reassignDialogInner}>
+            <DialogHeader className={styles.reassignDialogHeader}>
+              <DialogTitle className={styles.reassignDialogTitle}>
+                Editar nome do anexo
+              </DialogTitle>
+            </DialogHeader>
+            <div className={styles.reassignFields}>
+              <div className={styles.reassignField}>
+                <p className={styles.reassignFieldMessage}>
+                  A extensão do ficheiro não pode ser alterada.
+                </p>
+              </div>
+              <div className={styles.reassignField}>
+                <span
+                  className={styles.reassignLabel}
+                  id="pending-attachment-rename-label"
+                >
+                  Nome
+                </span>
+                <div className={styles.reassignFilenameRow}>
+                  <Input
+                    ref={renameInputRef}
+                    id="pending-attachment-rename"
+                    type="text"
+                    className={styles.reassignInput}
+                    value={renameDialog?.baseDraft ?? ''}
+                    onChange={(e) =>
+                      setRenameDialog((prev) =>
+                        prev ? { ...prev, baseDraft: e.target.value } : prev,
+                      )
+                    }
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault()
+                        confirmRenameDialog()
+                      }
+                    }}
+                    disabled={busy}
+                    aria-labelledby="pending-attachment-rename-label"
+                  />
+                  {renameLockedExtension ? (
+                    <span className={styles.reassignFilenameExt} aria-hidden>
+                      {renameLockedExtension}
+                    </span>
+                  ) : null}
+                </div>
+              </div>
             </div>
-          ) : null}
-        </div>
-      )}
-    </div>
+            <DialogFooter className={styles.footerActions}>
+              <button
+                type="button"
+                className={`${styles.footerBtn} ${styles.footerBtnDefault}`}
+                onClick={() => setRenameDialog(null)}
+                disabled={busy}
+              >
+                Cancelar
+              </button>
+              <button
+                type="button"
+                className={`${styles.footerBtn} ${styles.footerBtnPrimary}`}
+                onClick={confirmRenameDialog}
+                disabled={busy}
+              >
+                Guardar
+              </button>
+            </DialogFooter>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }

--- a/src/app/(app)/demandas/[ticketId]/ticket-detail.module.css
+++ b/src/app/(app)/demandas/[ticketId]/ticket-detail.module.css
@@ -1460,6 +1460,54 @@
   cursor: not-allowed;
 }
 
+.reassignInput {
+  width: 100%;
+  min-height: 44px;
+  padding: 10px 16px;
+  border-radius: 8px;
+  border: 1px solid var(--td-border);
+  background: var(--td-card-bg);
+  color: var(--td-text);
+  font-size: 14px;
+  line-height: 20px;
+}
+
+.reassignInput::placeholder {
+  color: var(--td-muted);
+}
+
+.reassignInput:focus-visible {
+  outline: 2px solid rgba(13, 148, 136, 0.35);
+  outline-offset: 0;
+}
+
+.reassignInput:disabled {
+  opacity: 0.75;
+  cursor: not-allowed;
+}
+
+.reassignFilenameRow {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  min-width: 0;
+}
+
+.reassignFilenameRow .reassignInput {
+  flex: 1 1 auto;
+  min-width: 0;
+  width: auto;
+}
+
+.reassignFilenameExt {
+  flex-shrink: 0;
+  font-size: 14px;
+  line-height: 20px;
+  color: var(--td-muted);
+  user-select: none;
+}
+
 .reassignMultiTrigger {
   width: 100%;
   max-width: 100%;
@@ -2582,6 +2630,12 @@
   background-color: var(--td-page-bg, #0c161f);
 }
 
+.servicoAnexosPendingDocInfo {
+  width: auto;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
 .servicoAnexosUploadProgress {
   display: flex;
   flex-direction: column;
@@ -2735,7 +2789,6 @@
   color: var(--td-text);
   font-size: 12px;
   line-height: 16px;
-  text-transform: uppercase;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/app/(app)/demandas/converter/components/email-to-ticket-view.module.css
+++ b/src/app/(app)/demandas/converter/components/email-to-ticket-view.module.css
@@ -22,7 +22,8 @@
   flex-direction: column;
   flex: 1;
   min-height: 0;
-  height: 100vh;
+  height: 100%;
+  max-height: 100dvh;
   background: var(--tc-page-bg);
   color: var(--tc-text);
 }
@@ -377,11 +378,13 @@
 /* Footer do formulário — alinhado ao Figma (Action Buttons Container) */
 .formFooter {
   padding: 16px 24px;
+  padding-bottom: max(16px, env(safe-area-inset-bottom, 0px));
   border-top: 1px solid var(--tc-card-border);
+  background: var(--tc-page-bg);
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: 16px;
+  gap: 12px;
   flex-shrink: 0;
 }
 

--- a/src/app/(app)/demandas/converter/page.tsx
+++ b/src/app/(app)/demandas/converter/page.tsx
@@ -7,6 +7,7 @@ import { Spinner } from '@/components/custom/spinner'
 import { config } from '@/config'
 import { useTicketScreenPermissionGate } from '@/hooks/useTicketScreenPermissionGate'
 
+import { CHAMADOS_IMPERSONATION_BAR_HEIGHT } from '../chamados-impersonation-bar'
 import { EmailToTicketView } from './components/email-to-ticket-view'
 
 const TICKET_CONVERT_SCREEN_CODE = 'ticket_convert'
@@ -38,5 +39,16 @@ export default function ConverterChamadoPage() {
     )
   }
 
-  return <ConverterChamadoPageContent />
+  const shellHeight = config.enableImpersonation
+    ? `calc(100dvh - ${CHAMADOS_IMPERSONATION_BAR_HEIGHT})`
+    : '100dvh'
+
+  return (
+    <div
+      className="flex min-h-0 w-full min-w-0 flex-1 flex-col overflow-hidden"
+      style={{ height: shellHeight, maxHeight: shellHeight }}
+    >
+      <ConverterChamadoPageContent />
+    </div>
+  )
 }


### PR DESCRIPTION
## Description

Melhorias no módulo **Demandas**, focadas em **anexos de serviços** na visualização detalhada do ticket e em ajustes de layout na conversão de e-mail.

### Anexos pendentes e renomeação (`/demandas/[ticketId]`)
- Novo utilitário `ticket-pending-attachment.ts` com modelo `PendingServiceAttachment` (id, `File`, nome editável).
- Renomeação de anexos **antes do upload** via diálogo (nome base editável; extensão bloqueada).
- No save dos serviços, ficheiros enviados usam o nome escolhido (`pendingAttachmentAsUploadFile`).
- Refatoração de `ticket-servico-anexos.tsx`: UI de pendentes com botão renomear, diálogo reutilizando estilos de reassign, reorganização da listagem de vídeos/documentos.
- Validade do link de reprodução de vídeo alterada de **120 min** para **7 horas** (`VIDEO_PLAYBACK_EXPIRATION_MINUTES`).
- Removido `text-transform: uppercase` nos nomes de ficheiros na grelha de documentos.

### Aba Serviços
- Fila de pendentes passa de `File[]` para `PendingServiceAttachment[]`.
- **Anexos habilitados também para `reserva_de_imagem`** (antes só `cerco_eletronico` ficava sem anexos).

### Estilos
- Novos estilos `.reassignInput`, `.reassignFilenameRow`, `.reassignFilenameExt` e `.servicoAnexosPendingDocInfo` em `ticket-detail.module.css`.

### Conversor de e-mail (`/demandas/converter`)
- Shell com altura `100dvh` descontando a barra de impersonação quando ativa.
- Ajustes de CSS: `max-height: 100dvh`, footer com `safe-area-inset-bottom`, fundo e espaçamento do rodapé.

## Related Issue
<!--- Colocar link da issue, se houver -->

## Motivation and Context

Operadores precisam **ajustar o nome dos ficheiros** antes de enviar anexos de serviço e ter **links de vídeo mais duradouros**. Serviços do tipo **reserva de imagem** passam a suportar anexos como os demais. A página de conversão de e-mail deixa de quebrar layout com a barra de impersonação e em viewports móveis.

## How has this been tested?

<!--- Descrever testes manuais/automáticos realizados -->

Sugestão de validação manual:
- [ ] Abrir ticket com serviços, anexar ficheiros pendentes, renomear (com e sem extensão) e guardar serviços — confirmar nomes no servidor.
- [ ] Upload de vídeo: barra de progresso e nome exibido corretos.
- [ ] Copiar/atualizar link de reprodução de vídeo — validar expiração ~7h.
- [ ] Serviço **reserva de imagem**: secção de anexos visível e funcional.
- [ ] `/demandas/converter` com `NEXT_PUBLIC_ENABLE_IMPERSONATION=true`: layout sem overflow; footer visível em mobile.
- [ ] Regressão em anexos já persistidos (download, delete, refresh de URL de vídeo).

**Testes automatizados:** nenhum novo neste commit; suite existente não cobre estes ficheiros.

## Screenshots (if appropriate):
<img width="1717" height="1158" alt="image" src="https://github.com/user-attachments/assets/ceb5ee6a-e51e-45a1-b0b9-94acf53be680" />

## Types of changes

- [ ] fix
- [x] feat
- [ ] perf
- [ ] test
- [x] refactor
- [x] style
- [ ] chore
- [ ] docs
- [ ] build
- [ ] ci
- [ ] revert

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.