### PR TITLE
feat: add notFound handling for pages based on config.enableChamados …

### DIFF
--- a/src/app/(app)/demandas/equipes/page.tsx
+++ b/src/app/(app)/demandas/equipes/page.tsx
@@ -2,7 +2,10 @@
 
 import './equipes.css'
 
+import { notFound } from 'next/navigation'
+
 import { Spinner } from '@/components/custom/spinner'
+import { config } from '@/config'
 import { useTicketScreenPermissionGate } from '@/hooks/useTicketScreenPermissionGate'
 
 import { TeamsDialogs } from './components/teams-dialogs'
@@ -27,6 +30,10 @@ function EquipesPageContent() {
 }
 
 export default function EquipesPage() {
+  if (!config.enableChamados) {
+    notFound()
+  }
+
   const { allowed, resolved } = useTicketScreenPermissionGate(TEAMS_SCREEN_CODE)
 
   if (!resolved || !allowed) {

--- a/src/app/(app)/demandas/perfis/page.tsx
+++ b/src/app/(app)/demandas/perfis/page.tsx
@@ -1,8 +1,10 @@
 'use client'
 
+import { notFound } from 'next/navigation'
 import { useState } from 'react'
 
 import { Spinner } from '@/components/custom/spinner'
+import { config } from '@/config'
 import { useDisclosure } from '@/hooks/use-disclosure'
 import { useTicketScreenPermissionGate } from '@/hooks/useTicketScreenPermissionGate'
 import type { UserRoleListItem } from '@/http/user-roles/get-users-with-roles'
@@ -41,6 +43,10 @@ function CadastroPerfilPageContent() {
 }
 
 export default function CadastroPerfilPage() {
+  if (!config.enableChamados) {
+    notFound()
+  }
+
   const { allowed, resolved } =
     useTicketScreenPermissionGate(PROFILE_SCREEN_CODE)
 

--- a/src/app/(app)/demandas/permissoes-telas/page.tsx
+++ b/src/app/(app)/demandas/permissoes-telas/page.tsx
@@ -2,6 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { RefreshCw } from 'lucide-react'
+import { notFound } from 'next/navigation'
 import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 
@@ -16,6 +17,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
+import { config } from '@/config'
 import { useTicketScreenPermissionGate } from '@/hooks/useTicketScreenPermissionGate'
 import {
   getTicketModulePermissionsByRole,
@@ -274,6 +276,10 @@ function TicketModulePermissionsByRolePageContent() {
 }
 
 export default function TicketModulePermissionsByRolePage() {
+  if (!config.enableChamados) {
+    notFound()
+  }
+
   const { allowed, resolved } = useTicketScreenPermissionGate(
     SCREEN_PERMISSIONS_SCREEN_CODE,
   )

--- a/src/app/(app)/demandas/workflow/page.tsx
+++ b/src/app/(app)/demandas/workflow/page.tsx
@@ -2,6 +2,7 @@
 
 import { useMutation, useQuery } from '@tanstack/react-query'
 import { Plus, RefreshCw, Trash2 } from 'lucide-react'
+import { notFound } from 'next/navigation'
 import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 
@@ -26,6 +27,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { config } from '@/config'
 import { useTicketScreenPermissionGate } from '@/hooks/useTicketScreenPermissionGate'
 import { getTicketTypes } from '@/http/ticket-types/get-ticket.types'
 import {
@@ -643,6 +645,10 @@ function WorkflowRolesPageContent() {
 }
 
 export default function WorkflowRolesPage() {
+  if (!config.enableChamados) {
+    notFound()
+  }
+
   const { allowed, resolved } =
     useTicketScreenPermissionGate(WORKFLOW_SCREEN_CODE)
 


### PR DESCRIPTION
## Description

Aligns four Demandas admin routes with the global Chamados feature flag (`NEXT_PUBLIC_ENABLE_CHAMADOS` → `config.enableChamados`).

Each affected page now calls `notFound()` when the flag is disabled, **before** the per-screen permission gate (`useTicketScreenPermissionGate`):

    if (!config.enableChamados) {
      notFound()
    }

**Routes updated:**

| Route | File |
|-------|------|
| `/demandas/workflow` | `src/app/(app)/demandas/workflow/page.tsx` |
| `/demandas/equipes` | `src/app/(app)/demandas/equipes/page.tsx` |
| `/demandas/perfis` | `src/app/(app)/demandas/perfis/page.tsx` |
| `/demandas/permissoes-telas` | `src/app/(app)/demandas/permissoes-telas/page.tsx` |

**Commit:** `c666c6d` — feat: add notFound handling for pages based on config.enableChamados to improve user navigation and access control  
**Branch:** `feat/view-ticket`  
**Scope:** 4 files changed, 25 insertions

## Related Issue

N/A — closes a gap in feature-flag coverage; no linked issue.

## Motivation and Context

The Demandas module uses two access layers:

1. **Global feature flag** — enables or disables the entire Chamados module per environment.
2. **Screen permissions** — restricts access by role via `ticketScreenCode` / `useTicketScreenPermissionGate`.

These four pages only had layer (2). With `enableChamados=false`, the sidebar already hid Demandas, but direct URLs could still load content (or the permission spinner). Other routes (e.g. archived, create, inbox, list, ticket detail) already used `notFound()` when the flag was off. This change makes behavior consistent across all Demandas `page.tsx` entry points without changing business rules or role permissions.

## How has this been tested?

- [ ] Set `NEXT_PUBLIC_ENABLE_CHAMADOS=false` and open directly:
  - `/demandas/workflow`
  - `/demandas/equipes`
  - `/demandas/perfis`
  - `/demandas/permissoes-telas`  
  → Expect Next.js **404** (`notFound()`).
- [ ] Set `NEXT_PUBLIC_ENABLE_CHAMADOS=true` and confirm the same routes still work for users with `can_view` on the matching screen code (`workflow`, `teams`, `profile`, `screen_permissions`).
- [ ] Smoke-check routes that were already guarded (e.g. `/demandas/arquivados`, `/demandas/criar`) for regressions.

## Screenshots (if appropriate):

N/A — behavioral change only (404 vs. page content).

## Types of changes

- [x] fix: used when there is correction of errors that are generating bugs in the system.
- [ ] feat: indicates the development of a new feature for the project.
- [ ] perf: indicates a change that improved system performance.
- [ ] test: indicates any type of creation or change of test codes.
- [ ] refactor: used when there is a code refactoring that does not have any type of impact on the system's business logic/rules.
- [ ] style: used when there are formatting and code style changes that do not alter the system in any way.
- [ ] chore: indicates changes to the project that do not affect the system or test files.
- [ ] docs: used when there are changes to the project documentation.
- [ ] build: used to indicate changes that affect the project's build process or external dependencies.
- [ ] ci: used for changes to CI configuration files.
- [ ] revert: indicates the revert of a previous commit

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
