### PR TITLE
refactor: update SLA and widgets configuration forms to use watched v…

### DIFF
--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-filter-modal.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-filter-modal.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 
 import filterModalStyles from '@/app/(app)/demandas/list/components/filter/tickets-general-list-filters.module.css'
 import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
 import { getTicketTypes } from '@/http/ticket-types/get-ticket.types'
 import {
   type SearchOption,
@@ -16,7 +17,6 @@ import {
   DEMAND_VOLUME_PRIORITY_OPTIONS,
   DEMAND_VOLUME_STATUS_OPTIONS,
   type DemandVolumeAdvancedFilterForm,
-  type DemandVolumePressFilter,
   emptyDemandVolumeAdvancedFilters,
 } from './demand-volume-filter-utils'
 
@@ -189,35 +189,22 @@ function PressRelevanceField({
   value,
   onChange,
 }: {
-  value: DemandVolumePressFilter
-  onChange: (value: DemandVolumePressFilter) => void
+  value: boolean
+  onChange: (value: boolean) => void
 }) {
-  const options: { value: DemandVolumePressFilter; label: string }[] = [
-    { value: 'all', label: 'Todos' },
-    { value: 'yes', label: 'Sim' },
-    { value: 'no', label: 'Não' },
-  ]
-
   return (
     <div className={filterModalStyles.filterBlock}>
       <span className={filterModalStyles.filterLabel}>
         RELEVANTE PARA IMPRENSA?
       </span>
-      <div
-        className={`${filterModalStyles.toggleGrid} ${filterModalStyles.toggleGridLastFull}`}
-      >
-        {options.map((option) => (
-          <button
-            key={option.value}
-            type="button"
-            className={`${filterModalStyles.toggleButton} ${
-              value === option.value ? filterModalStyles.toggleButtonActive : ''
-            }`}
-            onClick={() => onChange(option.value)}
-          >
-            {option.label}
-          </button>
-        ))}
+      <div className="flex items-center gap-2 pt-1">
+        <Switch
+          id="demand-volume-relevante-imprensa"
+          size="sm"
+          checked={value}
+          onCheckedChange={onChange}
+        />
+        <span className="text-sm text-[#91a6bc]">{value ? 'Sim' : 'Não'}</span>
       </div>
     </div>
   )

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-filter-utils.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-filter-utils.ts
@@ -5,14 +5,12 @@ import type {
 } from '@/http/tickets/get-demand-volume'
 import type { SearchOption } from '@/http/tickets/tickets-dashboard-filters'
 
-export type DemandVolumePressFilter = 'all' | 'yes' | 'no'
-
 export type DemandVolumeAdvancedFilterForm = {
   requisitante: SearchOption[]
   prioridade: SearchOption[]
   status: SearchOption[]
   tipo_chamado_id: SearchOption[]
-  relevanteImprensa: DemandVolumePressFilter
+  relevanteImprensa: boolean
 }
 
 export const DEMAND_VOLUME_PRIORITY_OPTIONS: SearchOption[] = [
@@ -42,7 +40,7 @@ export function emptyDemandVolumeAdvancedFilters(): DemandVolumeAdvancedFilterFo
     prioridade: [],
     status: [],
     tipo_chamado_id: [],
-    relevanteImprensa: 'all',
+    relevanteImprensa: false,
   }
 }
 
@@ -54,7 +52,7 @@ export function countDemandVolumeAdvancedFilters(
   count += form.prioridade.length
   count += form.status.length
   count += form.tipo_chamado_id.length
-  if (form.relevanteImprensa !== 'all') count += 1
+  if (form.relevanteImprensa) count += 1
   return count
 }
 
@@ -66,10 +64,7 @@ export function countDemandVolumeAdvancedFiltersFromApi(
   count += filters.prioridade?.length ?? 0
   count += filters.status?.length ?? 0
   count += filters.tipo_chamado_id?.length ?? 0
-  if (
-    filters.relevante_imprensa === true ||
-    filters.relevante_imprensa === false
-  ) {
+  if (filters.relevante_imprensa === true) {
     count += 1
   }
   return count
@@ -89,10 +84,6 @@ function toSearchOptions(
 export function advancedFiltersFromApi(
   filters: DemandVolumeFilterIn,
 ): DemandVolumeAdvancedFilterForm {
-  let relevanteImprensa: DemandVolumePressFilter = 'all'
-  if (filters.relevante_imprensa === true) relevanteImprensa = 'yes'
-  if (filters.relevante_imprensa === false) relevanteImprensa = 'no'
-
   return {
     requisitante: (filters.requisitante ?? []).map((value) => ({
       value,
@@ -110,7 +101,7 @@ export function advancedFiltersFromApi(
       value,
       label: value,
     })),
-    relevanteImprensa,
+    relevanteImprensa: filters.relevante_imprensa === true,
   }
 }
 
@@ -137,12 +128,7 @@ export function advancedFiltersToApiPatch(
     tipo_chamado_id: form.tipo_chamado_id.length
       ? form.tipo_chamado_id.map((item) => item.value)
       : undefined,
-    relevante_imprensa:
-      form.relevanteImprensa === 'yes'
-        ? true
-        : form.relevanteImprensa === 'no'
-          ? false
-          : undefined,
+    relevante_imprensa: form.relevanteImprensa ? true : null,
   }
 }
 
@@ -182,9 +168,6 @@ export function formatDemandVolumeAdvancedFiltersSummary(
   }
   if (filters.relevante_imprensa === true) {
     lines.push('Relevante para imprensa: Sim')
-  }
-  if (filters.relevante_imprensa === false) {
-    lines.push('Relevante para imprensa: Não')
   }
   return lines
 }

--- a/src/app/(app)/demandas/dashboard/sla/components/sla-config-form.tsx
+++ b/src/app/(app)/demandas/dashboard/sla/components/sla-config-form.tsx
@@ -96,7 +96,14 @@ export function SlaConfigForm() {
       defaultValues: SLA_CONFIG_DEFAULT_VALUES,
     })
 
-  const currentValues = useWatch({ control }) ?? SLA_CONFIG_DEFAULT_VALUES
+  const watchedValues = useWatch({
+    control,
+    defaultValue: SLA_CONFIG_DEFAULT_VALUES,
+  })
+  const currentValues: TicketDashboardSlaFormValues = {
+    ...SLA_CONFIG_DEFAULT_VALUES,
+    ...watchedValues,
+  }
 
   const hasChanges = useMemo(
     () => !areFormValuesEqual(currentValues, savedValues),

--- a/src/app/(app)/demandas/dashboard/visualizacao/components/widgets-config-form.tsx
+++ b/src/app/(app)/demandas/dashboard/visualizacao/components/widgets-config-form.tsx
@@ -94,7 +94,14 @@ export function WidgetsConfigForm() {
       defaultValues: WIDGETS_CONFIG_DEFAULT_VALUES,
     })
 
-  const currentValues = useWatch({ control }) ?? WIDGETS_CONFIG_DEFAULT_VALUES
+  const watchedValues = useWatch({
+    control,
+    defaultValue: WIDGETS_CONFIG_DEFAULT_VALUES,
+  })
+  const currentValues: TicketDashboardWidgetsFormValues = {
+    ...WIDGETS_CONFIG_DEFAULT_VALUES,
+    ...watchedValues,
+  }
 
   const hasChanges = useMemo(
     () => !areFormValuesEqual(currentValues, savedValues),

--- a/src/http/tickets/get-demand-volume.ts
+++ b/src/http/tickets/get-demand-volume.ts
@@ -25,7 +25,7 @@ export interface DemandVolumeFilterIn {
   prioridade?: TicketPriority[]
   status?: TicketStatus[]
   tipo_chamado_id?: string[]
-  relevante_imprensa?: boolean
+  relevante_imprensa?: boolean | null
 }
 
 export interface DemandVolumeSummaryOut {
@@ -93,10 +93,7 @@ export function sanitizeDemandVolumeFilters(
   if (!payload.prioridade?.length) delete payload.prioridade
   if (!payload.status?.length) delete payload.status
   if (!payload.tipo_chamado_id?.length) delete payload.tipo_chamado_id
-  if (
-    payload.relevante_imprensa !== true &&
-    payload.relevante_imprensa !== false
-  ) {
+  if (payload.relevante_imprensa === undefined) {
     delete payload.relevante_imprensa
   }
 


### PR DESCRIPTION
## Description

This branch consolidates improvements to the **Demands/Tickets** module, focused on **shift closing**, **dashboards**, and refinements to the **ticket detail** experience.

### Shift closings (`/demandas/fechamentos`)
- List view with filters (period, team, adjunct) and a link to **Close shift**
- Preview and persist flows via API (`/tickets/shift-closing`, `/tickets/shift-closings`)
- Detail screen by `shiftClosingId` with ticket cards, service tags, and comment
- Permission gate (`shift_closing`) and `notFound` when `config.enableChamados` is disabled
- **Fechamentos** item added to the sidebar

### Tactical dashboard — Volume (`/demandas/dashboard-tatico/volume`)
- View with summary cards, charts (total volume, urgency, average), matrices, and advanced filters (modal)
- CSV export with `toCsvScalar` for scalar values
- HTTP integration via `getDemandVolume` and period/filter utilities
- **Press relevance** filter simplified to a boolean `Switch` (sends `true` or `null` to the API)

### Dashboard — SLA and widgets configuration (`/demandas/dashboard`)
- SLA and Visualization tabs with forms persisted via API
- Fix for unsaved-change detection using `useWatch` merged with default values (avoids `undefined` in form control)

### Ticket detail
- GCS upload (including ZIP) with progress and pending attachment management (rename, etc.)
- Refactor of the **Services** tab and attachments

### Other
- `notFound` on teams, profiles, screen permissions, and workflow pages when Tickets is disabled
- Minor adjustments to the email converter and related pages

## Related Issue
<!-- Add issue link if applicable -->

## Motivation and Context

Operators need to **close shifts** with a consolidated view of tickets in the period, while managers need **tactical and configurable dashboards** (volume, SLA, widgets). This branch delivers those flows in the Civitas frontend and aligns filters/forms with the API contract (e.g. `relevante_imprensa` as an explicit boolean).

## How has this been tested?
<!-- Fill in with what was manually validated -->

Suggested validation:
- [ ] List and filter shift closings; open detail; close shift (preview → save)
- [ ] `shift_closing` permission and `enableChamados` flag (403/spinner vs `notFound`)
- [ ] Tactical dashboard: filters, charts, CSV export, “Press relevance” switch
- [ ] Save/restore SLA and widget config; confirm “unsaved changes” detection
- [ ] Upload/attachments on the ticket Services tab (including ZIP)

## Screenshots (if appropriate):
<!-- Add screenshots for shift closing, tactical dashboard, and SLA/widget config flows -->

## Types of changes

- [ ] fix: used when there is correction of errors that are generating bugs in the system.
- [x] feat: indicates the development of a new feature for the project.
- [ ] perf: indicates a change that improved system performance.
- [ ] test: indicates any type of creation or change of test codes.
- [x] refactor: used when there is a code refactoring that does not have any type of impact on the system's business logic/rules.
- [ ] style: used when there are formatting and code style changes that do not alter the system in any way.
- [ ] chore: indicates changes to the project that do not affect the system or test files.
- [ ] docs: used when there are changes to the project documentation.
- [ ] build: used to indicate changes that affect the project's build process or external dependencies.
- [ ] ci: used for changes to CI configuration files.
- [ ] revert: indicates the revert of a previous commit

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.