### PR TITLE
This branch adds three main areas to the **Demandas** module, plus ticket detail improvements:

### DIFF
--- a/src/app/(app)/components/sidebar/components/constants.ts
+++ b/src/app/(app)/components/sidebar/components/constants.ts
@@ -112,6 +112,12 @@ const demandasItem: Category = {
       path: '/demandas/dashboard/sla',
       ticketScreenCode: 'sla_config',
     },
+    {
+      icon: 'BarChart2',
+      title: 'Dashboard Tático',
+      path: '/demandas/dashboard-tatico/volume',
+      ticketScreenCode: 'tactical_dashboard',
+    },
   ],
 }
 

--- a/src/app/(app)/components/sidebar/components/constants.ts
+++ b/src/app/(app)/components/sidebar/components/constants.ts
@@ -54,6 +54,7 @@ const demandasItem: Category = {
       icon: 'CalendarClock',
       title: 'Fechamentos',
       path: '/demandas/fechamentos',
+      ticketScreenCode: 'shift_closing',
     },
     {
       icon: 'CirclePlus',
@@ -104,6 +105,12 @@ const demandasItem: Category = {
       title: 'Permissões Telas',
       path: '/demandas/permissoes-telas',
       ticketScreenCode: 'screen_permissions',
+    },
+    {
+      icon: 'Gauge',
+      title: 'Dashboard SLA',
+      path: '/demandas/dashboard/sla',
+      ticketScreenCode: 'sla_config',
     },
   ],
 }

