### PR TITLE
feat: implement GCS upload handling in ticket components, including s…

### DIFF
--- a/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-servicos.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-servicos.tsx
@@ -45,6 +45,11 @@ import {
   ticketServicosToReplacePayload,
 } from '../ticket-servicos-mapper'
 import {
+  isZipFile,
+  resolveGcsUploadContentType,
+  usesGcsSignedUrlUpload,
+} from './ticket-gcs-upload'
+import {
   createPendingServiceAttachments,
   pendingAttachmentAsUploadFile,
   type PendingServiceAttachment,
@@ -309,28 +314,29 @@ export function TicketDetailTabServicos({ ticketId }: Props) {
               continue
             }
 
-            const videoItems = pendingItems.filter((item) =>
-              item.file.type.startsWith('video/'),
+            const gcsItems = pendingItems.filter((item) =>
+              usesGcsSignedUrlUpload(item.file),
             )
-            const nonVideoItems = pendingItems.filter(
-              (item) => !item.file.type.startsWith('video/'),
+            const multipartItems = pendingItems.filter(
+              (item) => !usesGcsSignedUrlUpload(item.file),
             )
 
             try {
-              if (nonVideoItems.length > 0) {
+              if (multipartItems.length > 0) {
                 await uploadTicketServiceAttachmentsMultipart(
                   ticketId,
-                  nonVideoItems.map(pendingAttachmentAsUploadFile),
+                  multipartItems.map(pendingAttachmentAsUploadFile),
                   {
                     service_type: kind,
                     service_id: persistedServiceId,
                   },
                 )
               }
-              for (const item of videoItems) {
+              for (const item of gcsItems) {
                 const file = pendingAttachmentAsUploadFile(item)
-                const contentType = file.type || 'video/mp4'
-                toast.loading(`A enviar vídeo: ${file.name} — 0%`, {
+                const contentType = resolveGcsUploadContentType(file)
+                const uploadKind = isZipFile(file) ? 'ZIP' : 'vídeo'
+                toast.loading(`A enviar ${uploadKind}: ${file.name} — 0%`, {
                   id: SERVICOS_SAVE_VIDEO_TOAST_ID,
                   duration: Infinity,
                 })
@@ -358,7 +364,7 @@ export function TicketDetailTabServicos({ ticketId }: Props) {
                             ? Math.min(100, Math.round((loaded / t) * 100))
                             : 0
                         toast.loading(
-                          `A enviar vídeo: ${file.name} — ${pct}%`,
+                          `A enviar ${uploadKind}: ${file.name} — ${pct}%`,
                           {
                             id: SERVICOS_SAVE_VIDEO_TOAST_ID,
                             duration: Infinity,

--- a/src/app/(app)/demandas/[ticketId]/components/ticket-gcs-upload.ts
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-gcs-upload.ts
@@ -1,0 +1,48 @@
+import type { TicketAttachmentOut } from '@/http/tickets/ticket-attachments'
+
+export const ZIP_MIME_TYPES = [
+  'application/zip',
+  'application/x-zip-compressed',
+] as const
+
+export const DEFAULT_ZIP_CONTENT_TYPE = 'application/zip'
+
+export function isZipFile(file: File): boolean {
+  const t = file.type.toLowerCase()
+  if (ZIP_MIME_TYPES.includes(t as (typeof ZIP_MIME_TYPES)[number])) return true
+  return /\.zip$/i.test(file.name)
+}
+
+export function isVideoFile(file: File): boolean {
+  return file.type.toLowerCase().startsWith('video/')
+}
+
+export function usesGcsSignedUrlUpload(file: File): boolean {
+  return isVideoFile(file) || isZipFile(file)
+}
+
+export function resolveGcsUploadContentType(file: File): string {
+  if (isZipFile(file)) {
+    return file.type || DEFAULT_ZIP_CONTENT_TYPE
+  }
+  return file.type || 'video/mp4'
+}
+
+export function isZipAttachment(att: TicketAttachmentOut): boolean {
+  const ct = (att.content_type ?? '').toLowerCase()
+  if (ZIP_MIME_TYPES.includes(ct as (typeof ZIP_MIME_TYPES)[number]))
+    return true
+  return /\.zip$/i.test(att.filename ?? '')
+}
+
+export function isVideoAttachment(att: TicketAttachmentOut): boolean {
+  return (att.content_type ?? '').toLowerCase().startsWith('video/')
+}
+
+export function usesGcsSignedUrlAttachment(att: TicketAttachmentOut): boolean {
+  return isVideoAttachment(att) || isZipAttachment(att)
+}
+
+export function gcsAttachmentLabel(att: TicketAttachmentOut): string {
+  return isZipAttachment(att) ? 'ZIP' : 'Vídeo'
+}

--- a/src/app/(app)/demandas/[ticketId]/components/ticket-servico-anexos.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-servico-anexos.tsx
@@ -44,6 +44,13 @@ import { isApiError } from '@/lib/api'
 
 import styles from '../ticket-detail.module.css'
 import {
+  gcsAttachmentLabel,
+  isZipFile,
+  resolveGcsUploadContentType,
+  usesGcsSignedUrlAttachment,
+  usesGcsSignedUrlUpload,
+} from './ticket-gcs-upload'
+import {
   getFilenameExtension,
   getPendingAttachmentBaseName,
   normalizePendingFilename,
@@ -54,8 +61,8 @@ import {
 export type { PendingServiceAttachment } from './ticket-pending-attachment'
 
 const MAX_MULTIPART_BYTES = 10 * 1024 * 1024
-const MAX_VIDEO_GB = 20
-const MAX_VIDEO_BYTES = MAX_VIDEO_GB * 1024 * 1024 * 1024
+const MAX_GCS_UPLOAD_GB = 20
+const MAX_GCS_UPLOAD_BYTES = MAX_GCS_UPLOAD_GB * 1024 * 1024 * 1024
 /** Validade do link de reprodução ao atualizar (7 h, em minutos). */
 const VIDEO_PLAYBACK_EXPIRATION_MINUTES = 7 * 60
 
@@ -77,11 +84,8 @@ function formatBytes(bytes: number): string {
   return `${mb.toFixed(1)} MB`
 }
 
-function isVideoAttachment(att: TicketAttachmentOut): boolean {
-  return (att.content_type ?? '').toLowerCase().startsWith('video/')
-}
-
 function multipartFileAllowed(file: File): boolean {
+  if (usesGcsSignedUrlUpload(file)) return false
   if (file.size > MAX_MULTIPART_BYTES) return false
   const t = file.type.toLowerCase()
   if (MULTIPART_ACCEPT.includes(t as (typeof MULTIPART_ACCEPT)[number]))
@@ -252,7 +256,7 @@ export function TicketServicoAnexos({
       })
     },
     mutationFn: async (file: File) => {
-      const contentType = file.type || 'video/mp4'
+      const contentType = resolveGcsUploadContentType(file)
       const scope =
         serviceScope != null
           ? {
@@ -301,10 +305,13 @@ export function TicketServicoAnexos({
         ...scope,
       })
     },
-    onSuccess: () => {
+    onSuccess: (_data, file) => {
       invalidateAttachmentQueries(queryClient, ticketId)
+      const kind = isZipFile(file) ? 'ZIP' : 'Vídeo'
       toast.success(
-        serviceScope ? 'Vídeo anexado ao serviço.' : 'Vídeo anexado à demanda.',
+        serviceScope
+          ? `${kind} anexado ao serviço.`
+          : `${kind} anexado à demanda.`,
       )
       if (uploadRef.current) uploadRef.current.value = ''
     },
@@ -314,7 +321,8 @@ export function TicketServicoAnexos({
         return
       }
       toast.error(
-        getApiDetailUnless500(err) ?? 'Não foi possível enviar o vídeo.',
+        getApiDetailUnless500(err) ??
+          'Não foi possível enviar o ficheiro (vídeo ou ZIP).',
       )
     },
     onSettled: () => {
@@ -399,18 +407,18 @@ export function TicketServicoAnexos({
     [videoPlaybackOverrides],
   )
 
-  /** URL assinada no GCS; validade de 7 h para quem receber o link. */
   const handleCopyVideoLink = useCallback(
     async (att: TicketAttachmentOut) => {
       const playbackUrl = resolvePlaybackUrl(att)
+      const kind = gcsAttachmentLabel(att).toLowerCase()
       if (!playbackUrl) {
-        toast.error('Este vídeo ainda não possui link disponível para cópia.')
+        toast.error(`Este ${kind} ainda não possui link disponível para cópia.`)
         return
       }
       setVideoCopyingId(att.id)
       try {
         await navigator.clipboard.writeText(playbackUrl)
-        toast.success('Link do vídeo copiado.')
+        toast.success(`Link do ${kind} copiado.`)
       } catch {
         toast.error(
           'Não foi possível copiar o link. Verifique a permissão da área de transferência ou tente de novo.',
@@ -439,11 +447,13 @@ export function TicketServicoAnexos({
           ...prev,
           [att.id]: { signedUrl, expiresAt },
         }))
-        toast.success('Link do vídeo atualizado.')
+        toast.success(
+          `Link do ${gcsAttachmentLabel(att).toLowerCase()} atualizado.`,
+        )
       } catch (err) {
         toast.error(
           getApiDetailUnless500(err) ??
-            'Não foi possível atualizar o link do vídeo.',
+            'Não foi possível atualizar o link do anexo.',
         )
       } finally {
         setVideoRefreshingId(null)
@@ -458,42 +468,46 @@ export function TicketServicoAnexos({
       if (!list?.length) return
       const files = Array.from(list)
 
-      const videoFiles = files.filter((f) => f.type.startsWith('video/'))
-      const nonVideoFiles = files.filter((f) => !f.type.startsWith('video/'))
+      const gcsFiles = files.filter(usesGcsSignedUrlUpload)
+      const otherFiles = files.filter((f) => !usesGcsSignedUrlUpload(f))
 
-      if (videoFiles.length > 0 && nonVideoFiles.length > 0) {
+      if (gcsFiles.length > 0 && otherFiles.length > 0) {
         toast.error(
-          'Envie vídeos separados dos demais anexos para usar o endpoint correto.',
+          'Envie vídeos ou ZIP separados dos demais anexos para usar o endpoint correto.',
         )
         e.target.value = ''
         return
       }
 
-      if (videoFiles.length > 0) {
-        const videoFile = videoFiles[0]
-        if (videoFiles.length > 1) {
-          toast.error('Envie apenas um vídeo por vez.')
+      if (gcsFiles.length > 0) {
+        const gcsFile = gcsFiles[0]
+        if (gcsFiles.length > 1) {
+          toast.error('Envie apenas um vídeo ou ZIP por vez.')
           e.target.value = ''
           return
         }
-        if (videoFile.size > MAX_VIDEO_BYTES) {
-          toast.error(`O vídeo excede o limite de ${MAX_VIDEO_GB} GB.`)
+        if (gcsFile.size > MAX_GCS_UPLOAD_BYTES) {
+          const label = isZipFile(gcsFile) ? 'O ZIP' : 'O vídeo'
+          toast.error(`${label} excede o limite de ${MAX_GCS_UPLOAD_GB} GB.`)
           e.target.value = ''
           return
         }
         if (uploadBlocked && onQueuePendingFiles) {
-          onQueuePendingFiles(videoFiles)
-          toast.success('Vídeo adicionado. Será enviado após guardar serviços.')
+          onQueuePendingFiles(gcsFiles)
+          const pendingLabel = isZipFile(gcsFile) ? 'ZIP' : 'Vídeo'
+          toast.success(
+            `${pendingLabel} adicionado. Será enviado após guardar serviços.`,
+          )
           e.target.value = ''
           return
         }
-        videoMutation.mutate(videoFile)
+        videoMutation.mutate(gcsFile)
         e.target.value = ''
         return
       }
 
-      const bad = nonVideoFiles.filter((f) => !multipartFileAllowed(f))
-      if (bad.length || nonVideoFiles.length === 0) {
+      const bad = otherFiles.filter((f) => !multipartFileAllowed(f))
+      if (bad.length || otherFiles.length === 0) {
         toast.error(
           'Só PDF, imagens (JPEG, PNG, GIF, WebP) ou Word, até 10 MB cada.',
         )
@@ -510,7 +524,7 @@ export function TicketServicoAnexos({
         return
       }
 
-      multipartMutation.mutate(nonVideoFiles)
+      multipartMutation.mutate(otherFiles)
       e.target.value = ''
     },
     [multipartMutation, onQueuePendingFiles, uploadBlocked, videoMutation],
@@ -523,10 +537,10 @@ export function TicketServicoAnexos({
 
   const canUpload =
     !readOnly && !busy && (!uploadBlocked || !!onQueuePendingFiles)
-  const nonVideoAttachments = attachments.filter(
-    (att) => !isVideoAttachment(att),
+  const multipartAttachments = attachments.filter(
+    (att) => !usesGcsSignedUrlAttachment(att),
   )
-  const videoAttachments = attachments.filter((att) => isVideoAttachment(att))
+  const gcsUploadAttachments = attachments.filter(usesGcsSignedUrlAttachment)
 
   const renameLockedExtension = renameDialog
     ? getFilenameExtension(renameDialog.item.file.name)
@@ -544,7 +558,7 @@ export function TicketServicoAnexos({
                 type="file"
                 className={styles.servicoAnexosFileInput}
                 multiple
-                accept="video/*,.pdf,.jpg,.jpeg,.png,.gif,.webp,.doc,.docx"
+                accept="video/*,.zip,application/zip,.pdf,.jpg,.jpeg,.png,.gif,.webp,.doc,.docx"
                 onChange={onPickUpload}
                 aria-hidden
                 tabIndex={-1}
@@ -587,7 +601,7 @@ export function TicketServicoAnexos({
               <span className={styles.servicoAnexosUploadProgressLabel}>
                 {videoUploadUi.phase === 'preparing' && 'A preparar envio…'}
                 {videoUploadUi.phase === 'uploading' &&
-                  `A enviar vídeo — ${videoUploadUi.percent}%`}
+                  `A enviar — ${videoUploadUi.percent}%`}
                 {videoUploadUi.phase === 'finalizing' &&
                   'A concluir no servidor…'}
               </span>
@@ -689,9 +703,9 @@ export function TicketServicoAnexos({
           <p className={styles.servicoAnexosEmpty}>Nenhum anexo.</p>
         ) : (
           <div className={styles.servicoAnexosList}>
-            {nonVideoAttachments.length > 0 ? (
+            {multipartAttachments.length > 0 ? (
               <div className={styles.docGrid}>
-                {nonVideoAttachments.map((att) => {
+                {multipartAttachments.map((att) => {
                   return (
                     <div key={att.id} className={styles.docCard}>
                       <div className={styles.docCardLeft}>
@@ -763,9 +777,9 @@ export function TicketServicoAnexos({
               </div>
             ) : null}
 
-            {videoAttachments.length > 0 ? (
+            {gcsUploadAttachments.length > 0 ? (
               <div className={styles.videoList}>
-                {videoAttachments.map((att) => {
+                {gcsUploadAttachments.map((att) => {
                   const playbackUrl = resolvePlaybackUrl(att)
                   const expiresAt = resolvePlaybackExpiresAt(att)
                   const expiresDate = expiresAt ? new Date(expiresAt) : null
@@ -775,10 +789,11 @@ export function TicketServicoAnexos({
                   const expiryText = expiresAt
                     ? `${isExpired ? 'Expirado em' : 'Expira em'} ${formatPlaybackExpiry(expiresAt)}`
                     : 'Expiração não informada'
-                  const displayName = att.filename?.trim() || 'Vídeo'
+                  const kindLabel = gcsAttachmentLabel(att)
+                  const displayName = att.filename?.trim() || kindLabel
                   return (
                     <div key={att.id} className={styles.videoRow}>
-                      <p className={styles.videoLabel}>Vídeo</p>
+                      <p className={styles.videoLabel}>{kindLabel}</p>
                       <div className={styles.videoActionsRow}>
                         <div
                           className={styles.videoUrlBox}
@@ -789,7 +804,7 @@ export function TicketServicoAnexos({
                         <button
                           type="button"
                           className={styles.servicoAnexosIconButton}
-                          aria-label={`Copiar link do vídeo ${displayName}`}
+                          aria-label={`Copiar link do ${kindLabel.toLowerCase()} ${displayName}`}
                           title={
                             playbackUrl
                               ? 'Copiar link'
@@ -815,7 +830,7 @@ export function TicketServicoAnexos({
                         <button
                           type="button"
                           className={styles.servicoAnexosIconButton}
-                          aria-label={`Atualizar link do vídeo ${att.filename}`}
+                          aria-label={`Atualizar link do ${kindLabel.toLowerCase()} ${att.filename}`}
                           title="Atualizar link"
                           onClick={() => {
                             handleRefreshVideoLink(att).catch(() => {})
@@ -915,7 +930,9 @@ export function TicketServicoAnexos({
                 </div>
               </div>
             </div>
-            <DialogFooter className={styles.footerActions}>
+            <DialogFooter
+              className={`${styles.footerActions} ${styles.footerActionsCentered}`}
+            >
               <button
                 type="button"
                 className={`${styles.footerBtn} ${styles.footerBtnDefault}`}


### PR DESCRIPTION
## Description

Consolidation of the **Demandas** (tickets/demands) module with full ticket detail view, GCS uploads, screen-level permissions, and impersonation.

### Routes (`/chamados` → `/demandas`)
- Migration of listing, create, inbox, email-to-ticket conversion, answered, spam, teams, profiles, workflow, screen permissions, and **archived** pages.
- Sidebar gated by `NEXT_PUBLIC_ENABLE_CHAMADOS`; layout with impersonation bar when `NEXT_PUBLIC_ENABLE_IMPERSONATION=true`.

### Ticket detail view (`/demandas/[ticketId]`)
- Tabs: Ticket, Requester, Services, Documents, History, Internal opinion, Demand report, Response (conditional).
- Workflow actions, reassignment (comment + priority), rich text editor, date picker, report modal/configurable topics.
- Expanded services forms, per-service attachments, integration with fragmented APIs (header, record, requester, response, logs, etc.).

### GCS upload
- Signed URLs for video, multipart upload, ZIP support, upload progress UI, rename pending attachments, download/preview.

### Permissions and impersonation
- Screen/action-level permissions; `/demandas/permissoes-telas` admin page; permission gate → `/forbidden`.
- Impersonation (bar, context, local storage, API query param) scoped to `/demandas` paths only.

### Other
- Archived demands page with advanced filters.
- **Assessor** role in teams; profile CRUD updates.
- Expanded HTTP layer (reassign, archive, workflow, attachments, etc.).
- Map/radar tweaks, test updates, and CI (`cloudbuild-staging`: impersonation flag, Docker context prune).

**Branch:** `feat/view-ticket` → `staging`  
**Scope:** 59 commits · 222 files

## Related Issue

<!-- Add issue link if applicable -->

## Motivation and Context

Deliver end-to-end ticket operations beyond list/create flows, aligned with a domain-split backend, with per-role screen access and impersonation for testing and operations. The **Demandas** route namespace and feature flags allow gradual rollout.

## How has this been tested?

- [ ] `/demandas/[id]`: all tabs, edit flows, workflow, reassignment
- [ ] Attachment upload (file, GCS video, ZIP) and progress feedback
- [ ] Impersonation with `NEXT_PUBLIC_ENABLE_IMPERSONATION=true`
- [ ] User without permission → `/forbidden`
- [ ] `/demandas/arquivados`, inbox, convert, create, teams, profiles, workflow
- [ ] Sidebar hidden when `NEXT_PUBLIC_ENABLE_CHAMADOS=false`
- [ ] Map/radar tests and staging CI build

**Staging env:** `NEXT_PUBLIC_ENABLE_CHAMADOS=true`, `NEXT_PUBLIC_ENABLE_IMPERSONATION=true`

## Screenshots (if appropriate):

<!-- Ticket detail, impersonation bar, archived list -->

## Types of changes

- [x] fix: used when there is correction of errors that are generating bugs in the system.
- [x] feat: indicates the development of a new feature for the project.
- [ ] perf: indicates a change that improved system performance.
- [x] test: indicates any type of creation or change of test codes.
- [x] refactor: used when there is a code refactoring that does not have any type of impact on the system's business logic/rules.
- [ ] style: used when there are formatting and code style changes that do not alter the system in any way.
- [x] chore: indicates changes to the project that do not affect the system or test files.
- [ ] docs: used when there are changes to the project documentation.
- [x] build: used to indicate changes that affect the project's build process or external dependencies.
- [ ] ci: used for changes to CI configuration files.
- [ ] revert: indicates the revert of a previous commit

## Checklist:

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.