--- a/src/app/(app)/demandas/dashboard-tatico/components/dashboard-tatico-tabs.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/components/dashboard-tatico-tabs.tsx
@@ -1,0 +1,47 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+import styles from '../../dashboard/dashboard-tabs.module.css'
+
+const TABS = [
+  {
+    href: '/demandas/dashboard-tatico/volume',
+    label: 'Volume de Demandas',
+  },
+  {
+    href: '/demandas/dashboard-tatico/metricas',
+    label: 'Métricas de Resposta',
+  },
+  {
+    href: '/demandas/dashboard-tatico/visao-operacional',
+    label: 'Visão Operacional',
+  },
+] as const
+
+export function DashboardTaticoTabs() {
+  const pathname = usePathname()
+
+  return (
+    <nav
+      className={styles.tabs}
+      style={{ marginTop: '24px' }}
+      aria-label="Dashboard Tático"
+    >
+      {TABS.map((tab) => {
+        const isActive = pathname.startsWith(tab.href)
+        return (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            className={`${styles.tab} ${isActive ? styles.tabActive : ''}`}
+            aria-current={isActive ? 'page' : undefined}
+          >
+            {tab.label}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/constants.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/constants.ts
@@ -1,0 +1,1 @@
+export const TACTICAL_DASHBOARD_SCREEN_CODE = 'tactical_dashboard'

--- a/src/app/(app)/demandas/dashboard-tatico/layout.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/layout.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { notFound } from 'next/navigation'
+
+import { Spinner } from '@/components/custom/spinner'
+import { config } from '@/config'
+import { useTicketScreenPermissionGate } from '@/hooks/useTicketScreenPermissionGate'
+
+import { DashboardTaticoTabs } from './components/dashboard-tatico-tabs'
+import { TACTICAL_DASHBOARD_SCREEN_CODE } from './constants'
+
+export default function DashboardTaticoLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  if (!config.enableChamados) {
+    notFound()
+  }
+
+  const { allowed, resolved } = useTicketScreenPermissionGate(
+    TACTICAL_DASHBOARD_SCREEN_CODE,
+  )
+
+  if (!resolved || !allowed) {
+    return (
+      <div
+        className="flex min-h-[240px] items-center justify-center"
+        style={{ backgroundColor: '#0c161f' }}
+      >
+        <Spinner />
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className="page-content overflow-y-scroll pb-24"
+      style={{ backgroundColor: '#0c161f' }}
+    >
+      <div className="content px-10 pb-10 pt-6">
+        <div>
+          <h1
+            className="text-xl font-semibold"
+            style={{ color: '#f9fafa', lineHeight: '40px' }}
+          >
+            Dashboard Tático
+          </h1>
+          <p className="text-xs" style={{ color: '#97a2ab' }}>
+            Dashboard de métricas e indicadores de desempenho
+          </p>
+          <DashboardTaticoTabs />
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/page.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function DashboardTaticoPage() {
+  redirect('/demandas/dashboard-tatico/volume')
+}

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-chart-granularity.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-chart-granularity.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import type { DemandVolumeGranularity } from '@/http/tickets/get-demand-volume'
+
+import styles from './demand-volume-top.module.css'
+
+const GRANULARITY_OPTIONS: {
+  value: DemandVolumeGranularity
+  label: string
+}[] = [
+  { value: 'monthly', label: 'Mensal' },
+  { value: 'weekly', label: 'Semanal' },
+  { value: 'yearly', label: 'Anual' },
+]
+
+interface DemandVolumeChartGranularityProps {
+  value: DemandVolumeGranularity
+  onChange: (value: DemandVolumeGranularity) => void
+  disabled?: boolean
+}
+
+export function DemandVolumeChartGranularity({
+  value,
+  onChange,
+  disabled,
+}: DemandVolumeChartGranularityProps) {
+  return (
+    <div className={styles.pageSelectWrapCompact}>
+      <Select
+        value={value}
+        disabled={disabled}
+        onValueChange={(v) => onChange(v as DemandVolumeGranularity)}
+      >
+        <SelectTrigger
+          className={`h-11 w-full ${styles.pageSelectTrigger}`}
+          aria-label="Agrupamento do gráfico"
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent className={styles.selectContentForm}>
+          {GRANULARITY_OPTIONS.map((opt) => (
+            <SelectItem
+              key={opt.value}
+              value={opt.value}
+              className={styles.selectItemForm}
+            >
+              {opt.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-date-range.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-date-range.ts
@@ -1,0 +1,39 @@
+export function parseDemandVolumeDate(s: string | undefined): Date | undefined {
+  if (!s?.trim()) return undefined
+  const trimmed = s.trim()
+  const datePart = trimmed.includes('T') ? trimmed.slice(0, 10) : trimmed
+  const [year, month, day] = datePart.split('-').map(Number)
+  if (!year || !month || !day) return undefined
+  const d = new Date(year, month - 1, day)
+  return Number.isNaN(d.getTime()) ? undefined : d
+}
+
+export function toDemandVolumeDateString(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+export function compareDemandVolumeDates(a: string, b: string): number {
+  const dateA = parseDemandVolumeDate(a)
+  const dateB = parseDemandVolumeDate(b)
+  if (!dateA || !dateB) return 0
+  return dateA.getTime() - dateB.getTime()
+}
+
+/** Garante dateFrom <= dateTo; ajusta o campo oposto quando o usuário viola o intervalo. */
+export function normalizeDemandVolumeDateRange(
+  dateFrom: string,
+  dateTo: string,
+  changed: 'from' | 'to',
+): { dateFrom: string; dateTo: string } {
+  if (!dateFrom || !dateTo) return { dateFrom, dateTo }
+  if (compareDemandVolumeDates(dateFrom, dateTo) <= 0) {
+    return { dateFrom, dateTo }
+  }
+  if (changed === 'from') {
+    return { dateFrom, dateTo: dateFrom }
+  }
+  return { dateFrom: dateTo, dateTo }
+}

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-export-dialog.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-export-dialog.tsx
@@ -1,0 +1,180 @@
+'use client'
+
+import { format } from 'date-fns'
+import { Download, FileSpreadsheet, Upload } from 'lucide-react'
+import { useCallback, useState } from 'react'
+import { toast } from 'sonner'
+
+import { Spinner } from '@/components/custom/spinner'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import {
+  type DemandVolumeFilterIn,
+  getDemandVolumeTickets,
+} from '@/http/tickets/get-demand-volume'
+import { dateConfig } from '@/lib/date-config'
+import { downloadFile } from '@/utils/download-file'
+import { getApiErrorMessage } from '@/utils/error-handlers'
+
+import {
+  buildDemandVolumeTicketsCsv,
+  demandVolumeTicketsExportFilename,
+} from './demand-volume-export'
+import { formatDemandVolumeAdvancedFiltersSummary } from './demand-volume-filter-utils'
+import styles from './demand-volume-top.module.css'
+
+interface DemandVolumeExportDialogProps {
+  appliedFilters: DemandVolumeFilterIn
+  disabled?: boolean
+}
+
+function formatBrDate(iso: string | undefined): string {
+  if (!iso?.trim()) return '—'
+  const [y, m, d] = iso.split('-').map(Number)
+  if (!y || !m || !d) return iso
+  const date = new Date(y, m - 1, d)
+  return format(date, dateConfig.formats.date, { locale: dateConfig.locale })
+}
+
+export function DemandVolumeExportDialog({
+  appliedFilters,
+  disabled,
+}: DemandVolumeExportDialogProps) {
+  const [open, setOpen] = useState(false)
+  const [isExporting, setIsExporting] = useState(false)
+
+  const advancedFilterLines =
+    formatDemandVolumeAdvancedFiltersSummary(appliedFilters)
+
+  const handleExport = useCallback(async () => {
+    setIsExporting(true)
+    try {
+      const { items } = await getDemandVolumeTickets(appliedFilters)
+      if (items.length === 0) {
+        toast.message('Nenhum chamado para exportar com os filtros atuais.')
+        return
+      }
+      const exportedAt = new Date()
+      const csv = buildDemandVolumeTicketsCsv(items)
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+      downloadFile(blob, demandVolumeTicketsExportFilename(exportedAt))
+      toast.success(`Exportação concluída (${items.length} linhas).`)
+      setOpen(false)
+    } catch (error) {
+      toast.error(getApiErrorMessage(error))
+    } finally {
+      setIsExporting(false)
+    }
+  }, [appliedFilters])
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className={styles.iconButton}
+          aria-label="Exportar chamados"
+          title="Exportar"
+          disabled={disabled}
+        >
+          <Upload className="h-5 w-5" />
+        </button>
+      </DialogTrigger>
+      <DialogContent
+        className="border-[#4a5d6d] bg-[#101d28] text-[#f9fafa] sm:max-w-md"
+        style={{ maxWidth: '440px' }}
+      >
+        <DialogHeader>
+          <DialogTitle className="text-[#f9fafa]">
+            Exportar chamados
+          </DialogTitle>
+          <DialogDescription className="text-[#97a2ab]">
+            Gera um arquivo CSV com a lista de chamados do período e filtros
+            aplicados, pronto para abrir no Excel ou Google Planilhas.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div
+          className="flex flex-col gap-3 rounded-lg border border-[#4a5d6d] bg-[#152534] p-4 text-sm"
+          role="region"
+          aria-label="Parâmetros da exportação"
+        >
+          <div className="flex items-start gap-3">
+            <FileSpreadsheet
+              className="mt-0.5 h-5 w-5 shrink-0 text-[#06b2bb]"
+              aria-hidden
+            />
+            <div className="min-w-0 space-y-2">
+              <p className="font-medium text-[#f9fafa]">Conteúdo incluído</p>
+              <ul className="list-inside list-disc space-y-1 text-[#97a2ab]">
+                <li>Nº interno, data, status e prioridade</li>
+                <li>Demandante, operação e tipo de chamado</li>
+                <li>Natureza, equipe e chamado pai (quando houver)</li>
+              </ul>
+            </div>
+          </div>
+
+          <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 border-t border-[#1d3449] pt-3 text-[13px]">
+            <dt className="text-[#97a2ab]">Período da busca</dt>
+            <dd className="text-[#f9fafa]">
+              {formatBrDate(appliedFilters.date_from)} —{' '}
+              {formatBrDate(appliedFilters.date_to)}
+            </dd>
+            {advancedFilterLines.length > 0 ? (
+              <>
+                <dt className="text-[#97a2ab]">Filtros</dt>
+                <dd className="text-[#f9fafa]">
+                  <ul className="list-inside list-disc space-y-0.5">
+                    {advancedFilterLines.map((line) => (
+                      <li key={line}>{line}</li>
+                    ))}
+                  </ul>
+                </dd>
+              </>
+            ) : null}
+          </dl>
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            className="border-[#4a5d6d] bg-transparent text-[#f9fafa] hover:bg-[#1d3449]"
+            onClick={() => setOpen(false)}
+            disabled={isExporting}
+          >
+            Cancelar
+          </Button>
+          <Button
+            type="button"
+            className="gap-2 bg-[#1d3449] text-[#f9fafa] hover:bg-[#254a66]"
+            onClick={() => {
+              handleExport()
+            }}
+            disabled={isExporting}
+          >
+            {isExporting ? (
+              <>
+                <Spinner className="h-4 w-4" />
+                Exportando…
+              </>
+            ) : (
+              <>
+                <Download className="h-4 w-4" />
+                Baixar CSV
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-export.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-export.ts
@@ -1,0 +1,81 @@
+import { format } from 'date-fns'
+
+import type { DemandVolumeTicketItemOut } from '@/http/tickets/get-demand-volume'
+
+type FlatRow = Record<string, string | number | boolean>
+
+function escapeCsvCell(value: string | number | boolean): string {
+  const text = String(value)
+  const needsQuotes = /[",\n\r]/.test(text)
+  const escaped = text.replace(/"/g, '""')
+  return needsQuotes ? `"${escaped}"` : escaped
+}
+
+function csvRow(cells: (string | number | boolean)[]): string {
+  return cells.map(escapeCsvCell).join(',')
+}
+
+function flattenTicketItem(item: DemandVolumeTicketItemOut): FlatRow {
+  const row: FlatRow = {}
+
+  for (const [key, value] of Object.entries(item)) {
+    if (value === null || value === undefined) {
+      row[key] = ''
+      continue
+    }
+
+    if (typeof value === 'object') {
+      for (const [nestedKey, nestedValue] of Object.entries(value)) {
+        const column = `${key}.${nestedKey}`
+        row[column] =
+          nestedValue === null || nestedValue === undefined ? '' : nestedValue
+      }
+      continue
+    }
+
+    row[key] = value
+  }
+
+  return row
+}
+
+function resolveColumns(rows: FlatRow[]): string[] {
+  const ordered: string[] = []
+  const seen = new Set<string>()
+
+  const addKeys = (keys: string[]) => {
+    for (const key of keys) {
+      if (!seen.has(key)) {
+        seen.add(key)
+        ordered.push(key)
+      }
+    }
+  }
+
+  if (rows[0]) addKeys(Object.keys(rows[0]))
+  for (const row of rows) addKeys(Object.keys(row))
+
+  return ordered
+}
+
+export function buildDemandVolumeTicketsCsv(
+  items: DemandVolumeTicketItemOut[],
+): string {
+  if (items.length === 0) return '\uFEFF'
+
+  const rows = items.map(flattenTicketItem)
+  const columns = resolveColumns(rows)
+  const header = csvRow(columns)
+  const body = rows
+    .map((row) => csvRow(columns.map((col) => row[col] ?? '')))
+    .join('\r\n')
+
+  return `\uFEFF${header}\r\n${body}`
+}
+
+export function demandVolumeTicketsExportFilename(
+  exportedAt = new Date(),
+): string {
+  const stamp = format(exportedAt, 'yyyy-MM-dd')
+  return `dashboard-tatico-volume-chamados-${stamp}.csv`
+}

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-filter-modal.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-filter-modal.tsx
@@ -1,0 +1,371 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { ChevronDown, X } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import filterModalStyles from '@/app/(app)/demandas/list/components/filter/tickets-general-list-filters.module.css'
+import { Button } from '@/components/ui/button'
+import { getTicketTypes } from '@/http/ticket-types/get-ticket.types'
+import {
+  type SearchOption,
+  searchRequesters,
+} from '@/http/tickets/tickets-dashboard-filters'
+
+import {
+  DEMAND_VOLUME_PRIORITY_OPTIONS,
+  DEMAND_VOLUME_STATUS_OPTIONS,
+  type DemandVolumeAdvancedFilterForm,
+  type DemandVolumePressFilter,
+  emptyDemandVolumeAdvancedFilters,
+} from './demand-volume-filter-utils'
+
+function useDebouncedValue<T>(value: T, delay = 400) {
+  const [debouncedValue, setDebouncedValue] = useState(value)
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedValue(value)
+    }, delay)
+    return () => window.clearTimeout(timeout)
+  }, [value, delay])
+
+  return debouncedValue
+}
+
+function SearchMultiSelect({
+  label,
+  placeholder = 'Selecione',
+  value,
+  onChange,
+  searchFn,
+  staticOptions,
+  optionsLoading,
+  minCharsMessage = 'Digite ao menos 2 caracteres',
+}: {
+  label: string
+  placeholder?: string
+  value: SearchOption[]
+  onChange: (value: SearchOption[]) => void
+  searchFn?: (search: string) => Promise<SearchOption[]>
+  staticOptions?: SearchOption[]
+  optionsLoading?: boolean
+  minCharsMessage?: string
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [search, setSearch] = useState('')
+  const [isOpen, setIsOpen] = useState(false)
+  const debouncedSearch = useDebouncedValue(search, 350)
+
+  const { data, isFetching } = useQuery({
+    queryKey: ['demand-volume-filter-search', label, debouncedSearch],
+    queryFn: () => searchFn!(debouncedSearch),
+    enabled:
+      isOpen &&
+      !staticOptions &&
+      Boolean(searchFn) &&
+      debouncedSearch.trim().length >= 2,
+    staleTime: 1000 * 60 * 5,
+  })
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!containerRef.current) return
+      if (!containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  const selectedValues = useMemo(
+    () => new Set(value.map((item) => item.value)),
+    [value],
+  )
+
+  const staticFiltered = useMemo(() => {
+    if (!staticOptions) return []
+    const q = debouncedSearch.trim().toLowerCase()
+    return staticOptions.filter(
+      (item) =>
+        !selectedValues.has(item.value) &&
+        (q === '' ||
+          item.label.toLowerCase().includes(q) ||
+          item.value.toLowerCase().includes(q)),
+    )
+  }, [staticOptions, debouncedSearch, selectedValues])
+
+  const options = useMemo(() => {
+    if (staticOptions) return staticFiltered
+    return (data ?? []).filter((item) => !selectedValues.has(item.value))
+  }, [staticOptions, staticFiltered, data, selectedValues])
+
+  const removeItem = (itemValue: string) => {
+    onChange(value.filter((item) => item.value !== itemValue))
+  }
+
+  const addItem = (item: SearchOption) => {
+    onChange([...value, item])
+    setSearch('')
+  }
+
+  return (
+    <div className={filterModalStyles.filterBlock} ref={containerRef}>
+      <span className={filterModalStyles.filterLabel}>{label}</span>
+
+      <div className={filterModalStyles.multiSelectBox}>
+        <div className={filterModalStyles.multiSelectInputWrapper}>
+          <input
+            value={search}
+            onFocus={() => setIsOpen(true)}
+            onChange={(event) => {
+              setSearch(event.target.value)
+              setIsOpen(true)
+            }}
+            placeholder={value.length > 0 ? '' : placeholder}
+            className={filterModalStyles.multiSelectInput}
+          />
+          <ChevronDown
+            className={filterModalStyles.multiSelectChevron}
+            size={16}
+          />
+          {isOpen ? (
+            <div className={filterModalStyles.multiSelectDropdown}>
+              {optionsLoading ? (
+                <div className={filterModalStyles.dropdownHint}>
+                  Buscando...
+                </div>
+              ) : !staticOptions && debouncedSearch.trim().length < 2 ? (
+                <div className={filterModalStyles.dropdownHint}>
+                  {minCharsMessage}
+                </div>
+              ) : isFetching ? (
+                <div className={filterModalStyles.dropdownHint}>
+                  Buscando...
+                </div>
+              ) : options.length === 0 ? (
+                <div className={filterModalStyles.dropdownHint}>
+                  Nenhum resultado encontrado
+                </div>
+              ) : (
+                options.map((item) => (
+                  <button
+                    key={item.value}
+                    type="button"
+                    className={filterModalStyles.dropdownOption}
+                    onClick={() => addItem(item)}
+                  >
+                    {item.label}
+                  </button>
+                ))
+              )}
+            </div>
+          ) : null}
+        </div>
+
+        {value.length > 0 ? (
+          <div className={filterModalStyles.selectedChips}>
+            {value.map((item) => (
+              <span key={item.value} className={filterModalStyles.selectedChip}>
+                {item.label}
+                <button
+                  type="button"
+                  className={filterModalStyles.selectedChipRemove}
+                  onClick={() => removeItem(item.value)}
+                >
+                  <X size={12} />
+                </button>
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function PressRelevanceField({
+  value,
+  onChange,
+}: {
+  value: DemandVolumePressFilter
+  onChange: (value: DemandVolumePressFilter) => void
+}) {
+  const options: { value: DemandVolumePressFilter; label: string }[] = [
+    { value: 'all', label: 'Todos' },
+    { value: 'yes', label: 'Sim' },
+    { value: 'no', label: 'Não' },
+  ]
+
+  return (
+    <div className={filterModalStyles.filterBlock}>
+      <span className={filterModalStyles.filterLabel}>
+        RELEVANTE PARA IMPRENSA?
+      </span>
+      <div
+        className={`${filterModalStyles.toggleGrid} ${filterModalStyles.toggleGridLastFull}`}
+      >
+        {options.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            className={`${filterModalStyles.toggleButton} ${
+              value === option.value ? filterModalStyles.toggleButtonActive : ''
+            }`}
+            onClick={() => onChange(option.value)}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export type DemandVolumeFilterModalProps = {
+  isOpen: boolean
+  onClose: () => void
+  filters: DemandVolumeAdvancedFilterForm
+  onApply: (filters: DemandVolumeAdvancedFilterForm) => void
+}
+
+export function DemandVolumeFilterModal({
+  isOpen,
+  onClose,
+  filters,
+  onApply,
+}: DemandVolumeFilterModalProps) {
+  const [draftFilters, setDraftFilters] =
+    useState<DemandVolumeAdvancedFilterForm>(filters)
+
+  useEffect(() => {
+    if (isOpen) {
+      setDraftFilters(filters)
+    }
+  }, [isOpen, filters])
+
+  const { data: ticketTypeOptions, isFetching: isTicketTypesLoading } =
+    useQuery({
+      queryKey: ['ticket-types', 'demand-volume-filter'],
+      queryFn: async () => {
+        const response = await getTicketTypes({ isActive: true })
+        return (response.data ?? []).map((item) => ({
+          value: item.id,
+          label: item.name,
+        }))
+      },
+      enabled: isOpen,
+      staleTime: 1000 * 60 * 5,
+    })
+
+  const handleApply = () => {
+    onApply(draftFilters)
+    onClose()
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <div className={filterModalStyles.filterModalOverlay}>
+      <div className={filterModalStyles.filterModal}>
+        <div className={filterModalStyles.filterModalHeader}>
+          <div className={filterModalStyles.filterModalTitle} />
+          <button
+            type="button"
+            className={filterModalStyles.filterModalClose}
+            onClick={onClose}
+            aria-label="Fechar filtros"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className={filterModalStyles.filterModalBody}>
+          <div className={filterModalStyles.filterGrid}>
+            <SearchMultiSelect
+              label="REQUISITANTE"
+              value={draftFilters.requisitante}
+              onChange={(value) =>
+                setDraftFilters((current) => ({
+                  ...current,
+                  requisitante: value,
+                }))
+              }
+              searchFn={searchRequesters}
+            />
+
+            <SearchMultiSelect
+              label="URGÊNCIA"
+              placeholder="Selecione"
+              value={draftFilters.prioridade}
+              onChange={(value) =>
+                setDraftFilters((current) => ({
+                  ...current,
+                  prioridade: value,
+                }))
+              }
+              staticOptions={DEMAND_VOLUME_PRIORITY_OPTIONS}
+            />
+
+            <SearchMultiSelect
+              label="STATUS DO CHAMADO"
+              placeholder="Selecione"
+              value={draftFilters.status}
+              onChange={(value) =>
+                setDraftFilters((current) => ({
+                  ...current,
+                  status: value,
+                }))
+              }
+              staticOptions={DEMAND_VOLUME_STATUS_OPTIONS}
+            />
+
+            <SearchMultiSelect
+              label="TIPO DE CHAMADO"
+              placeholder="Selecione"
+              value={draftFilters.tipo_chamado_id}
+              onChange={(value) =>
+                setDraftFilters((current) => ({
+                  ...current,
+                  tipo_chamado_id: value,
+                }))
+              }
+              staticOptions={ticketTypeOptions ?? []}
+              optionsLoading={isTicketTypesLoading}
+            />
+          </div>
+
+          <div className={filterModalStyles.filterTogglesGrid}>
+            <PressRelevanceField
+              value={draftFilters.relevanteImprensa}
+              onChange={(relevanteImprensa) =>
+                setDraftFilters((current) => ({
+                  ...current,
+                  relevanteImprensa,
+                }))
+              }
+            />
+          </div>
+        </div>
+
+        <div className={filterModalStyles.filterModalFooter}>
+          <Button
+            type="button"
+            className={filterModalStyles.filterSecondaryButton}
+            onClick={() => setDraftFilters(emptyDemandVolumeAdvancedFilters())}
+          >
+            Limpar Filtro
+          </Button>
+          <Button
+            type="button"
+            className={filterModalStyles.filterPrimaryButton}
+            onClick={handleApply}
+          >
+            Salvar
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-filter-utils.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-filter-utils.ts
@@ -1,0 +1,190 @@
+import type {
+  DemandVolumeFilterIn,
+  TicketPriority,
+  TicketStatus,
+} from '@/http/tickets/get-demand-volume'
+import type { SearchOption } from '@/http/tickets/tickets-dashboard-filters'
+
+export type DemandVolumePressFilter = 'all' | 'yes' | 'no'
+
+export type DemandVolumeAdvancedFilterForm = {
+  requisitante: SearchOption[]
+  prioridade: SearchOption[]
+  status: SearchOption[]
+  tipo_chamado_id: SearchOption[]
+  relevanteImprensa: DemandVolumePressFilter
+}
+
+export const DEMAND_VOLUME_PRIORITY_OPTIONS: SearchOption[] = [
+  { value: 'URGENTE', label: 'Urgente' },
+  { value: 'ALTA', label: 'Alta' },
+  { value: 'ROTINA', label: 'Rotina' },
+]
+
+export const DEMAND_VOLUME_STATUS_OPTIONS: SearchOption[] = [
+  { value: 'PENDENTE', label: 'Pendente' },
+  { value: 'RESTRITO', label: 'Restrito' },
+  { value: 'BLOQUEADO', label: 'Bloqueado' },
+  { value: 'AGUARDANDO_REVISAO', label: 'Aguardando revisão' },
+  { value: 'CONCLUIDO', label: 'Concluído' },
+]
+
+const priorityLabelByValue = new Map(
+  DEMAND_VOLUME_PRIORITY_OPTIONS.map((o) => [o.value, o.label]),
+)
+const statusLabelByValue = new Map(
+  DEMAND_VOLUME_STATUS_OPTIONS.map((o) => [o.value, o.label]),
+)
+
+export function emptyDemandVolumeAdvancedFilters(): DemandVolumeAdvancedFilterForm {
+  return {
+    requisitante: [],
+    prioridade: [],
+    status: [],
+    tipo_chamado_id: [],
+    relevanteImprensa: 'all',
+  }
+}
+
+export function countDemandVolumeAdvancedFilters(
+  form: DemandVolumeAdvancedFilterForm,
+): number {
+  let count = 0
+  count += form.requisitante.length
+  count += form.prioridade.length
+  count += form.status.length
+  count += form.tipo_chamado_id.length
+  if (form.relevanteImprensa !== 'all') count += 1
+  return count
+}
+
+export function countDemandVolumeAdvancedFiltersFromApi(
+  filters: DemandVolumeFilterIn,
+): number {
+  let count = 0
+  count += filters.requisitante?.length ?? 0
+  count += filters.prioridade?.length ?? 0
+  count += filters.status?.length ?? 0
+  count += filters.tipo_chamado_id?.length ?? 0
+  if (
+    filters.relevante_imprensa === true ||
+    filters.relevante_imprensa === false
+  ) {
+    count += 1
+  }
+  return count
+}
+
+function toSearchOptions(
+  values: string[] | undefined,
+  labelMap: Map<string, string>,
+): SearchOption[] {
+  if (!values?.length) return []
+  return values.map((value) => ({
+    value,
+    label: labelMap.get(value) ?? value,
+  }))
+}
+
+export function advancedFiltersFromApi(
+  filters: DemandVolumeFilterIn,
+): DemandVolumeAdvancedFilterForm {
+  let relevanteImprensa: DemandVolumePressFilter = 'all'
+  if (filters.relevante_imprensa === true) relevanteImprensa = 'yes'
+  if (filters.relevante_imprensa === false) relevanteImprensa = 'no'
+
+  return {
+    requisitante: (filters.requisitante ?? []).map((value) => ({
+      value,
+      label: value,
+    })),
+    prioridade: toSearchOptions(
+      filters.prioridade,
+      priorityLabelByValue,
+    ) as SearchOption[],
+    status: toSearchOptions(
+      filters.status,
+      statusLabelByValue,
+    ) as SearchOption[],
+    tipo_chamado_id: (filters.tipo_chamado_id ?? []).map((value) => ({
+      value,
+      label: value,
+    })),
+    relevanteImprensa,
+  }
+}
+
+export function advancedFiltersToApiPatch(
+  form: DemandVolumeAdvancedFilterForm,
+): Pick<
+  DemandVolumeFilterIn,
+  | 'requisitante'
+  | 'prioridade'
+  | 'status'
+  | 'tipo_chamado_id'
+  | 'relevante_imprensa'
+> {
+  return {
+    requisitante: form.requisitante.length
+      ? form.requisitante.map((item) => item.value)
+      : undefined,
+    prioridade: form.prioridade.length
+      ? (form.prioridade.map((item) => item.value) as TicketPriority[])
+      : undefined,
+    status: form.status.length
+      ? (form.status.map((item) => item.value) as TicketStatus[])
+      : undefined,
+    tipo_chamado_id: form.tipo_chamado_id.length
+      ? form.tipo_chamado_id.map((item) => item.value)
+      : undefined,
+    relevante_imprensa:
+      form.relevanteImprensa === 'yes'
+        ? true
+        : form.relevanteImprensa === 'no'
+          ? false
+          : undefined,
+  }
+}
+
+export function stripAdvancedFiltersFromApi(
+  filters: DemandVolumeFilterIn,
+): DemandVolumeFilterIn {
+  const rest = { ...filters }
+  delete rest.requisitante
+  delete rest.prioridade
+  delete rest.status
+  delete rest.tipo_chamado_id
+  delete rest.relevante_imprensa
+  return rest
+}
+
+export function formatDemandVolumeAdvancedFiltersSummary(
+  filters: DemandVolumeFilterIn,
+): string[] {
+  const lines: string[] = []
+  if (filters.requisitante?.length) {
+    lines.push(`Requisitante: ${filters.requisitante.join(', ')}`)
+  }
+  if (filters.prioridade?.length) {
+    const labels = filters.prioridade.map(
+      (p) => priorityLabelByValue.get(p) ?? p,
+    )
+    lines.push(`Urgência: ${labels.join(', ')}`)
+  }
+  if (filters.status?.length) {
+    const labels = filters.status.map((s) => statusLabelByValue.get(s) ?? s)
+    lines.push(`Status: ${labels.join(', ')}`)
+  }
+  if (filters.tipo_chamado_id?.length) {
+    lines.push(
+      `Tipo de chamado: ${filters.tipo_chamado_id.length} selecionado(s)`,
+    )
+  }
+  if (filters.relevante_imprensa === true) {
+    lines.push('Relevante para imprensa: Sim')
+  }
+  if (filters.relevante_imprensa === false) {
+    lines.push('Relevante para imprensa: Não')
+  }
+  return lines
+}

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-filters.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-filters.tsx
@@ -1,0 +1,199 @@
+'use client'
+
+import { format } from 'date-fns'
+import { CalendarIcon, Filter } from 'lucide-react'
+import { useMemo, useState } from 'react'
+
+import { Calendar } from '@/components/ui/calendar'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import type { DemandVolumeFilterIn } from '@/http/tickets/get-demand-volume'
+import { dateConfig } from '@/lib/date-config'
+
+import {
+  parseDemandVolumeDate,
+  toDemandVolumeDateString,
+} from './demand-volume-date-range'
+import { DemandVolumeExportDialog } from './demand-volume-export-dialog'
+import { DemandVolumeFilterModal } from './demand-volume-filter-modal'
+import {
+  advancedFiltersFromApi,
+  countDemandVolumeAdvancedFiltersFromApi,
+  type DemandVolumeAdvancedFilterForm,
+} from './demand-volume-filter-utils'
+import styles from './demand-volume-top.module.css'
+
+interface DemandVolumeFiltersProps {
+  dateFrom: string
+  dateTo: string
+  onDateFromChange: (dateFrom: string) => void
+  onDateToChange: (dateTo: string) => void
+  isLoading: boolean
+  appliedFilters: DemandVolumeFilterIn
+  onApplyAdvancedFilters: (filters: DemandVolumeAdvancedFilterForm) => void
+}
+
+function formatTrigger(d: Date | undefined): string | null {
+  if (!d) return null
+  return format(d, dateConfig.formats.date, { locale: dateConfig.locale })
+}
+
+function DateField({
+  value,
+  placeholder,
+  ariaLabel,
+  onChange,
+  disabled,
+  minDate,
+  maxDate,
+}: {
+  value: string
+  placeholder: string
+  ariaLabel: string
+  onChange: (value: string) => void
+  disabled?: boolean
+  minDate?: Date
+  maxDate?: Date
+}) {
+  const [open, setOpen] = useState(false)
+  const date = useMemo(() => parseDemandVolumeDate(value), [value])
+
+  return (
+    <div className={styles.dateFieldWrap}>
+      <Popover
+        open={disabled ? false : open}
+        onOpenChange={(o) => {
+          if (!disabled) setOpen(o)
+        }}
+      >
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className={styles.dateTrigger}
+            disabled={disabled}
+            aria-label={ariaLabel}
+          >
+            {formatTrigger(date) ? (
+              <span className={styles.dateTriggerValue}>
+                {formatTrigger(date)}
+              </span>
+            ) : (
+              <span className={styles.dateTriggerPlaceholder}>
+                {placeholder}
+              </span>
+            )}
+            <CalendarIcon className="h-5 w-5 shrink-0 opacity-50" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          className="z-[100] w-auto p-0"
+          align="start"
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          onCloseAutoFocus={(e) => e.preventDefault()}
+        >
+          <Calendar
+            mode="single"
+            selected={date}
+            onSelect={(d) => {
+              if (!d) return
+              onChange(toDemandVolumeDateString(d))
+              setOpen(false)
+            }}
+            disabled={(d) => {
+              if (minDate && d < minDate) return true
+              if (maxDate && d > maxDate) return true
+              return false
+            }}
+            locale={dateConfig.locale}
+            defaultMonth={date ?? minDate ?? maxDate ?? new Date()}
+            initialFocus
+            className="rounded-lg border"
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}
+
+export function DemandVolumeFilters({
+  dateFrom,
+  dateTo,
+  onDateFromChange,
+  onDateToChange,
+  isLoading,
+  appliedFilters,
+  onApplyAdvancedFilters,
+}: DemandVolumeFiltersProps) {
+  const [isFilterModalOpen, setIsFilterModalOpen] = useState(false)
+  const startDate = useMemo(() => parseDemandVolumeDate(dateFrom), [dateFrom])
+  const endDate = useMemo(() => parseDemandVolumeDate(dateTo), [dateTo])
+  const activeAdvancedCount = useMemo(
+    () => countDemandVolumeAdvancedFiltersFromApi(appliedFilters),
+    [appliedFilters],
+  )
+  const advancedFiltersForm = useMemo(
+    () => advancedFiltersFromApi(appliedFilters),
+    [appliedFilters],
+  )
+
+  return (
+    <div className={styles.periodBar}>
+      <div className={styles.periodBarLabelBlock}>
+        <p className={styles.periodBarLabel}>Período da Busca</p>
+        <div className={styles.dateFieldsRow}>
+          <DateField
+            value={dateFrom}
+            placeholder="dd/mm/aaaa"
+            ariaLabel="Data inicial do período"
+            onChange={onDateFromChange}
+            disabled={isLoading}
+            maxDate={endDate}
+          />
+          <DateField
+            value={dateTo}
+            placeholder="dd/mm/aaaa"
+            ariaLabel="Data final do período"
+            onChange={onDateToChange}
+            disabled={isLoading}
+            minDate={startDate}
+          />
+        </div>
+      </div>
+
+      <div className={styles.periodBarActions}>
+        <div className={styles.filterButtonWrap}>
+          <button
+            type="button"
+            className={styles.iconButton}
+            aria-label="Filtrar dados"
+            title="Filtrar"
+            disabled={isLoading}
+            onClick={() => setIsFilterModalOpen(true)}
+          >
+            <Filter className="h-5 w-5" />
+          </button>
+          {activeAdvancedCount > 0 ? (
+            <span className={styles.filterBadge} aria-hidden>
+              {activeAdvancedCount}
+            </span>
+          ) : null}
+        </div>
+
+        <DemandVolumeExportDialog
+          appliedFilters={appliedFilters}
+          disabled={isLoading}
+        />
+      </div>
+
+      <DemandVolumeFilterModal
+        isOpen={isFilterModalOpen}
+        onClose={() => setIsFilterModalOpen(false)}
+        filters={advancedFiltersForm}
+        onApply={onApplyAdvancedFilters}
+      />
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-matrix-table.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-matrix-table.tsx
@@ -1,0 +1,280 @@
+'use client'
+
+import type {
+  DemandVolumeGranularity,
+  MatrixRowOut,
+} from '@/http/tickets/get-demand-volume'
+
+import { formatPeriodLabel } from './demand-volume-period-label'
+
+interface DemandVolumeMatrixTableProps {
+  title: string
+  columnHeader: string
+  rows: MatrixRowOut[]
+  periodLabels: string[]
+  isLoading: boolean
+}
+
+/** Tabelas usam agrupamento fixo (mensal) definido pelo backend. */
+const MATRIX_GRANULARITY: DemandVolumeGranularity = 'monthly'
+
+type CellVariant = 'above' | 'below' | 'neutral'
+
+function getCellVariant(
+  count: number,
+  average: number | null | undefined,
+): CellVariant {
+  if (count === 0) return 'neutral'
+  if (average == null || Number.isNaN(average)) return 'neutral'
+  if (count > average) return 'above'
+  if (count < average) return 'below'
+  return 'neutral'
+}
+
+const CELL_STYLES: Record<CellVariant, React.CSSProperties> = {
+  above: {
+    backgroundColor: 'rgba(185, 61, 82, 0.25)',
+    color: '#f9a7b3',
+    fontWeight: 600,
+  },
+  below: {
+    backgroundColor: 'rgba(6, 178, 187, 0.15)',
+    color: '#06b2bb',
+    fontWeight: 600,
+  },
+  neutral: {
+    backgroundColor: 'transparent',
+    color: '#f9fafa',
+    fontWeight: 400,
+  },
+}
+
+const HEADER_CELL: React.CSSProperties = {
+  padding: '10px 12px',
+  fontSize: '11px',
+  fontWeight: 600,
+  color: '#97a2ab',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+  whiteSpace: 'nowrap',
+  borderBottom: '1px solid #1d3449',
+  textAlign: 'center',
+}
+
+const ROW_LABEL_CELL: React.CSSProperties = {
+  padding: '10px 12px',
+  fontSize: '13px',
+  color: '#f9fafa',
+  whiteSpace: 'nowrap',
+  borderBottom: '1px solid #1d3449',
+  textAlign: 'left',
+  position: 'sticky',
+  left: 0,
+  backgroundColor: '#101d28',
+  zIndex: 1,
+}
+
+const DATA_CELL_BASE: React.CSSProperties = {
+  padding: '8px 12px',
+  fontSize: '13px',
+  textAlign: 'center',
+  borderBottom: '1px solid #1d3449',
+  borderRadius: '4px',
+  minWidth: '52px',
+}
+
+const TOTAL_CELL: React.CSSProperties = {
+  padding: '10px 12px',
+  fontSize: '13px',
+  fontWeight: 600,
+  color: '#f9fafa',
+  textAlign: 'center',
+  borderBottom: '1px solid #1d3449',
+  borderLeft: '1px solid #1d3449',
+  whiteSpace: 'nowrap',
+}
+
+export function DemandVolumeMatrixTable({
+  title,
+  columnHeader,
+  rows,
+  periodLabels,
+  isLoading,
+}: DemandVolumeMatrixTableProps) {
+  const formattedHeaders = periodLabels.map((pl) =>
+    formatPeriodLabel(pl, MATRIX_GRANULARITY),
+  )
+
+  return (
+    <div
+      style={{
+        backgroundColor: '#101d28',
+        border: '1px solid #4a5d6d',
+        borderRadius: '8px',
+        padding: '24px',
+      }}
+    >
+      <h2
+        style={{
+          fontSize: '20px',
+          fontWeight: 600,
+          color: '#f9fafa',
+          margin: '0 0 20px 0',
+        }}
+      >
+        {title}
+      </h2>
+
+      {isLoading && rows.length === 0 ? (
+        <div
+          style={{
+            height: '120px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: '#97a2ab',
+            fontSize: '14px',
+          }}
+        >
+          Carregando…
+        </div>
+      ) : rows.length === 0 ? (
+        <div
+          style={{
+            height: '80px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: '#97a2ab',
+            fontSize: '14px',
+          }}
+        >
+          Nenhum dado disponível
+        </div>
+      ) : (
+        <>
+          <div style={{ overflowX: 'auto' }}>
+            <table
+              style={{
+                width: '100%',
+                borderCollapse: 'separate',
+                borderSpacing: 0,
+              }}
+            >
+              <thead>
+                <tr>
+                  <th
+                    style={{
+                      ...HEADER_CELL,
+                      textAlign: 'left',
+                      position: 'sticky',
+                      left: 0,
+                      backgroundColor: '#101d28',
+                      zIndex: 2,
+                      minWidth: '160px',
+                    }}
+                  >
+                    {columnHeader}
+                  </th>
+                  {formattedHeaders.map((h, i) => (
+                    <th key={i} style={HEADER_CELL}>
+                      {h}
+                    </th>
+                  ))}
+                  <th
+                    style={{
+                      ...HEADER_CELL,
+                      borderLeft: '1px solid #1d3449',
+                    }}
+                  >
+                    Total
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.label}>
+                    <td style={ROW_LABEL_CELL}>{row.label}</td>
+                    {row.periods.map((period) => {
+                      const variant = getCellVariant(
+                        period.count,
+                        period.average,
+                      )
+                      return (
+                        <td
+                          key={period.period_label}
+                          style={{
+                            ...DATA_CELL_BASE,
+                            ...CELL_STYLES[variant],
+                          }}
+                        >
+                          {period.count === 0 ? (
+                            <span style={{ opacity: 0.3 }}>—</span>
+                          ) : (
+                            period.count
+                          )}
+                        </td>
+                      )
+                    })}
+                    <td style={TOTAL_CELL}>
+                      {row.total.toLocaleString('pt-BR')}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: '24px',
+              marginTop: '16px',
+              paddingTop: '12px',
+              borderTop: '1px solid #1d3449',
+            }}
+          >
+            <LegendItem
+              color="#f9a7b3"
+              bg="rgba(185, 61, 82, 0.25)"
+              label="Acima da média"
+            />
+            <LegendItem
+              color="#06b2bb"
+              bg="rgba(6, 178, 187, 0.15)"
+              label="Abaixo da média"
+            />
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+function LegendItem({
+  color,
+  bg,
+  label,
+}: {
+  color: string
+  bg: string
+  label: string
+}) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+      <span
+        style={{
+          display: 'inline-block',
+          width: '32px',
+          height: '16px',
+          backgroundColor: bg,
+          borderRadius: '4px',
+          border: `1px solid ${color}`,
+        }}
+      />
+      <span style={{ fontSize: '12px', color: '#97a2ab' }}>{label}</span>
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-media-chart.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-media-chart.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+
+import type {
+  DemandVolumeGranularity,
+  PeriodValueItemOut,
+} from '@/http/tickets/get-demand-volume'
+
+import { DemandVolumeChartGranularity } from './demand-volume-chart-granularity'
+import { formatPeriodLabel } from './demand-volume-period-label'
+import styles from './demand-volume-top.module.css'
+
+interface DemandVolumeMediaChartProps {
+  data: PeriodValueItemOut[]
+  granularity: DemandVolumeGranularity
+  onGranularityChange: (granularity: DemandVolumeGranularity) => void
+  isLoading: boolean
+}
+
+const CHART_COLORS = {
+  line: '#22c1f1',
+  grid: '#1d3449',
+  axis: '#97a2ab',
+  tooltip: { bg: '#101d28', border: '#4a5d6d', text: '#f9fafa' },
+}
+
+export function DemandVolumeMediaChart({
+  data,
+  granularity,
+  onGranularityChange,
+  isLoading,
+}: DemandVolumeMediaChartProps) {
+  const chartData = data.map((item) => ({
+    ...item,
+    label: formatPeriodLabel(item.period_label, granularity),
+  }))
+
+  return (
+    <div
+      style={{
+        backgroundColor: '#101d28',
+        border: '1px solid #4a5d6d',
+        borderRadius: '8px',
+        padding: '24px',
+      }}
+    >
+      <div className={styles.chartHeaderRow}>
+        <h2
+          style={{
+            fontSize: '20px',
+            fontWeight: 600,
+            color: '#f9fafa',
+            margin: 0,
+          }}
+        >
+          Relevância na Mídia
+        </h2>
+        <DemandVolumeChartGranularity
+          value={granularity}
+          onChange={onGranularityChange}
+          disabled={isLoading}
+        />
+      </div>
+
+      {isLoading && chartData.length === 0 ? (
+        <div
+          style={{
+            height: '280px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: '#97a2ab',
+            fontSize: '14px',
+          }}
+        >
+          Carregando…
+        </div>
+      ) : (
+        <ResponsiveContainer width="100%" height={280}>
+          <LineChart
+            data={chartData}
+            margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+          >
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke={CHART_COLORS.grid}
+              vertical={false}
+            />
+            <XAxis
+              dataKey="label"
+              tick={{ fill: CHART_COLORS.axis, fontSize: 12 }}
+              axisLine={false}
+              tickLine={false}
+              tickMargin={8}
+            />
+            <YAxis
+              tick={{ fill: CHART_COLORS.axis, fontSize: 12 }}
+              axisLine={false}
+              tickLine={false}
+              width={40}
+            />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: CHART_COLORS.tooltip.bg,
+                border: `1px solid ${CHART_COLORS.tooltip.border}`,
+                borderRadius: '8px',
+                color: CHART_COLORS.tooltip.text,
+                fontSize: '12px',
+              }}
+              itemStyle={{ color: CHART_COLORS.tooltip.text }}
+              labelStyle={{
+                color: CHART_COLORS.tooltip.text,
+                fontWeight: 600,
+                marginBottom: '4px',
+              }}
+            />
+            <Legend
+              wrapperStyle={{ paddingTop: '24px', fontSize: '12px' }}
+              formatter={(value) => (
+                <span style={{ color: '#97a2ab' }}>{value}</span>
+              )}
+            />
+            <Line
+              type="monotone"
+              dataKey="count"
+              name="Relevância na Mídia"
+              stroke={CHART_COLORS.line}
+              strokeWidth={2}
+              dot={false}
+              activeDot={{ r: 4, strokeWidth: 0 }}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-period-label.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-period-label.ts
@@ -1,0 +1,43 @@
+import type { DemandVolumeGranularity } from '@/http/tickets/get-demand-volume'
+
+const MONTH_ABBR = [
+  'Jan',
+  'Fev',
+  'Mar',
+  'Abr',
+  'Mai',
+  'Jun',
+  'Jul',
+  'Ago',
+  'Set',
+  'Out',
+  'Nov',
+  'Dez',
+]
+
+export function formatPeriodLabel(
+  label: string,
+  granularity: DemandVolumeGranularity,
+): string {
+  if (granularity === 'monthly') {
+    // "2026-03" → "Mar/26"
+    const [year, month] = label.split('-')
+    const monthIdx = parseInt(month, 10) - 1
+    const abbr = MONTH_ABBR[monthIdx] ?? label
+    return `${abbr}/${year?.slice(2)}`
+  }
+
+  if (granularity === 'weekly') {
+    // "2026-W12" → "Sem. 12"
+    const match = label.match(/W(\d+)$/)
+    if (match) return `Sem. ${match[1]}`
+    return label
+  }
+
+  if (granularity === 'yearly') {
+    // "2026" → "2026"
+    return label
+  }
+
+  return label
+}

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-period-presets.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-period-presets.ts
@@ -1,0 +1,41 @@
+import type {
+  DemandVolumeFilterIn,
+  DemandVolumeSummaryPeriod,
+} from '@/http/tickets/get-demand-volume'
+
+export type { DemandVolumeSummaryPeriod }
+
+export const SUMMARY_PERIOD_OPTIONS: {
+  value: DemandVolumeSummaryPeriod
+  label: string
+}[] = [
+  { value: 'current_year', label: 'Ano atual' },
+  { value: 'current_month', label: 'Mês atual' },
+  { value: 'current_week', label: 'Semana atual' },
+]
+
+function toDateString(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+/** Período padrão dos gráficos/tabelas: 1º de janeiro do ano corrente → hoje. */
+export function getDefaultChartDateRange(): Pick<
+  DemandVolumeFilterIn,
+  'date_from' | 'date_to'
+> {
+  const now = new Date()
+  return {
+    date_from: `${now.getFullYear()}-01-01`,
+    date_to: toDateString(now),
+  }
+}
+
+export function createDefaultDemandVolumeFilters(): DemandVolumeFilterIn {
+  return {
+    summary_period: 'current_year',
+    ...getDefaultChartDateRange(),
+  }
+}

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-summary-cards.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-summary-cards.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import type {
+  DemandVolumeSummaryOut,
+  DemandVolumeSummaryPeriod,
+} from '@/http/tickets/get-demand-volume'
+
+import { SUMMARY_PERIOD_OPTIONS } from './demand-volume-period-presets'
+import styles from './demand-volume-top.module.css'
+
+interface DemandVolumeSummaryCardsProps {
+  summary: DemandVolumeSummaryOut | undefined
+  isLoading: boolean
+  summaryPeriod: DemandVolumeSummaryPeriod
+  onSummaryPeriodChange: (period: DemandVolumeSummaryPeriod) => void
+}
+
+interface SummaryCardProps {
+  label: string
+  sublabel: string
+  value: number | undefined
+  isLoading: boolean
+}
+
+function SummaryCard({ label, sublabel, value, isLoading }: SummaryCardProps) {
+  return (
+    <div className={styles.summaryCard}>
+      <p className={styles.summaryCardLabel}>{label}</p>
+      <p className={styles.summaryCardValue}>
+        {isLoading ? (
+          <span style={{ opacity: 0.4 }}>—</span>
+        ) : (
+          (value?.toLocaleString('pt-BR') ?? '—')
+        )}
+      </p>
+      <p className={styles.summaryCardSublabel}>{sublabel}</p>
+    </div>
+  )
+}
+
+export function DemandVolumeSummaryCards({
+  summary,
+  isLoading,
+  summaryPeriod,
+  onSummaryPeriodChange,
+}: DemandVolumeSummaryCardsProps) {
+  return (
+    <section className={styles.summarySection} aria-label="Resumo de demandas">
+      <div className={styles.summaryHeader}>
+        <div className={styles.pageSelectWrapWide}>
+          <Select
+            value={summaryPeriod}
+            onValueChange={(value) =>
+              onSummaryPeriodChange(value as DemandVolumeSummaryPeriod)
+            }
+          >
+            <SelectTrigger
+              className={`h-11 w-full ${styles.pageSelectTrigger}`}
+              aria-label="Período do resumo"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent className={styles.selectContentForm}>
+              {SUMMARY_PERIOD_OPTIONS.map((opt) => (
+                <SelectItem
+                  key={opt.value}
+                  value={opt.value}
+                  className={styles.selectItemForm}
+                >
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <div className={styles.summaryCardsRow}>
+        <SummaryCard
+          label="Total de Demandas"
+          sublabel="no período selecionado"
+          value={summary?.total}
+          isLoading={isLoading}
+        />
+        <SummaryCard
+          label="Em aberto"
+          sublabel="em todas as equipes"
+          value={summary?.open}
+          isLoading={isLoading}
+        />
+        <SummaryCard
+          label="Bloqueadas"
+          sublabel="aguardando informação"
+          value={summary?.blocked}
+          isLoading={isLoading}
+        />
+      </div>
+    </section>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-top.module.css
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-top.module.css
@@ -1,0 +1,238 @@
+.summarySection {
+  background-color: #152534;
+  border: 1px solid #4a5d6d;
+  border-radius: 8px;
+  padding: 20px 24px 24px;
+}
+
+.summaryHeader {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 16px;
+}
+
+/* Selects da página — mesmo padrão de demandas/criar (.inputBg + dropdown) */
+.pageSelectWrapWide {
+  min-width: 140px;
+}
+
+.pageSelectWrapCompact {
+  min-width: 120px;
+}
+
+.pageSelectTrigger {
+  background-color: #152534;
+  border: 1px solid #4a5d6d;
+  border-radius: 8px;
+  min-height: 44px;
+  color: #97a2ab;
+  font-size: 14px;
+  font-weight: 400;
+}
+
+.pageSelectTrigger:hover:not(:disabled) {
+  border-color: #507290;
+}
+
+.pageSelectTrigger:focus {
+  border-color: #507290;
+  outline: none;
+  box-shadow: none;
+}
+
+.pageSelectTrigger:focus-visible {
+  outline: 2px solid rgba(80, 114, 144, 0.45);
+  outline-offset: 0;
+  box-shadow: none;
+}
+
+.selectContentForm {
+  background: #101d28 !important;
+  border: 1px solid #4a5d6d !important;
+  color: #f9fafa !important;
+}
+
+.selectItemForm {
+  color: #f9fafa !important;
+}
+
+.selectItemForm:hover,
+.selectItemForm:focus,
+.selectItemForm[data-highlighted] {
+  background: #18344d !important;
+  color: #f9fafa !important;
+}
+
+.selectItemForm[data-state='checked'] {
+  background: #18344d !important;
+  color: #f9fafa !important;
+}
+
+.summaryCardsRow {
+  display: flex;
+  gap: 16px;
+}
+
+.summaryCard {
+  flex: 1;
+  min-width: 0;
+  background-color: #101d28;
+  border: 1px solid #4a5d6d;
+  border-radius: 8px;
+  padding: 24px;
+}
+
+.summaryCardLabel {
+  font-size: 12px;
+  color: #97a2ab;
+  margin: 0 0 8px;
+}
+
+.summaryCardValue {
+  font-size: 28px;
+  font-weight: 600;
+  color: #f9fafa;
+  line-height: 40px;
+  margin: 0 0 4px;
+}
+
+.summaryCardSublabel {
+  font-size: 12px;
+  color: #97a2ab;
+  margin: 0;
+}
+
+.periodBar {
+  display: flex;
+  align-items: flex-end;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.periodBarLabelBlock {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  flex: 1;
+  min-width: 280px;
+}
+
+.periodBarLabel {
+  font-size: 12px;
+  font-weight: 600;
+  color: #f9fafa;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+.dateFieldsRow {
+  display: flex;
+  gap: 16px;
+  flex: 1;
+  min-width: 0;
+}
+
+.dateFieldWrap {
+  flex: 1;
+  min-width: 200px;
+  max-width: 320px;
+}
+
+.dateTrigger {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  min-height: 52px;
+  padding: 0 16px;
+  border: 1px solid #4a5d6d;
+  border-radius: 8px;
+  background-color: #101d28;
+  color: #97a2ab;
+  font-size: 16px;
+  font-weight: 400;
+  cursor: pointer;
+  outline: none;
+  text-align: left;
+}
+
+.dateTrigger:hover {
+  border-color: #6a7d8d;
+}
+
+.dateTriggerValue {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: #f9fafa;
+}
+
+.dateTriggerPlaceholder {
+  flex: 1;
+  min-width: 0;
+  color: #97a2ab;
+}
+
+.iconButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 52px;
+  height: 52px;
+  flex-shrink: 0;
+  border: none;
+  border-radius: 8px;
+  background-color: #1d3449;
+  color: #f9fafa;
+  cursor: pointer;
+  transition: background-color 0.15s ease;
+}
+
+.iconButton:hover:not(:disabled) {
+  background-color: #254a66;
+}
+
+.iconButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.periodBarActions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.filterButtonWrap {
+  position: relative;
+  display: inline-flex;
+}
+
+.filterBadge {
+  position: absolute;
+  top: -4px;
+  right: -4px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background-color: #06b2bb;
+  color: #101d28;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 18px;
+  text-align: center;
+}
+
+.chartHeaderRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-total-chart.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-total-chart.tsx
@@ -1,0 +1,158 @@
+'use client'
+
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+
+import type {
+  DemandVolumeGranularity,
+  PeriodVolumeItemOut,
+} from '@/http/tickets/get-demand-volume'
+
+import { DemandVolumeChartGranularity } from './demand-volume-chart-granularity'
+import { formatPeriodLabel } from './demand-volume-period-label'
+import styles from './demand-volume-top.module.css'
+
+interface DemandVolumeTotalChartProps {
+  data: PeriodVolumeItemOut[]
+  granularity: DemandVolumeGranularity
+  onGranularityChange: (granularity: DemandVolumeGranularity) => void
+  isLoading: boolean
+}
+
+const SERIES = [
+  { key: 'created', label: 'Chamados Criados', color: '#b93d52' },
+  { key: 'closed', label: 'Chamados Encerrados', color: '#06b2bb' },
+] as const
+
+const CHART_COLORS = {
+  grid: '#1d3449',
+  axis: '#97a2ab',
+  tooltip: { bg: '#101d28', border: '#4a5d6d', text: '#f9fafa' },
+}
+
+export function DemandVolumeTotalChart({
+  data,
+  granularity,
+  onGranularityChange,
+  isLoading,
+}: DemandVolumeTotalChartProps) {
+  const chartData = data.map((item) => ({
+    ...item,
+    label: formatPeriodLabel(item.period_label, granularity),
+  }))
+
+  return (
+    <div
+      style={{
+        backgroundColor: '#101d28',
+        border: '1px solid #4a5d6d',
+        borderRadius: '8px',
+        padding: '24px',
+      }}
+    >
+      <div className={styles.chartHeaderRow}>
+        <h2
+          style={{
+            fontSize: '20px',
+            fontWeight: 600,
+            color: '#f9fafa',
+            margin: 0,
+          }}
+        >
+          Volume Total de Chamados
+        </h2>
+        <DemandVolumeChartGranularity
+          value={granularity}
+          onChange={onGranularityChange}
+          disabled={isLoading}
+        />
+      </div>
+
+      {isLoading && chartData.length === 0 ? (
+        <div
+          style={{
+            height: '280px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: '#97a2ab',
+            fontSize: '14px',
+          }}
+        >
+          Carregando…
+        </div>
+      ) : (
+        <ResponsiveContainer width="100%" height={280}>
+          <LineChart
+            data={chartData}
+            margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+          >
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke={CHART_COLORS.grid}
+              vertical={false}
+            />
+            <XAxis
+              dataKey="label"
+              tick={{ fill: CHART_COLORS.axis, fontSize: 12 }}
+              axisLine={false}
+              tickLine={false}
+              tickMargin={8}
+            />
+            <YAxis
+              tick={{ fill: CHART_COLORS.axis, fontSize: 12 }}
+              axisLine={false}
+              tickLine={false}
+              width={40}
+            />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: CHART_COLORS.tooltip.bg,
+                border: `1px solid ${CHART_COLORS.tooltip.border}`,
+                borderRadius: '8px',
+                color: CHART_COLORS.tooltip.text,
+                fontSize: '12px',
+              }}
+              itemStyle={{ color: CHART_COLORS.tooltip.text }}
+              labelStyle={{
+                color: CHART_COLORS.tooltip.text,
+                fontWeight: 600,
+                marginBottom: '4px',
+              }}
+            />
+            <Legend
+              wrapperStyle={{
+                paddingTop: '24px',
+                fontSize: '12px',
+                color: '#97a2ab',
+              }}
+              formatter={(value) => (
+                <span style={{ color: '#97a2ab' }}>{value}</span>
+              )}
+            />
+            {SERIES.map((s) => (
+              <Line
+                key={s.key}
+                type="monotone"
+                dataKey={s.key}
+                name={s.label}
+                stroke={s.color}
+                strokeWidth={2}
+                dot={false}
+                activeDot={{ r: 4, strokeWidth: 0 }}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-urgency-chart.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-urgency-chart.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+
+import type {
+  DemandVolumeGranularity,
+  PeriodUrgencyItemOut,
+} from '@/http/tickets/get-demand-volume'
+
+import { DemandVolumeChartGranularity } from './demand-volume-chart-granularity'
+import { formatPeriodLabel } from './demand-volume-period-label'
+import styles from './demand-volume-top.module.css'
+
+interface DemandVolumeUrgencyChartProps {
+  data: PeriodUrgencyItemOut[]
+  granularity: DemandVolumeGranularity
+  onGranularityChange: (granularity: DemandVolumeGranularity) => void
+  isLoading: boolean
+}
+
+const SERIES = [
+  { key: 'urgent', label: 'Urgente', color: '#b93d52' },
+  { key: 'high', label: 'Alta', color: '#5b4db2' },
+  { key: 'routine', label: 'Rotina', color: '#06b2bb' },
+] as const
+
+const CHART_COLORS = {
+  grid: '#1d3449',
+  axis: '#97a2ab',
+  tooltip: { bg: '#101d28', border: '#4a5d6d', text: '#f9fafa' },
+}
+
+export function DemandVolumeUrgencyChart({
+  data,
+  granularity,
+  onGranularityChange,
+  isLoading,
+}: DemandVolumeUrgencyChartProps) {
+  const chartData = data.map((item) => ({
+    ...item,
+    label: formatPeriodLabel(item.period_label, granularity),
+  }))
+
+  return (
+    <div
+      style={{
+        backgroundColor: '#101d28',
+        border: '1px solid #4a5d6d',
+        borderRadius: '8px',
+        padding: '24px',
+      }}
+    >
+      <div className={styles.chartHeaderRow}>
+        <h2
+          style={{
+            fontSize: '20px',
+            fontWeight: 600,
+            color: '#f9fafa',
+            margin: 0,
+          }}
+        >
+          Volume de Chamados Encerrados por Urgência
+        </h2>
+        <DemandVolumeChartGranularity
+          value={granularity}
+          onChange={onGranularityChange}
+          disabled={isLoading}
+        />
+      </div>
+
+      {isLoading && chartData.length === 0 ? (
+        <div
+          style={{
+            height: '280px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: '#97a2ab',
+            fontSize: '14px',
+          }}
+        >
+          Carregando…
+        </div>
+      ) : (
+        <ResponsiveContainer width="100%" height={280}>
+          <LineChart
+            data={chartData}
+            margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+          >
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke={CHART_COLORS.grid}
+              vertical={false}
+            />
+            <XAxis
+              dataKey="label"
+              tick={{ fill: CHART_COLORS.axis, fontSize: 12 }}
+              axisLine={false}
+              tickLine={false}
+              tickMargin={8}
+            />
+            <YAxis
+              tick={{ fill: CHART_COLORS.axis, fontSize: 12 }}
+              axisLine={false}
+              tickLine={false}
+              width={40}
+            />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: CHART_COLORS.tooltip.bg,
+                border: `1px solid ${CHART_COLORS.tooltip.border}`,
+                borderRadius: '8px',
+                color: CHART_COLORS.tooltip.text,
+                fontSize: '12px',
+              }}
+              itemStyle={{ color: CHART_COLORS.tooltip.text }}
+              labelStyle={{
+                color: CHART_COLORS.tooltip.text,
+                fontWeight: 600,
+                marginBottom: '4px',
+              }}
+            />
+            <Legend
+              wrapperStyle={{ paddingTop: '24px', fontSize: '12px' }}
+              formatter={(value) => (
+                <span style={{ color: '#97a2ab' }}>{value}</span>
+              )}
+            />
+            {SERIES.map((s) => (
+              <Line
+                key={s.key}
+                type="monotone"
+                dataKey={s.key}
+                name={s.label}
+                stroke={s.color}
+                strokeWidth={2}
+                dot={false}
+                activeDot={{ r: 4, strokeWidth: 0 }}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-view.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-view.tsx
@@ -1,0 +1,229 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { useEffect, useMemo, useState } from 'react'
+
+import {
+  type DemandVolumeFilterIn,
+  type DemandVolumeGranularity,
+  type DemandVolumeSummaryPeriod,
+  getDemandVolume,
+  pickDemandVolumeGranularitySeries,
+} from '@/http/tickets/get-demand-volume'
+
+import { normalizeDemandVolumeDateRange } from './demand-volume-date-range'
+import {
+  advancedFiltersToApiPatch,
+  type DemandVolumeAdvancedFilterForm,
+  stripAdvancedFiltersFromApi,
+} from './demand-volume-filter-utils'
+import { DemandVolumeFilters } from './demand-volume-filters'
+import { DemandVolumeMatrixTable } from './demand-volume-matrix-table'
+import { DemandVolumeMediaChart } from './demand-volume-media-chart'
+import {
+  createDefaultDemandVolumeFilters,
+  getDefaultChartDateRange,
+} from './demand-volume-period-presets'
+import { DemandVolumeSummaryCards } from './demand-volume-summary-cards'
+import { DemandVolumeTotalChart } from './demand-volume-total-chart'
+import { DemandVolumeUrgencyChart } from './demand-volume-urgency-chart'
+
+export function DemandVolumeView() {
+  const [draftFilters, setDraftFilters] = useState<DemandVolumeFilterIn>(
+    createDefaultDemandVolumeFilters,
+  )
+  const [appliedFilters, setAppliedFilters] = useState<DemandVolumeFilterIn>(
+    createDefaultDemandVolumeFilters,
+  )
+  const [totalCallVolumeGranularity, setTotalCallVolumeGranularity] =
+    useState<DemandVolumeGranularity>('monthly')
+  const [urgencyGranularity, setUrgencyGranularity] =
+    useState<DemandVolumeGranularity>('monthly')
+  const [mediaGranularity, setMediaGranularity] =
+    useState<DemandVolumeGranularity>('monthly')
+
+  useEffect(() => {
+    const fillDates = (prev: DemandVolumeFilterIn): DemandVolumeFilterIn => {
+      if (prev.date_from && prev.date_to) return prev
+      return { ...prev, ...getDefaultChartDateRange() }
+    }
+    setDraftFilters(fillDates)
+    setAppliedFilters(fillDates)
+  }, [])
+
+  const { data, isFetching, isError } = useQuery({
+    queryKey: ['demand-volume', appliedFilters],
+    queryFn: () => getDemandVolume(appliedFilters),
+    staleTime: 60_000,
+  })
+
+  const summaryPeriod = appliedFilters.summary_period ?? 'current_year'
+
+  const totalCallVolumeData = useMemo(
+    () =>
+      pickDemandVolumeGranularitySeries(
+        data?.total_call_volume,
+        totalCallVolumeGranularity,
+      ),
+    [data?.total_call_volume, totalCallVolumeGranularity],
+  )
+
+  const urgencyChartData = useMemo(
+    () =>
+      pickDemandVolumeGranularitySeries(
+        data?.closed_calls_by_urgency,
+        urgencyGranularity,
+      ),
+    [data?.closed_calls_by_urgency, urgencyGranularity],
+  )
+
+  const mediaChartData = useMemo(
+    () =>
+      pickDemandVolumeGranularitySeries(
+        data?.media_relevant_calls,
+        mediaGranularity,
+      ),
+    [data?.media_relevant_calls, mediaGranularity],
+  )
+
+  function applyFilters(next: DemandVolumeFilterIn) {
+    setDraftFilters(next)
+    setAppliedFilters(next)
+  }
+
+  function handleSummaryPeriodChange(summaryPeriod: DemandVolumeSummaryPeriod) {
+    applyFilters({ ...appliedFilters, summary_period: summaryPeriod })
+  }
+
+  function handlePeriodDatesChange(
+    patch: Partial<{ dateFrom: string; dateTo: string }>,
+    changed: 'from' | 'to',
+  ) {
+    const fallback = getDefaultChartDateRange()
+    let dateFrom =
+      patch.dateFrom ?? draftFilters.date_from ?? fallback.date_from ?? ''
+    let dateTo = patch.dateTo ?? draftFilters.date_to ?? fallback.date_to ?? ''
+
+    if (dateFrom && dateTo) {
+      ;({ dateFrom, dateTo } = normalizeDemandVolumeDateRange(
+        dateFrom,
+        dateTo,
+        changed,
+      ))
+    }
+
+    applyFilters({
+      ...appliedFilters,
+      date_from: dateFrom || undefined,
+      date_to: dateTo || undefined,
+    })
+  }
+
+  function handleApplyAdvancedFilters(form: DemandVolumeAdvancedFilterForm) {
+    applyFilters({
+      ...stripAdvancedFiltersFromApi(appliedFilters),
+      ...advancedFiltersToApiPatch(form),
+    })
+  }
+
+  /** Tabelas fixas (agrupamento mensal no backend); colunas vêm dos dados da matriz. */
+  const matrixPeriodLabels = useMemo(() => {
+    const fromNature = data?.closed_calls_by_nature[0]?.periods.map(
+      (p) => p.period_label,
+    )
+    if (fromNature?.length) return fromNature
+    return (
+      data?.closed_calls_by_service[0]?.periods.map((p) => p.period_label) ?? []
+    )
+  }, [data?.closed_calls_by_nature, data?.closed_calls_by_service])
+
+  return (
+    <div
+      style={{
+        paddingTop: '24px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '24px',
+      }}
+    >
+      <DemandVolumeSummaryCards
+        summary={data?.summary}
+        isLoading={isFetching}
+        summaryPeriod={summaryPeriod}
+        onSummaryPeriodChange={handleSummaryPeriodChange}
+      />
+
+      <DemandVolumeFilters
+        dateFrom={draftFilters.date_from ?? ''}
+        dateTo={draftFilters.date_to ?? ''}
+        onDateFromChange={(dateFrom) =>
+          handlePeriodDatesChange({ dateFrom }, 'from')
+        }
+        onDateToChange={(dateTo) => handlePeriodDatesChange({ dateTo }, 'to')}
+        isLoading={isFetching}
+        appliedFilters={appliedFilters}
+        onApplyAdvancedFilters={handleApplyAdvancedFilters}
+      />
+
+      {isError && (
+        <div
+          style={{
+            backgroundColor: '#1d3449',
+            border: '1px solid #4a5d6d',
+            borderRadius: '8px',
+            padding: '16px 24px',
+            color: '#f9fafa',
+            fontSize: '14px',
+          }}
+        >
+          Erro ao carregar dados. Verifique sua conexão e tente novamente.
+        </div>
+      )}
+
+      <DemandVolumeTotalChart
+        data={totalCallVolumeData}
+        granularity={totalCallVolumeGranularity}
+        onGranularityChange={setTotalCallVolumeGranularity}
+        isLoading={isFetching}
+      />
+
+      <DemandVolumeUrgencyChart
+        data={urgencyChartData}
+        granularity={urgencyGranularity}
+        onGranularityChange={setUrgencyGranularity}
+        isLoading={isFetching}
+      />
+
+      <DemandVolumeMatrixTable
+        title="Volume de Chamados Encerrados por Natureza"
+        rows={data?.closed_calls_by_nature ?? []}
+        periodLabels={matrixPeriodLabels}
+        isLoading={isFetching}
+        columnHeader="NATUREZA"
+      />
+
+      <DemandVolumeMatrixTable
+        title="Volume de Chamados Encerrados por Serviço"
+        rows={data?.closed_calls_by_service ?? []}
+        periodLabels={matrixPeriodLabels}
+        isLoading={isFetching}
+        columnHeader="SERVIÇO"
+      />
+
+      <DemandVolumeMediaChart
+        data={mediaChartData}
+        granularity={mediaGranularity}
+        onGranularityChange={setMediaGranularity}
+        isLoading={isFetching}
+      />
+
+      <DemandVolumeMatrixTable
+        title="Volume de Chamados Encerrados por Demandante"
+        rows={data?.closed_calls_by_requester ?? []}
+        periodLabels={matrixPeriodLabels}
+        isLoading={isFetching}
+        columnHeader="DEMANDANTE"
+      />
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/volume/page.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/page.tsx
@@ -1,0 +1,5 @@
+import { DemandVolumeView } from './components/demand-volume-view'
+
+export default function DemandVolumePage() {
+  return <DemandVolumeView />
+}

--- a/src/app/(app)/demandas/dashboard/components/dashboard-tabs.tsx
+++ b/src/app/(app)/demandas/dashboard/components/dashboard-tabs.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+
+import styles from '../dashboard-tabs.module.css'
+
+const TABS = [
+  { href: '/demandas/dashboard/sla', label: 'SLA' },
+  { href: '/demandas/dashboard/visualizacao', label: 'Visualização' },
+] as const
+
+export function DashboardTabs() {
+  const pathname = usePathname()
+
+  return (
+    <nav className={styles.tabs} aria-label="Configuração do dashboard">
+      {TABS.map((tab) => {
+        const isActive = pathname.startsWith(tab.href)
+        return (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            className={`${styles.tab} ${isActive ? styles.tabActive : ''}`}
+            aria-current={isActive ? 'page' : undefined}
+          >
+            {tab.label}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/src/app/(app)/demandas/dashboard/dashboard-tabs.module.css
+++ b/src/app/(app)/demandas/dashboard/dashboard-tabs.module.css
@@ -1,0 +1,39 @@
+.tabs {
+  display: flex;
+  gap: 8px;
+  border-bottom: 1px solid var(--tc-card-border, #4a5d6d);
+  margin-bottom: 32px;
+}
+
+.tab {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 47px;
+  padding: 12px 16px 0;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 16px;
+  color: var(--tc-muted, #97a2ab);
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.tab:hover {
+  color: var(--tc-text, #f9fafa);
+}
+
+.tabActive {
+  color: #22c1f1;
+}
+
+.tabActive::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 2px;
+  background: #22c1f1;
+}

--- a/src/app/(app)/demandas/dashboard/layout.tsx
+++ b/src/app/(app)/demandas/dashboard/layout.tsx
@@ -1,0 +1,24 @@
+'use client'
+
+import tcFormStyles from '../criar/ticket-create/ticket-create-form.module.css'
+import { DashboardTabs } from './components/dashboard-tabs'
+
+export default function DemandasDashboardLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div
+      className="page-content overflow-y-scroll pb-24"
+      style={{ backgroundColor: '#0c161f' }}
+    >
+      <div className="content px-10 pb-10 pt-0">
+        <div className={tcFormStyles.root}>
+          <DashboardTabs />
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard/layout.tsx
+++ b/src/app/(app)/demandas/dashboard/layout.tsx
@@ -1,5 +1,9 @@
 'use client'
 
+import { notFound } from 'next/navigation'
+
+import { config } from '@/config'
+
 import tcFormStyles from '../criar/ticket-create/ticket-create-form.module.css'
 import { DashboardTabs } from './components/dashboard-tabs'
 
@@ -8,6 +12,10 @@ export default function DemandasDashboardLayout({
 }: {
   children: React.ReactNode
 }) {
+  if (!config.enableChamados) {
+    notFound()
+  }
+
   return (
     <div
       className="page-content overflow-y-scroll pb-24"

--- a/src/app/(app)/demandas/dashboard/page.tsx
+++ b/src/app/(app)/demandas/dashboard/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function DemandasDashboardPage() {
+  redirect('/demandas/dashboard/sla')
+}

--- a/src/app/(app)/demandas/dashboard/sla/components/sla-config-form.tsx
+++ b/src/app/(app)/demandas/dashboard/sla/components/sla-config-form.tsx
@@ -1,0 +1,247 @@
+'use client'
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { isAxiosError } from 'axios'
+import { useEffect, useMemo, useState } from 'react'
+import { Controller, useForm, useWatch } from 'react-hook-form'
+import { toast } from 'sonner'
+import { z } from 'zod'
+
+import { Spinner } from '@/components/custom/spinner'
+import { Button } from '@/components/ui/button'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import {
+  getTicketDashboardSlaConfig,
+  mapSlaConfigOutToFormValues,
+  SLA_CONFIG_DEFAULT_VALUES,
+  type TicketDashboardSlaConfigOut,
+  type TicketDashboardSlaFormValues,
+  updateTicketDashboardSlaConfig,
+} from '@/http/tickets/ticket-dashboard-sla-config'
+import { getApiErrorMessage } from '@/utils/error-handlers'
+
+import tcFormStyles from '../../../criar/ticket-create/ticket-create-form.module.css'
+import { SLA_CONFIG_FIELDS, SLA_DAY_OPTIONS } from '../sla-config.constants'
+import styles from '../sla-config.module.css'
+
+const SLA_CONFIG_QUERY_KEY = ['ticket-dashboard-sla-config'] as const
+
+const slaConfigSchema = z.object({
+  image_search_days: z.coerce.number().int().min(1),
+  electronic_fence_days: z.coerce.number().int().min(1),
+  radar_search_days: z.coerce.number().int().min(1),
+  license_plate_search_days: z.coerce.number().int().min(1),
+  related_license_plates_days: z.coerce.number().int().min(1),
+  joint_license_plates_days: z.coerce.number().int().min(1),
+  image_analysis_days: z.coerce.number().int().min(1),
+  others_days: z.coerce.number().int().min(1),
+})
+
+const SLA_FIELD_ROWS = [
+  [SLA_CONFIG_FIELDS[0], SLA_CONFIG_FIELDS[1]],
+  [SLA_CONFIG_FIELDS[2], SLA_CONFIG_FIELDS[3]],
+  [SLA_CONFIG_FIELDS[4], SLA_CONFIG_FIELDS[5]],
+  [SLA_CONFIG_FIELDS[6], SLA_CONFIG_FIELDS[7]],
+] as const
+
+function resolveFormValues(
+  config: TicketDashboardSlaConfigOut | undefined,
+  notFound: boolean,
+): TicketDashboardSlaFormValues {
+  if (notFound || !config) return SLA_CONFIG_DEFAULT_VALUES
+  return mapSlaConfigOutToFormValues(config)
+}
+
+function areFormValuesEqual(
+  a: TicketDashboardSlaFormValues,
+  b: TicketDashboardSlaFormValues,
+) {
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+export function SlaConfigForm() {
+  const queryClient = useQueryClient()
+
+  const configQuery = useQuery({
+    queryKey: SLA_CONFIG_QUERY_KEY,
+    queryFn: getTicketDashboardSlaConfig,
+    retry: (failureCount, error) => {
+      if (isAxiosError(error) && error.response?.status === 404) {
+        return false
+      }
+      return failureCount < 2
+    },
+  })
+
+  const isNotFound =
+    configQuery.isError &&
+    isAxiosError(configQuery.error) &&
+    configQuery.error.response?.status === 404
+
+  const [savedValues, setSavedValues] = useState<TicketDashboardSlaFormValues>(
+    SLA_CONFIG_DEFAULT_VALUES,
+  )
+
+  const { control, handleSubmit, reset } =
+    useForm<TicketDashboardSlaFormValues>({
+      resolver: zodResolver(slaConfigSchema),
+      defaultValues: SLA_CONFIG_DEFAULT_VALUES,
+    })
+
+  const currentValues = useWatch({ control }) ?? SLA_CONFIG_DEFAULT_VALUES
+
+  const hasChanges = useMemo(
+    () => !areFormValuesEqual(currentValues, savedValues),
+    [currentValues, savedValues],
+  )
+
+  useEffect(() => {
+    if (configQuery.isLoading) return
+    const values = resolveFormValues(configQuery.data, isNotFound)
+    setSavedValues(values)
+    reset(values)
+  }, [configQuery.data, configQuery.isLoading, isNotFound, reset])
+
+  useEffect(() => {
+    if (!configQuery.isError || !isAxiosError(configQuery.error)) return
+    if (configQuery.error.response?.status === 404) return
+    toast.error(getApiErrorMessage(configQuery.error))
+  }, [configQuery.error, configQuery.isError])
+
+  const saveMutation = useMutation({
+    mutationFn: (values: TicketDashboardSlaFormValues) =>
+      updateTicketDashboardSlaConfig(values),
+    onSuccess: (data) => {
+      const values = mapSlaConfigOutToFormValues(data)
+      queryClient.setQueryData(SLA_CONFIG_QUERY_KEY, data)
+      setSavedValues(values)
+      reset(values)
+      toast.success('Configuração de SLA salva com sucesso.')
+    },
+    onError: (error) => {
+      toast.error(getApiErrorMessage(error))
+    },
+  })
+
+  const isLoadingConfig = configQuery.isLoading
+  const isSaving = saveMutation.isPending
+
+  const canSave = !isLoadingConfig && hasChanges
+
+  function handleClear() {
+    reset(SLA_CONFIG_DEFAULT_VALUES)
+    toast.message(
+      'Valores restaurados para o padrão. Clique em Salvar para gravar.',
+    )
+  }
+
+  async function onSubmit(values: TicketDashboardSlaFormValues) {
+    await saveMutation.mutateAsync(values)
+  }
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <h1 className={styles.title}>Configuração de SLA</h1>
+        <p className={styles.subtitle}>
+          Dashboard de métricas e indicadores de desempenho
+        </p>
+      </header>
+
+      {isLoadingConfig ? (
+        <div className="flex h-40 items-center justify-center">
+          <Spinner />
+        </div>
+      ) : (
+        <form
+          className={styles.formSection}
+          onSubmit={handleSubmit(onSubmit)}
+          noValidate
+        >
+          {SLA_FIELD_ROWS.map((row, rowIndex) => (
+            <div key={rowIndex} className={styles.formRow}>
+              {row.map((field) => (
+                <div key={field.name} className={styles.field}>
+                  <Label
+                    htmlFor={field.name}
+                    className={tcFormStyles.fieldLabel}
+                  >
+                    {field.label}
+                  </Label>
+                  <Controller
+                    control={control}
+                    name={field.name}
+                    render={({ field: controllerField }) => {
+                      const days = Number(controllerField.value)
+                      const selectValue = Number.isFinite(days)
+                        ? String(days)
+                        : undefined
+
+                      return (
+                        <Select
+                          key={`${field.name}-${selectValue ?? 'empty'}`}
+                          value={selectValue}
+                          onValueChange={(value) =>
+                            controllerField.onChange(Number(value))
+                          }
+                          disabled={isSaving}
+                        >
+                          <SelectTrigger
+                            id={field.name}
+                            className={`h-11 w-full ${tcFormStyles.inputBg}`}
+                          >
+                            <SelectValue placeholder="Selecione" />
+                          </SelectTrigger>
+                          <SelectContent
+                            className={tcFormStyles.selectContentForm}
+                          >
+                            {SLA_DAY_OPTIONS.map((option) => (
+                              <SelectItem
+                                key={option.value}
+                                value={option.value}
+                                className={tcFormStyles.selectItemForm}
+                              >
+                                {option.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      )
+                    }}
+                  />
+                </div>
+              ))}
+            </div>
+          ))}
+
+          <div className={styles.actions}>
+            <Button
+              type="button"
+              variant="secondary"
+              className={styles.clearButton}
+              onClick={handleClear}
+              disabled={isSaving}
+            >
+              Limpar configuração
+            </Button>
+            <Button
+              type="submit"
+              className={`${tcFormStyles.saveButton} ${styles.saveButton}`}
+              disabled={!canSave || isSaving}
+            >
+              {isSaving ? <Spinner /> : 'Salvar'}
+            </Button>
+          </div>
+        </form>
+      )}
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard/sla/page.tsx
+++ b/src/app/(app)/demandas/dashboard/sla/page.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { notFound } from 'next/navigation'
+
+import { Spinner } from '@/components/custom/spinner'
+import { config } from '@/config'
+import { useTicketScreenPermissionGate } from '@/hooks/useTicketScreenPermissionGate'
+
+import { SlaConfigForm } from './components/sla-config-form'
+
+const SLA_CONFIG_SCREEN_CODE = 'sla_config'
+
+function SlaConfigPageContent() {
+  return <SlaConfigForm />
+}
+
+export default function SlaConfigPage() {
+  if (!config.enableChamados) {
+    notFound()
+  }
+
+  const { allowed, resolved } = useTicketScreenPermissionGate(
+    SLA_CONFIG_SCREEN_CODE,
+  )
+
+  if (!resolved || !allowed) {
+    return (
+      <div
+        className="flex min-h-[240px] items-center justify-center"
+        style={{ backgroundColor: '#0c161f' }}
+      >
+        <Spinner />
+      </div>
+    )
+  }
+
+  return <SlaConfigPageContent />
+}

--- a/src/app/(app)/demandas/dashboard/sla/page.tsx
+++ b/src/app/(app)/demandas/dashboard/sla/page.tsx
@@ -1,9 +1,6 @@
 'use client'
 
-import { notFound } from 'next/navigation'
-
 import { Spinner } from '@/components/custom/spinner'
-import { config } from '@/config'
 import { useTicketScreenPermissionGate } from '@/hooks/useTicketScreenPermissionGate'
 
 import { SlaConfigForm } from './components/sla-config-form'
@@ -15,10 +12,6 @@ function SlaConfigPageContent() {
 }
 
 export default function SlaConfigPage() {
-  if (!config.enableChamados) {
-    notFound()
-  }
-
   const { allowed, resolved } = useTicketScreenPermissionGate(
     SLA_CONFIG_SCREEN_CODE,
   )

--- a/src/app/(app)/demandas/dashboard/sla/sla-config.constants.ts
+++ b/src/app/(app)/demandas/dashboard/sla/sla-config.constants.ts
@@ -1,0 +1,31 @@
+import type { TicketDashboardSlaFormValues } from '@/http/tickets/ticket-dashboard-sla-config'
+
+export type SlaConfigFieldName = keyof TicketDashboardSlaFormValues
+
+export type SlaConfigField = {
+  name: SlaConfigFieldName
+  label: string
+}
+
+export const SLA_CONFIG_FIELDS: SlaConfigField[] = [
+  { name: 'image_search_days', label: 'busca por imagem' },
+  { name: 'electronic_fence_days', label: 'cerco eletrônico' },
+  { name: 'radar_search_days', label: 'busca por radar' },
+  { name: 'license_plate_search_days', label: 'busca por placa' },
+  { name: 'related_license_plates_days', label: 'placa correlatas' },
+  { name: 'joint_license_plates_days', label: 'placas conjuntas' },
+  { name: 'image_analysis_days', label: 'análise de imagem' },
+  { name: 'others_days', label: 'outros' },
+]
+
+export const SLA_DAY_OPTIONS = Array.from({ length: 30 }, (_, index) => {
+  const value = index + 1
+  return {
+    value: String(value),
+    label: value === 1 ? '1 dia' : `${value} dias`,
+  }
+})
+
+export function formatSlaDaysLabel(days: number): string {
+  return days === 1 ? '1 dia' : `${days} dias`
+}

--- a/src/app/(app)/demandas/dashboard/sla/sla-config.module.css
+++ b/src/app/(app)/demandas/dashboard/sla/sla-config.module.css
@@ -1,0 +1,82 @@
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  width: 100%;
+}
+
+.header {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  line-height: 40px;
+  color: var(--tc-text, #f9fafa);
+}
+
+.subtitle {
+  margin: 0;
+  font-size: 12px;
+  line-height: 16px;
+  color: var(--tc-muted, #97a2ab);
+}
+
+.formSection {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+}
+
+.formRow {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+  width: 100%;
+}
+
+@media (min-width: 768px) {
+  .formRow {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 16px;
+}
+
+.clearButton {
+  min-width: 220px;
+  height: 40px;
+  background: #1d3449 !important;
+  color: #f9fafa !important;
+}
+
+.clearButton:hover {
+  background: #254a66 !important;
+}
+
+.saveButton {
+  min-width: 220px;
+  height: 40px;
+  color: #f9fafa !important;
+}
+
+.saveButton:hover:not(:disabled) {
+  color: #f9fafa !important;
+}

--- a/src/app/(app)/demandas/dashboard/visualizacao/components/widget-config-section.tsx
+++ b/src/app/(app)/demandas/dashboard/visualizacao/components/widget-config-section.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { ChevronDown, ChevronUp } from 'lucide-react'
+import { useState } from 'react'
+import type { Control } from 'react-hook-form'
+import { Controller } from 'react-hook-form'
+
+import { Collapsible, CollapsibleContent } from '@/components/ui/collapsible'
+import { Switch } from '@/components/ui/switch'
+import type { TicketDashboardWidgetsFormValues } from '@/http/tickets/ticket-dashboard-widgets-config'
+
+import tcFormStyles from '../../../criar/ticket-create/ticket-create-form.module.css'
+import type { WidgetConfigSection } from '../widgets-config.constants'
+import styles from '../widgets-config.module.css'
+
+type WidgetConfigSectionProps = {
+  section: WidgetConfigSection
+  control: Control<TicketDashboardWidgetsFormValues>
+  disabled?: boolean
+}
+
+export function WidgetConfigSection({
+  section,
+  control,
+  disabled = false,
+}: WidgetConfigSectionProps) {
+  const [isOpen, setIsOpen] = useState(true)
+
+  return (
+    <Collapsible
+      open={isOpen}
+      onOpenChange={setIsOpen}
+      className={styles.sectionCard}
+    >
+      <header className={styles.sectionHeader}>
+        <span className={styles.sectionBadge}>{section.title}</span>
+        <button
+          type="button"
+          className={styles.collapseButton}
+          onClick={() => setIsOpen((current) => !current)}
+          aria-expanded={isOpen}
+          aria-label={isOpen ? 'Recolher seção' : 'Expandir seção'}
+        >
+          {isOpen ? <ChevronDown size={24} /> : <ChevronUp size={24} />}
+        </button>
+      </header>
+
+      <CollapsibleContent>
+        {section.fields.map((field) => (
+          <div key={field.name} className={styles.widgetRow}>
+            <p className={styles.widgetLabel}>{field.label}</p>
+            <Controller
+              control={control}
+              name={field.name}
+              render={({ field: controllerField }) => (
+                <Switch
+                  size="sm"
+                  className={`${styles.widgetSwitch} ${tcFormStyles.apelidoToggle}`}
+                  checked={controllerField.value}
+                  onCheckedChange={controllerField.onChange}
+                  disabled={disabled}
+                  aria-label={field.label}
+                />
+              )}
+            />
+          </div>
+        ))}
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}

--- a/src/app/(app)/demandas/dashboard/visualizacao/components/widgets-config-form.tsx
+++ b/src/app/(app)/demandas/dashboard/visualizacao/components/widgets-config-form.tsx
@@ -1,0 +1,199 @@
+'use client'
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { isAxiosError } from 'axios'
+import { useEffect, useMemo, useState } from 'react'
+import { useForm, useWatch } from 'react-hook-form'
+import { toast } from 'sonner'
+import { z } from 'zod'
+
+import { Spinner } from '@/components/custom/spinner'
+import { Button } from '@/components/ui/button'
+import {
+  getTicketDashboardWidgetsConfig,
+  mapWidgetsConfigOutToFormValues,
+  type TicketDashboardWidgetsConfigOut,
+  type TicketDashboardWidgetsFormValues,
+  updateTicketDashboardWidgetsConfig,
+  WIDGETS_CONFIG_DEFAULT_VALUES,
+} from '@/http/tickets/ticket-dashboard-widgets-config'
+import { getApiErrorMessage } from '@/utils/error-handlers'
+
+import tcFormStyles from '../../../criar/ticket-create/ticket-create-form.module.css'
+import pageStyles from '../../sla/sla-config.module.css'
+import { WIDGET_CONFIG_SECTIONS } from '../widgets-config.constants'
+import styles from '../widgets-config.module.css'
+import { WidgetConfigSection } from './widget-config-section'
+
+const WIDGETS_CONFIG_QUERY_KEY = ['ticket-dashboard-widgets-config'] as const
+
+const widgetsConfigSchema = z.object({
+  total_call_volume: z.boolean(),
+  closed_calls_by_urgency: z.boolean(),
+  closed_calls_by_nature: z.boolean(),
+  closed_calls_by_service: z.boolean(),
+  media_relevant_calls_volume: z.boolean(),
+  average_resolution_time_general: z.boolean(),
+  average_resolution_time_by_profile: z.boolean(),
+  average_resolution_time_by_urgency: z.boolean(),
+  delivery_time_performance_by_urgency: z.boolean(),
+  delivery_time_performance_by_service: z.boolean(),
+  delivery_time_for_media_relevant: z.boolean(),
+  open_calls_by_team: z.boolean(),
+  closed_calls_by_team: z.boolean(),
+  delivery_time_by_team: z.boolean(),
+  sla_attainment_by_team: z.boolean(),
+  closed_calls_by_requester_sphere: z.boolean(),
+  closed_calls_by_requester: z.boolean(),
+  closed_calls_by_requester_agency: z.boolean(),
+  closed_calls_by_requester_type: z.boolean(),
+  closed_calls_by_requester_institution: z.boolean(),
+})
+
+function resolveFormValues(
+  config: TicketDashboardWidgetsConfigOut | undefined,
+  notFound: boolean,
+): TicketDashboardWidgetsFormValues {
+  if (notFound || !config) return WIDGETS_CONFIG_DEFAULT_VALUES
+  return mapWidgetsConfigOutToFormValues(config)
+}
+
+function areFormValuesEqual(
+  a: TicketDashboardWidgetsFormValues,
+  b: TicketDashboardWidgetsFormValues,
+) {
+  return JSON.stringify(a) === JSON.stringify(b)
+}
+
+export function WidgetsConfigForm() {
+  const queryClient = useQueryClient()
+
+  const configQuery = useQuery({
+    queryKey: WIDGETS_CONFIG_QUERY_KEY,
+    queryFn: getTicketDashboardWidgetsConfig,
+    retry: (failureCount, error) => {
+      if (isAxiosError(error) && error.response?.status === 404) {
+        return false
+      }
+      return failureCount < 2
+    },
+  })
+
+  const isNotFound =
+    configQuery.isError &&
+    isAxiosError(configQuery.error) &&
+    configQuery.error.response?.status === 404
+
+  const [savedValues, setSavedValues] =
+    useState<TicketDashboardWidgetsFormValues>(WIDGETS_CONFIG_DEFAULT_VALUES)
+
+  const { control, handleSubmit, reset } =
+    useForm<TicketDashboardWidgetsFormValues>({
+      resolver: zodResolver(widgetsConfigSchema),
+      defaultValues: WIDGETS_CONFIG_DEFAULT_VALUES,
+    })
+
+  const currentValues = useWatch({ control }) ?? WIDGETS_CONFIG_DEFAULT_VALUES
+
+  const hasChanges = useMemo(
+    () => !areFormValuesEqual(currentValues, savedValues),
+    [currentValues, savedValues],
+  )
+
+  useEffect(() => {
+    if (configQuery.isLoading) return
+    const values = resolveFormValues(configQuery.data, isNotFound)
+    setSavedValues(values)
+    reset(values)
+  }, [configQuery.data, configQuery.isLoading, isNotFound, reset])
+
+  useEffect(() => {
+    if (!configQuery.isError || !isAxiosError(configQuery.error)) return
+    if (configQuery.error.response?.status === 404) return
+    toast.error(getApiErrorMessage(configQuery.error))
+  }, [configQuery.error, configQuery.isError])
+
+  const saveMutation = useMutation({
+    mutationFn: (values: TicketDashboardWidgetsFormValues) =>
+      updateTicketDashboardWidgetsConfig(values),
+    onSuccess: (data) => {
+      const values = mapWidgetsConfigOutToFormValues(data)
+      queryClient.setQueryData(WIDGETS_CONFIG_QUERY_KEY, data)
+      setSavedValues(values)
+      reset(values)
+      toast.success('Configuração de visualização salva com sucesso.')
+    },
+    onError: (error) => {
+      toast.error(getApiErrorMessage(error))
+    },
+  })
+
+  const isLoadingConfig = configQuery.isLoading
+  const isSaving = saveMutation.isPending
+  const canSave = !isLoadingConfig && hasChanges
+
+  function handleClear() {
+    reset(WIDGETS_CONFIG_DEFAULT_VALUES)
+    toast.message(
+      'Valores restaurados para o padrão. Clique em Salvar para gravar.',
+    )
+  }
+
+  async function onSubmit(values: TicketDashboardWidgetsFormValues) {
+    await saveMutation.mutateAsync(values)
+  }
+
+  return (
+    <div className={pageStyles.page}>
+      <header className={pageStyles.header}>
+        <h1 className={pageStyles.title}>Configuração de Dashboard</h1>
+        <p className={pageStyles.subtitle}>
+          Dashboard de métricas e indicadores de desempenho
+        </p>
+      </header>
+
+      {isLoadingConfig ? (
+        <div className="flex h-40 items-center justify-center">
+          <Spinner />
+        </div>
+      ) : (
+        <form
+          className={pageStyles.formSection}
+          onSubmit={handleSubmit(onSubmit)}
+          noValidate
+        >
+          <div className={styles.sections}>
+            {WIDGET_CONFIG_SECTIONS.map((section) => (
+              <WidgetConfigSection
+                key={section.id}
+                section={section}
+                control={control}
+                disabled={isSaving}
+              />
+            ))}
+          </div>
+
+          <div className={pageStyles.actions}>
+            <Button
+              type="button"
+              variant="secondary"
+              className={pageStyles.clearButton}
+              onClick={handleClear}
+              disabled={isSaving}
+            >
+              Limpar configuração
+            </Button>
+            <Button
+              type="submit"
+              className={`${tcFormStyles.saveButton} ${pageStyles.saveButton}`}
+              disabled={!canSave || isSaving}
+            >
+              {isSaving ? <Spinner /> : 'Salvar'}
+            </Button>
+          </div>
+        </form>
+      )}
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard/visualizacao/page.tsx
+++ b/src/app/(app)/demandas/dashboard/visualizacao/page.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { notFound } from 'next/navigation'
+
+import { Spinner } from '@/components/custom/spinner'
+import { config } from '@/config'
+import { useTicketScreenPermissionGate } from '@/hooks/useTicketScreenPermissionGate'
+
+import { WidgetsConfigForm } from './components/widgets-config-form'
+
+const SLA_CONFIG_SCREEN_CODE = 'sla_config'
+
+function DashboardVisualizacaoPageContent() {
+  return <WidgetsConfigForm />
+}
+
+export default function DashboardVisualizacaoPage() {
+  if (!config.enableChamados) {
+    notFound()
+  }
+
+  const { allowed, resolved } = useTicketScreenPermissionGate(
+    SLA_CONFIG_SCREEN_CODE,
+  )
+
+  if (!resolved || !allowed) {
+    return (
+      <div
+        className="flex min-h-[240px] items-center justify-center"
+        style={{ backgroundColor: '#0c161f' }}
+      >
+        <Spinner />
+      </div>
+    )
+  }
+
+  return <DashboardVisualizacaoPageContent />
+}

--- a/src/app/(app)/demandas/dashboard/visualizacao/page.tsx
+++ b/src/app/(app)/demandas/dashboard/visualizacao/page.tsx
@@ -1,9 +1,6 @@
 'use client'
 
-import { notFound } from 'next/navigation'
-
 import { Spinner } from '@/components/custom/spinner'
-import { config } from '@/config'
 import { useTicketScreenPermissionGate } from '@/hooks/useTicketScreenPermissionGate'
 
 import { WidgetsConfigForm } from './components/widgets-config-form'
@@ -15,10 +12,6 @@ function DashboardVisualizacaoPageContent() {
 }
 
 export default function DashboardVisualizacaoPage() {
-  if (!config.enableChamados) {
-    notFound()
-  }
-
   const { allowed, resolved } = useTicketScreenPermissionGate(
     SLA_CONFIG_SCREEN_CODE,
   )

--- a/src/app/(app)/demandas/dashboard/visualizacao/widgets-config.constants.ts
+++ b/src/app/(app)/demandas/dashboard/visualizacao/widgets-config.constants.ts
@@ -1,0 +1,120 @@
+import type { TicketDashboardWidgetsConfigField } from '@/http/tickets/ticket-dashboard-widgets-config'
+
+export type WidgetConfigField = {
+  name: TicketDashboardWidgetsConfigField
+  label: string
+}
+
+export type WidgetConfigSection = {
+  id: string
+  title: string
+  fields: WidgetConfigField[]
+}
+
+export const WIDGET_CONFIG_SECTIONS: WidgetConfigSection[] = [
+  {
+    id: 'volumes-estados',
+    title: 'volumes e estados',
+    fields: [
+      {
+        name: 'total_call_volume',
+        label: 'volume total de chamados',
+      },
+      {
+        name: 'closed_calls_by_urgency',
+        label: 'volume de chamados encerrados por urgência',
+      },
+      {
+        name: 'closed_calls_by_nature',
+        label: 'volume de chamados encerrados por natureza',
+      },
+      {
+        name: 'closed_calls_by_service',
+        label: 'volume de chamados encerrados por serviço',
+      },
+      {
+        name: 'media_relevant_calls_volume',
+        label: 'volume de chamados com relevância na mídia',
+      },
+    ],
+  },
+  {
+    id: 'metricas-resposta',
+    title: 'métricas de resposta',
+    fields: [
+      {
+        name: 'average_resolution_time_general',
+        label: 'tempo médio de resolução - geral',
+      },
+      {
+        name: 'average_resolution_time_by_profile',
+        label: 'tempo médio de resolução por perfil',
+      },
+      {
+        name: 'average_resolution_time_by_urgency',
+        label: 'tempo médio de resolução por urgência',
+      },
+      {
+        name: 'delivery_time_performance_by_urgency',
+        label: 'performance de tempo de entrega por urgência',
+      },
+      {
+        name: 'delivery_time_performance_by_service',
+        label: 'performance de tempo de entrega por serviço',
+      },
+      {
+        name: 'delivery_time_for_media_relevant',
+        label: 'tempo de entrega por relevantes para mídia',
+      },
+    ],
+  },
+  {
+    id: 'visao-operacional',
+    title: 'visão operacional',
+    fields: [
+      {
+        name: 'open_calls_by_team',
+        label: 'abertos com cada equipe',
+      },
+      {
+        name: 'closed_calls_by_team',
+        label: 'volume de chamados encerrados por equipe',
+      },
+      {
+        name: 'delivery_time_by_team',
+        label: 'tempo de entrega por equipe',
+      },
+      {
+        name: 'sla_attainment_by_team',
+        label: 'atingimento de sla por equipe',
+      },
+    ],
+  },
+  {
+    id: 'demandantes',
+    title: 'demandantes',
+    fields: [
+      {
+        name: 'closed_calls_by_requester_sphere',
+        label: 'volume de chamados encerrados por demandantes - esfera',
+      },
+      {
+        name: 'closed_calls_by_requester',
+        label: 'volume de chamados encerrados por demandantes',
+      },
+      {
+        name: 'closed_calls_by_requester_agency',
+        label: 'volume de chamados encerrados por demandantes - órgão',
+      },
+      {
+        name: 'closed_calls_by_requester_type',
+        label:
+          'volume de chamados encerrados por demandantes - tipo de requisitante',
+      },
+      {
+        name: 'closed_calls_by_requester_institution',
+        label: 'volume de chamados encerrados por demandantes - instituição',
+      },
+    ],
+  },
+]

--- a/src/app/(app)/demandas/dashboard/visualizacao/widgets-config.module.css
+++ b/src/app/(app)/demandas/dashboard/visualizacao/widgets-config.module.css
@@ -1,0 +1,79 @@
+.sections {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 100%;
+}
+
+.sectionCard {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  padding: 16px 16px 32px;
+  border-radius: 16px;
+  background: #101d28;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 48px;
+  width: 100%;
+}
+
+.sectionBadge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  padding: 4px 12px;
+  border-radius: 8px;
+  background: #1d3449;
+  color: #f9fafa;
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 16px;
+  text-transform: uppercase;
+}
+
+.collapseButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: none;
+  background: transparent;
+  color: #97a2ab;
+  cursor: pointer;
+}
+
+.widgetRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 8px 16px;
+  border-bottom: 1px solid #4a5d6d;
+}
+
+.widgetRow:last-child {
+  border-bottom: none;
+}
+
+.widgetLabel {
+  flex: 1;
+  min-width: 0;
+  margin: 0;
+  padding: 8px;
+  font-size: 12px;
+  font-weight: 400;
+  line-height: 16px;
+  text-transform: uppercase;
+  color: #97a2ab;
+}
+
+.widgetSwitch {
+  flex-shrink: 0;
+}

--- a/src/app/(app)/demandas/fechamentos/[shiftClosingId]/page.tsx
+++ b/src/app/(app)/demandas/fechamentos/[shiftClosingId]/page.tsx
@@ -1,20 +1,20 @@
-import { notFound } from 'next/navigation'
+'use client'
 
+import { notFound, useParams } from 'next/navigation'
+
+import { Spinner } from '@/components/custom/spinner'
 import { config } from '@/config'
+import { useTicketScreenPermissionGate } from '@/hooks/useTicketScreenPermissionGate'
 
 import { ShiftClosingView } from '../components/shift-closing-view'
 
-type PageProps = {
-  params: Promise<{ shiftClosingId: string }>
-}
+const SHIFT_CLOSING_SCREEN_CODE = 'shift_closing'
 
-export default async function ShiftClosingDetailPage({ params }: PageProps) {
-  if (!config.enableChamados) {
-    notFound()
-  }
-
-  const { shiftClosingId } = await params
-
+function ShiftClosingDetailPageContent({
+  shiftClosingId,
+}: {
+  shiftClosingId: string
+}) {
   return (
     <div
       className="page-content space-y-4 overflow-y-scroll pb-24"
@@ -25,4 +25,34 @@ export default async function ShiftClosingDetailPage({ params }: PageProps) {
       </div>
     </div>
   )
+}
+
+export default function ShiftClosingDetailPage() {
+  if (!config.enableChamados) {
+    notFound()
+  }
+
+  const params = useParams<{ shiftClosingId: string }>()
+  const shiftClosingId = params.shiftClosingId
+
+  const { allowed, resolved } = useTicketScreenPermissionGate(
+    SHIFT_CLOSING_SCREEN_CODE,
+  )
+
+  if (!resolved || !allowed) {
+    return (
+      <div
+        className="page-content flex min-h-screen flex-col items-center justify-center px-6 py-6"
+        style={{ backgroundColor: '#0c161f' }}
+      >
+        <Spinner />
+      </div>
+    )
+  }
+
+  if (!shiftClosingId) {
+    notFound()
+  }
+
+  return <ShiftClosingDetailPageContent shiftClosingId={shiftClosingId} />
 }

--- a/src/app/(app)/demandas/fechamentos/fechar/page.tsx
+++ b/src/app/(app)/demandas/fechamentos/fechar/page.tsx
@@ -1,14 +1,16 @@
+'use client'
+
 import { notFound } from 'next/navigation'
 
+import { Spinner } from '@/components/custom/spinner'
 import { config } from '@/config'
+import { useTicketScreenPermissionGate } from '@/hooks/useTicketScreenPermissionGate'
 
 import { ShiftClosingView } from '../components/shift-closing-view'
 
-export default function ShiftClosingPage() {
-  if (!config.enableChamados) {
-    notFound()
-  }
+const SHIFT_CLOSING_SCREEN_CODE = 'shift_closing'
 
+function ShiftClosingPageContent() {
   return (
     <div
       className="page-content space-y-4 overflow-y-scroll pb-24"
@@ -19,4 +21,27 @@ export default function ShiftClosingPage() {
       </div>
     </div>
   )
+}
+
+export default function ShiftClosingPage() {
+  if (!config.enableChamados) {
+    notFound()
+  }
+
+  const { allowed, resolved } = useTicketScreenPermissionGate(
+    SHIFT_CLOSING_SCREEN_CODE,
+  )
+
+  if (!resolved || !allowed) {
+    return (
+      <div
+        className="page-content flex min-h-screen flex-col items-center justify-center px-6 py-6"
+        style={{ backgroundColor: '#0c161f' }}
+      >
+        <Spinner />
+      </div>
+    )
+  }
+
+  return <ShiftClosingPageContent />
 }

--- a/src/app/(app)/demandas/fechamentos/page.tsx
+++ b/src/app/(app)/demandas/fechamentos/page.tsx
@@ -1,14 +1,16 @@
+'use client'
+
 import { notFound } from 'next/navigation'
 
+import { Spinner } from '@/components/custom/spinner'
 import { config } from '@/config'
+import { useTicketScreenPermissionGate } from '@/hooks/useTicketScreenPermissionGate'
 
 import { ShiftClosingsList } from './components/shift-closings-list'
 
-export default function ShiftClosingsPage() {
-  if (!config.enableChamados) {
-    notFound()
-  }
+const SHIFT_CLOSING_SCREEN_CODE = 'shift_closing'
 
+function ShiftClosingsPageContent() {
   return (
     <div
       className="page-content space-y-4 overflow-y-scroll pb-24"
@@ -19,4 +21,27 @@ export default function ShiftClosingsPage() {
       </div>
     </div>
   )
+}
+
+export default function ShiftClosingsPage() {
+  if (!config.enableChamados) {
+    notFound()
+  }
+
+  const { allowed, resolved } = useTicketScreenPermissionGate(
+    SHIFT_CLOSING_SCREEN_CODE,
+  )
+
+  if (!resolved || !allowed) {
+    return (
+      <div
+        className="page-content flex min-h-screen flex-col items-center justify-center px-6 py-6"
+        style={{ backgroundColor: '#0c161f' }}
+      >
+        <Spinner />
+      </div>
+    )
+  }
+
+  return <ShiftClosingsPageContent />
 }

--- a/src/http/tickets/get-demand-volume.ts
+++ b/src/http/tickets/get-demand-volume.ts
@@ -1,0 +1,153 @@
+import { api } from '@/lib/api'
+
+export type DemandVolumeGranularity = 'monthly' | 'weekly' | 'yearly'
+
+export type DemandVolumeSummaryPeriod =
+  | 'current_year'
+  | 'current_month'
+  | 'current_week'
+
+export type TicketPriority = 'URGENTE' | 'ALTA' | 'ROTINA'
+
+export type TicketStatus =
+  | 'PENDENTE'
+  | 'RESTRITO'
+  | 'BLOQUEADO'
+  | 'AGUARDANDO_REVISAO'
+  | 'CONCLUIDO'
+
+export interface DemandVolumeFilterIn {
+  date_from?: string
+  date_to?: string
+  /** Afeta apenas summary (Total, Em aberto, Bloqueadas). Padrão: current_year */
+  summary_period?: DemandVolumeSummaryPeriod
+  requisitante?: string[]
+  prioridade?: TicketPriority[]
+  status?: TicketStatus[]
+  tipo_chamado_id?: string[]
+  relevante_imprensa?: boolean
+}
+
+export interface DemandVolumeSummaryOut {
+  total: number
+  open: number
+  blocked: number
+}
+
+export interface PeriodValueItemOut {
+  period_label: string
+  count: number
+  /** Média de referência para cor da célula (matrizes). Ausente/null em media_relevant_calls. */
+  average?: number | null
+}
+
+export interface PeriodVolumeItemOut {
+  period_label: string
+  created: number
+  closed: number
+}
+
+export interface PeriodUrgencyItemOut {
+  period_label: string
+  urgent: number
+  high: number
+  routine: number
+}
+
+export interface MatrixRowOut {
+  label: string
+  periods: PeriodValueItemOut[]
+  total: number
+}
+
+export interface DemandVolumeGranularitySeries<T> {
+  monthly: T[]
+  weekly: T[]
+  yearly: T[]
+}
+
+export function pickDemandVolumeGranularitySeries<T>(
+  series: DemandVolumeGranularitySeries<T> | undefined,
+  granularity: DemandVolumeGranularity,
+): T[] {
+  if (!series) return []
+  return series[granularity] ?? []
+}
+
+export interface DemandVolumeOut {
+  summary: DemandVolumeSummaryOut
+  total_call_volume: DemandVolumeGranularitySeries<PeriodVolumeItemOut>
+  closed_calls_by_urgency: DemandVolumeGranularitySeries<PeriodUrgencyItemOut>
+  closed_calls_by_nature: MatrixRowOut[]
+  closed_calls_by_service: MatrixRowOut[]
+  media_relevant_calls: DemandVolumeGranularitySeries<PeriodValueItemOut>
+  closed_calls_by_requester: MatrixRowOut[]
+}
+
+export function sanitizeDemandVolumeFilters(
+  filters: DemandVolumeFilterIn,
+): DemandVolumeFilterIn {
+  const payload: DemandVolumeFilterIn = { ...filters }
+
+  if (!payload.requisitante?.length) delete payload.requisitante
+  if (!payload.prioridade?.length) delete payload.prioridade
+  if (!payload.status?.length) delete payload.status
+  if (!payload.tipo_chamado_id?.length) delete payload.tipo_chamado_id
+  if (
+    payload.relevante_imprensa !== true &&
+    payload.relevante_imprensa !== false
+  ) {
+    delete payload.relevante_imprensa
+  }
+
+  return payload
+}
+
+export async function getDemandVolume(
+  filters: DemandVolumeFilterIn,
+): Promise<DemandVolumeOut> {
+  const response = await api.post(
+    '/ticket-dashboard/demand-volume',
+    sanitizeDemandVolumeFilters(filters),
+  )
+  return response.data
+}
+
+export interface DemandVolumeTicketRefOut {
+  id: string
+  name?: string
+  title?: string
+}
+
+export interface DemandVolumeTicketParentOut {
+  id: string
+  internal_number?: number
+}
+
+export interface DemandVolumeTicketItemOut {
+  id: string
+  internal_number: number
+  created_at: string
+  status: TicketStatus
+  priority: TicketPriority
+  requester_name: string
+  operation: DemandVolumeTicketRefOut | null
+  ticket_type: { id: string; name: string } | null
+  nature: DemandVolumeTicketRefOut | null
+  team: DemandVolumeTicketRefOut | null
+  parent_ticket: DemandVolumeTicketParentOut | null
+}
+
+export interface DemandVolumeTicketsOut {
+  items: DemandVolumeTicketItemOut[]
+}
+
+export async function getDemandVolumeTickets(
+  filters: DemandVolumeFilterIn,
+): Promise<DemandVolumeTicketsOut> {
+  const response = await api.post<DemandVolumeTicketsOut>(
+    '/ticket-dashboard/demand-volume/tickets',
+    sanitizeDemandVolumeFilters(filters),
+  )
+  return response.data
+}

--- a/src/http/tickets/ticket-dashboard-sla-config.ts
+++ b/src/http/tickets/ticket-dashboard-sla-config.ts
@@ -1,0 +1,83 @@
+import { api } from '@/lib/api'
+
+export type TicketDashboardSlaConfigUpdateIn = Partial<
+  Record<
+    | 'image_search_days'
+    | 'electronic_fence_days'
+    | 'radar_search_days'
+    | 'license_plate_search_days'
+    | 'related_license_plates_days'
+    | 'joint_license_plates_days'
+    | 'image_analysis_days'
+    | 'others_days',
+    number
+  >
+>
+
+export type TicketDashboardSlaConfigOut = {
+  id: string
+  created_at: string
+  updated_at: string
+  image_search_days: number
+  electronic_fence_days: number
+  radar_search_days: number
+  license_plate_search_days: number
+  related_license_plates_days: number
+  joint_license_plates_days: number
+  image_analysis_days: number
+  others_days: number
+}
+
+export type TicketDashboardSlaFormValues = {
+  image_search_days: number
+  electronic_fence_days: number
+  radar_search_days: number
+  license_plate_search_days: number
+  related_license_plates_days: number
+  joint_license_plates_days: number
+  image_analysis_days: number
+  others_days: number
+}
+
+export const SLA_CONFIG_DEFAULT_VALUES: TicketDashboardSlaFormValues = {
+  image_search_days: 3,
+  electronic_fence_days: 1,
+  radar_search_days: 2,
+  license_plate_search_days: 1,
+  related_license_plates_days: 1,
+  joint_license_plates_days: 3,
+  image_analysis_days: 1,
+  others_days: 3,
+}
+
+export function mapSlaConfigOutToFormValues(
+  config: TicketDashboardSlaConfigOut,
+): TicketDashboardSlaFormValues {
+  return {
+    image_search_days: config.image_search_days,
+    electronic_fence_days: config.electronic_fence_days,
+    radar_search_days: config.radar_search_days,
+    license_plate_search_days: config.license_plate_search_days,
+    related_license_plates_days: config.related_license_plates_days,
+    joint_license_plates_days: config.joint_license_plates_days,
+    image_analysis_days: config.image_analysis_days,
+    others_days: config.others_days,
+  }
+}
+
+export async function getTicketDashboardSlaConfig() {
+  const { data } = await api.get<TicketDashboardSlaConfigOut>(
+    '/ticket-dashboard/sla-config/',
+  )
+  return data
+}
+
+export async function updateTicketDashboardSlaConfig(
+  payload: TicketDashboardSlaConfigUpdateIn,
+) {
+  const { data } = await api.put<TicketDashboardSlaConfigOut>(
+    '/ticket-dashboard/sla-config/',
+    payload,
+  )
+  return data
+}

--- a/src/http/tickets/ticket-dashboard-widgets-config.ts
+++ b/src/http/tickets/ticket-dashboard-widgets-config.ts
@@ -1,0 +1,110 @@
+import { api } from '@/lib/api'
+
+export type TicketDashboardWidgetsConfigField =
+  | 'total_call_volume'
+  | 'closed_calls_by_urgency'
+  | 'closed_calls_by_nature'
+  | 'closed_calls_by_service'
+  | 'media_relevant_calls_volume'
+  | 'average_resolution_time_general'
+  | 'average_resolution_time_by_profile'
+  | 'average_resolution_time_by_urgency'
+  | 'delivery_time_performance_by_urgency'
+  | 'delivery_time_performance_by_service'
+  | 'delivery_time_for_media_relevant'
+  | 'open_calls_by_team'
+  | 'closed_calls_by_team'
+  | 'delivery_time_by_team'
+  | 'sla_attainment_by_team'
+  | 'closed_calls_by_requester_sphere'
+  | 'closed_calls_by_requester'
+  | 'closed_calls_by_requester_agency'
+  | 'closed_calls_by_requester_type'
+  | 'closed_calls_by_requester_institution'
+
+export type TicketDashboardWidgetsConfigUpdateIn = Partial<
+  Record<TicketDashboardWidgetsConfigField, boolean>
+>
+
+export type TicketDashboardWidgetsConfigOut = {
+  id: string
+  created_at: string
+  updated_at: string
+} & Record<TicketDashboardWidgetsConfigField, boolean>
+
+export type TicketDashboardWidgetsFormValues = Record<
+  TicketDashboardWidgetsConfigField,
+  boolean
+>
+
+export const WIDGETS_CONFIG_DEFAULT_VALUES: TicketDashboardWidgetsFormValues = {
+  total_call_volume: true,
+  closed_calls_by_urgency: true,
+  closed_calls_by_nature: true,
+  closed_calls_by_service: true,
+  media_relevant_calls_volume: true,
+  average_resolution_time_general: true,
+  average_resolution_time_by_profile: true,
+  average_resolution_time_by_urgency: true,
+  delivery_time_performance_by_urgency: true,
+  delivery_time_performance_by_service: true,
+  delivery_time_for_media_relevant: true,
+  open_calls_by_team: true,
+  closed_calls_by_team: true,
+  delivery_time_by_team: true,
+  sla_attainment_by_team: true,
+  closed_calls_by_requester_sphere: true,
+  closed_calls_by_requester: true,
+  closed_calls_by_requester_agency: true,
+  closed_calls_by_requester_type: true,
+  closed_calls_by_requester_institution: true,
+}
+
+export function mapWidgetsConfigOutToFormValues(
+  config: TicketDashboardWidgetsConfigOut,
+): TicketDashboardWidgetsFormValues {
+  return {
+    total_call_volume: config.total_call_volume,
+    closed_calls_by_urgency: config.closed_calls_by_urgency,
+    closed_calls_by_nature: config.closed_calls_by_nature,
+    closed_calls_by_service: config.closed_calls_by_service,
+    media_relevant_calls_volume: config.media_relevant_calls_volume,
+    average_resolution_time_general: config.average_resolution_time_general,
+    average_resolution_time_by_profile:
+      config.average_resolution_time_by_profile,
+    average_resolution_time_by_urgency:
+      config.average_resolution_time_by_urgency,
+    delivery_time_performance_by_urgency:
+      config.delivery_time_performance_by_urgency,
+    delivery_time_performance_by_service:
+      config.delivery_time_performance_by_service,
+    delivery_time_for_media_relevant: config.delivery_time_for_media_relevant,
+    open_calls_by_team: config.open_calls_by_team,
+    closed_calls_by_team: config.closed_calls_by_team,
+    delivery_time_by_team: config.delivery_time_by_team,
+    sla_attainment_by_team: config.sla_attainment_by_team,
+    closed_calls_by_requester_sphere: config.closed_calls_by_requester_sphere,
+    closed_calls_by_requester: config.closed_calls_by_requester,
+    closed_calls_by_requester_agency: config.closed_calls_by_requester_agency,
+    closed_calls_by_requester_type: config.closed_calls_by_requester_type,
+    closed_calls_by_requester_institution:
+      config.closed_calls_by_requester_institution,
+  }
+}
+
+export async function getTicketDashboardWidgetsConfig() {
+  const { data } = await api.get<TicketDashboardWidgetsConfigOut>(
+    '/ticket-dashboard/widgets-config/',
+  )
+  return data
+}
+
+export async function updateTicketDashboardWidgetsConfig(
+  payload: TicketDashboardWidgetsConfigUpdateIn,
+) {
+  const { data } = await api.put<TicketDashboardWidgetsConfigOut>(
+    '/ticket-dashboard/widgets-config/',
+    payload,
+  )
+  return data
+}

--- a/src/http/tickets/tickets-dashboard-filters.ts
+++ b/src/http/tickets/tickets-dashboard-filters.ts
@@ -53,33 +53,53 @@ type FocalPointSearchResponse = {
   ponto_focal: string
 }
 
+function normalizeTicketTypeItems(
+  data: TicketTypePageResponse | TicketTypeItem[],
+): TicketTypeItem[] {
+  if (Array.isArray(data)) return data
+  return data.items ?? []
+}
+
 export async function searchTicketTypes(
   search: string,
 ): Promise<SearchOption[]> {
-  const response = await api.get<TicketTypePageResponse>('/ticket-types', {
-    params: {
-      search,
-      isActive: true,
+  const response = await api.get<TicketTypePageResponse | TicketTypeItem[]>(
+    '/ticket-types',
+    {
+      params: {
+        search,
+        isActive: true,
+      },
     },
-  })
+  )
 
-  return response.data.items.map((item) => ({
+  return normalizeTicketTypeItems(response.data).map((item) => ({
     label: item.name,
     value: item.id,
   }))
 }
 
+function normalizeTicketNatureItems(
+  data: TicketNaturePageResponse | TicketNatureItem[],
+): TicketNatureItem[] {
+  if (Array.isArray(data)) return data
+  return data.items ?? []
+}
+
 export async function searchTicketNatures(
   search: string,
 ): Promise<SearchOption[]> {
-  const response = await api.get<TicketNaturePageResponse>('/ticket-natures', {
-    params: {
-      search,
-      isActive: true,
+  const response = await api.get<TicketNaturePageResponse | TicketNatureItem[]>(
+    '/ticket-natures',
+    {
+      params: {
+        search,
+        isActive: true,
+      },
     },
-  })
+  )
 
-  return response.data.items.map((item) => ({
+  return normalizeTicketNatureItems(response.data).map((item) => ({
     label: item.name,
     value: item.id,
   }))


### PR DESCRIPTION
## Description

This branch adds three main areas to the **Demandas** module, plus ticket detail improvements:

### 1. Shift closing (`shift_closing`)
- New route `/demandas/fechamentos` with paginated list, filters (team, closed-by user, shift date), and detail links.
- Flow at `/demandas/fechamentos/fechar` to preview and persist a shift closing for a time window (date + start/end time + optional comment).
- Detail page `/demandas/fechamentos/[shiftClosingId]` with cards for tickets included in the closing.
- HTTP integration: `previewTicketShiftClosing`, `persistTicketShiftClosing`, `getTicketShiftClosing`, `getTicketShiftClosings`.
- **Fechamentos** sidebar entry with `ticketScreenCode: 'shift_closing'` and screen permission gate.

### 2. Operational dashboard configuration
- **Dashboard SLA** (`/demandas/dashboard/sla`): SLA configuration form with API persistence.
- **Visualization** (`/demandas/dashboard/visualizacao`): dashboard widget configuration.
- Tabbed layout (SLA / Visualization) and sidebar entry **Dashboard SLA**.

### 3. Tactical dashboard — Volume
- New area `/demandas/dashboard-tatico/volume` for demand volume analysis.
- Summary cards (total, open, blocked), charts (total volume, urgency, press-relevant calls), matrix tables, and advanced filters (modal + period presets).
- Data export dialog.
- `getDemandVolume` client with filter types, granularity (monthly/weekly/yearly), and time series.

### 4. Ticket detail improvements
- Centralized GCS upload (`ticket-gcs-upload.ts`), ZIP support, and upload progress notifications.
- Pending attachment handling (`ticket-pending-attachment.ts`): rename, state management, and refactor of `ticket-servico-anexos.tsx`.
- Reassign textarea styles and tab/CSS updates on the ticket detail view.

### 5. Feature-flag access control
- Demandas pages (teams, profiles, workflow, screen permissions, converter, shift closings, etc.) return `notFound()` when `config.enableChamados` is false, consistent with other module routes.


## Motivation and Context

Shift closing lets teams formally record which tickets were handled in a given window, with a searchable history for operations and audit. Dashboards (SLA, widgets, and tactical volume) provide managerial visibility and configurability beyond the ticket list. Attachment/upload improvements reduce friction during service (large files, ZIP, rename before send). `notFound` when `enableChamados` is off prevents orphan routes when the tickets module is disabled in an environment.

## How has this been tested?
<!-- Fill in what was validated manually -->

Suggested test plan:
- [ ] With `enableChamados=true` and `shift_closing` permission: list closings, filter, open detail, create closing (preview → save).
- [ ] Without permission or with flag off: spinner / `notFound` as expected per route.
- [ ] Dashboard SLA: load, edit, and save configuration.
- [ ] Dashboard Visualization: change widgets and persist.
- [ ] Tactical volume dashboard: filters, chart granularity, matrices, and export.
- [ ] Ticket detail: attachment upload (incl. ZIP), rename pending file, reassign with comment.
- [ ] Sidebar: Fechamentos, Dashboard SLA, and Tactical Dashboard respect screen permissions.

## Screenshots (if appropriate)
<img width="1723" height="829" alt="image" src="https://github.com/user-attachments/assets/4f447d45-136c-47e0-924f-4e5362716d5f" />
## Types of changes

- [ ] fix: correction of bugs in the system
- [x] feat: new feature
- [ ] perf: performance improvement
- [ ] test: tests added or updated
- [x] refactor: refactoring without business logic change
- [ ] style: formatting / style only
- [ ] chore: tooling or non-production changes
- [ ] docs: documentation
- [ ] build: build or dependencies
- [ ] ci: CI configuration
- [ ] revert: revert of a previous commit

## Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.