### PR TITLE
feat: enhance ticket detail components with new camera input fields, …

### DIFF
--- a/src/app/(app)/components/sidebar/components/constants.ts
+++ b/src/app/(app)/components/sidebar/components/constants.ts
@@ -108,7 +108,7 @@ const demandasItem: Category = {
     },
     {
       icon: 'Gauge',
-      title: 'Dashboard SLA',
+      title: 'Configuração SLA',
       path: '/demandas/dashboard/sla',
       ticketScreenCode: 'sla_config',
     },

--- a/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-chamado.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-chamado.tsx
@@ -32,15 +32,20 @@ import {
   normalizeNumeroOficio,
 } from '@/utils/string-formatters'
 
+import { shouldShowTicketSeiFields } from '../ticket-detail.constants'
 import styles from '../ticket-detail.module.css'
 
 const MAX_OFICIO_PROC = 60
 const MAX_APELIDO = 120
+const MAX_NUMERO_SEI = 60
+const MAX_LINK_SEI = 2048
 
 const SERVICE_PREVIEW = 3
 
 type Props = {
   ticketId: string
+  ticketStateId?: string | null
+  ticketStatus?: string | null
 }
 
 function displayText(value?: string | null) {
@@ -101,6 +106,12 @@ function mapOutToDraft(f: TicketFichaOut): TicketFichaUpdateIn {
       ? f.apelido_imprensa.trim()
       : null,
     link_materia: f.link_materia?.trim() ? f.link_materia.trim() : null,
+    numero_processo_sei: f.numero_processo_sei?.trim()
+      ? f.numero_processo_sei.trim()
+      : null,
+    link_processo_sei: f.link_processo_sei?.trim()
+      ? f.link_processo_sei.trim()
+      : null,
   }
 }
 
@@ -117,7 +128,11 @@ function normalizeHttpUrl(raw: string): string | null {
   return null
 }
 
-export function TicketDetailTabChamado({ ticketId }: Props) {
+export function TicketDetailTabChamado({
+  ticketId,
+  ticketStateId,
+  ticketStatus,
+}: Props) {
   const queryClient = useQueryClient()
   const [isEditing, setIsEditing] = useState(false)
   const [draft, setDraft] = useState<TicketFichaUpdateIn | null>(null)
@@ -231,6 +246,27 @@ export function TicketDetailTabChamado({ ticketId }: Props) {
       linkOut = normalized
     }
 
+    const numeroSei = draft.numero_processo_sei?.trim() ?? ''
+    if (numeroSei.length > MAX_NUMERO_SEI) {
+      toast.error(`Nº SEI: no máximo ${MAX_NUMERO_SEI} caracteres.`)
+      return
+    }
+
+    let linkSeiOut: string | null = null
+    const linkSeiRaw = draft.link_processo_sei?.trim() ?? ''
+    if (linkSeiRaw) {
+      if (linkSeiRaw.length > MAX_LINK_SEI) {
+        toast.error(`Link SEI: no máximo ${MAX_LINK_SEI} caracteres.`)
+        return
+      }
+      const normalized = normalizeHttpUrl(linkSeiRaw)
+      if (!normalized) {
+        toast.error('Informe um link válido (URL) para o processo SEI.')
+        return
+      }
+      linkSeiOut = normalized
+    }
+
     const payload: TicketFichaUpdateIn = {
       tipo_chamado_id: draft.tipo_chamado_id.trim(),
       numero_oficio: oficio || null,
@@ -239,6 +275,8 @@ export function TicketDetailTabChamado({ ticketId }: Props) {
       possui_apelido_imprensa: draft.possui_apelido_imprensa,
       apelido_imprensa: apelido || null,
       link_materia: linkOut,
+      numero_processo_sei: numeroSei || null,
+      link_processo_sei: linkSeiOut,
     }
 
     updateMutation.mutate(payload)
@@ -275,6 +313,12 @@ export function TicketDetailTabChamado({ ticketId }: Props) {
   const pressSimNao = d.possui_apelido_imprensa ? 'Sim' : 'Não'
   const linkRaw =
     (isEditing && draft ? draft.link_materia : view.link_materia)?.trim() ?? ''
+  const showSeiFields = shouldShowTicketSeiFields(ticketStateId, ticketStatus)
+  const linkSeiRaw =
+    (isEditing && draft
+      ? draft.link_processo_sei
+      : view.link_processo_sei
+    )?.trim() ?? ''
 
   return (
     <div className={styles.panel} role="tabpanel">
@@ -596,6 +640,87 @@ export function TicketDetailTabChamado({ ticketId }: Props) {
             </div>
           </div>
         </div>
+
+        {showSeiFields ? (
+          <div className={styles.fieldBlock}>
+            <div>
+              <p className={styles.sectionTitle} role="heading" aria-level={2}>
+                Processo SEI
+              </p>
+            </div>
+            <div className={styles.chamadoTwoCol}>
+              <div className={styles.chamadoCol}>
+                <div className={styles.subLabel}>
+                  <span className={styles.subLabelText}>Número SEI</span>
+                </div>
+                {isEditing ? (
+                  <input
+                    className={`${styles.editableField} ${styles.solicitanteEditField}`}
+                    value={d.numero_processo_sei ?? ''}
+                    maxLength={MAX_NUMERO_SEI}
+                    onChange={(e) =>
+                      setDraft((prev) =>
+                        prev
+                          ? {
+                              ...prev,
+                              numero_processo_sei: e.target.value || null,
+                            }
+                          : prev,
+                      )
+                    }
+                  />
+                ) : (
+                  <div
+                    className={`${styles.readonlyInput} ${styles.solicitanteReadOnlyText}`}
+                  >
+                    {displayText(view.numero_processo_sei)}
+                  </div>
+                )}
+              </div>
+              <div className={styles.chamadoCol}>
+                <div className={styles.subLabel}>
+                  <span className={styles.subLabelText}>Link SEI</span>
+                </div>
+                {isEditing ? (
+                  <input
+                    className={`${styles.editableField} ${styles.solicitanteEditField}`}
+                    type="url"
+                    value={d.link_processo_sei ?? ''}
+                    maxLength={MAX_LINK_SEI}
+                    onChange={(e) =>
+                      setDraft((prev) =>
+                        prev
+                          ? {
+                              ...prev,
+                              link_processo_sei: e.target.value || null,
+                            }
+                          : prev,
+                      )
+                    }
+                    placeholder="https://…"
+                  />
+                ) : (
+                  <div
+                    className={`${styles.readonlyInput} ${styles.readonlyInputLinkCell}`}
+                  >
+                    {linkSeiRaw ? (
+                      <a
+                        href={linkSeiRaw}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={styles.linkExternal}
+                      >
+                        {linkSeiRaw}
+                      </a>
+                    ) : (
+                      <span className={styles.readonlyInputMuted}>—</span>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        ) : null}
 
         <div className={styles.fieldBlock}>
           <div>

--- a/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-historico.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-historico.tsx
@@ -28,6 +28,47 @@ function badgeClassForPapel(papel: string): string {
   return styles.parecerBadgeDefault
 }
 
+/** Limite para exibir ação longa em bloco colapsável. */
+const HISTORICO_ACAO_LONG_MIN_CHARS = 160
+
+function formatAcaoDisplay(raw: string): string {
+  const trimmed = raw.trim()
+  if (!trimmed) return ''
+  return trimmed.startsWith('-') ? trimmed : `- ${trimmed}`
+}
+
+function isHistoricoAcaoLong(raw: string): boolean {
+  const trimmed = raw.trim()
+  if (!trimmed) return false
+  return (
+    trimmed.includes('\n') || trimmed.length > HISTORICO_ACAO_LONG_MIN_CHARS
+  )
+}
+
+function historicoAcaoSummaryLine(raw: string): string {
+  const first = raw.trim().split('\n')[0]?.trim() ?? ''
+  if (first.length <= 120) return first
+  return `${first.slice(0, 117)}…`
+}
+
+function HistoricoAcao({ acaoRaw }: { acaoRaw: string }) {
+  const text = formatAcaoDisplay(acaoRaw)
+  if (!text) return null
+
+  if (!isHistoricoAcaoLong(acaoRaw)) {
+    return <p className={styles.historicoAction}>{text}</p>
+  }
+
+  return (
+    <details className={styles.historicoActionDetails}>
+      <summary className={styles.historicoActionSummary}>
+        {historicoAcaoSummaryLine(acaoRaw)}
+      </summary>
+      <p className={styles.historicoActionBody}>{text}</p>
+    </details>
+  )
+}
+
 export function TicketDetailTabHistorico({ ticketId }: Props) {
   const query = useQuery({
     queryKey: ['ticket-logs', ticketId],
@@ -67,9 +108,10 @@ export function TicketDetailTabHistorico({ ticketId }: Props) {
       >
         {items.map((item, index) => {
           const isLast = index === items.length - 1
-          const nome = (item.autor_nome || '').trim() || '—'
+          const autorNome = (item.autor_nome || '').trim()
           const papel = (item.autor_papeis[0] || '').trim()
           const acaoRaw = (item.acao || '').trim()
+          const hasAuthor = Boolean(autorNome) || Boolean(papel)
           return (
             <li key={item.id} className={styles.historicoRow}>
               <div className={styles.historicoRail} aria-hidden>
@@ -83,24 +125,22 @@ export function TicketDetailTabHistorico({ ticketId }: Props) {
                 >
                   {formatHistoricoTimestamp(item.criado_em)}
                 </time>
-                <div className={styles.historicoTextRow}>
-                  <span className={styles.historicoNameGroup}>
-                    <span className={styles.historicoName}>{nome}</span>
-                    {papel ? (
-                      <span
-                        className={`${styles.parecerBadge} ${badgeClassForPapel(papel)}`}
-                      >
-                        {papel}
+                <div className={styles.historicoEntry}>
+                  {hasAuthor ? (
+                    <div className={styles.historicoEntryHeader}>
+                      <span className={styles.historicoName}>
+                        {autorNome || '—'}
                       </span>
-                    ) : null}
-                  </span>
-                  {acaoRaw ? (
-                    <span className={styles.historicoAction}>
-                      {acaoRaw.startsWith('-')
-                        ? ` ${acaoRaw}`
-                        : ` - ${acaoRaw}`}
-                    </span>
+                      {papel ? (
+                        <span
+                          className={`${styles.parecerBadge} ${badgeClassForPapel(papel)}`}
+                        >
+                          {papel}
+                        </span>
+                      ) : null}
+                    </div>
                   ) : null}
+                  <HistoricoAcao acaoRaw={acaoRaw} />
                 </div>
               </div>
             </li>

--- a/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-resposta.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-resposta.tsx
@@ -19,11 +19,14 @@ import {
   getStandardizedResponseById,
   listStandardizedResponses,
 } from '@/http/standardized-responses/standardized-responses'
+import { fetchTicketServiceAttachmentBlob } from '@/http/tickets/download-ticket-attachment'
+import { getTicketAllServicoAnexos } from '@/http/tickets/get-ticket-all-servico-anexos'
 import { getTicketServicoAnexos } from '@/http/tickets/get-ticket-servico-anexos'
 import {
   getTicketServicosIndice,
   type TicketServicoIndiceItem,
 } from '@/http/tickets/get-ticket-servicos-indice'
+import { getTicketServiceAttachmentPlaybackUrl } from '@/http/tickets/ticket-attachments'
 import {
   getTicketResposta,
   putTicketResposta,
@@ -34,10 +37,13 @@ import { getApiErrorMessage } from '@/utils/error-handlers'
 
 import responderStyles from '../../caixa-entrada/responder/[emailId]/components/responder-email-view.module.css'
 import detailStyles from '../ticket-detail.module.css'
+import { usesGcsSignedUrlAttachment } from './ticket-gcs-upload'
 
 const EMPTY_POP_VALUE = '__civitas_pop_empty__'
 const EMPTY_SERVICE_VALUE = '__civitas_service_empty__'
 const EMPTY_ANEXO_VALUE = '__civitas_anexo_empty__'
+/** Validade do link ao abrir vídeo/ZIP na aba Resposta (15 min). */
+const RESPOSTA_PLAYBACK_EXPIRATION_MINUTES = 15
 
 type RespostaAnexoSelecionado = TicketAttachmentWithPlaybackOut & {
   servico_label: string
@@ -112,6 +118,8 @@ export function TicketDetailTabResposta({ ticketId }: Props) {
   const [anexosResposta, setAnexosResposta] = useState<
     RespostaAnexoSelecionado[]
   >([])
+  const [isSelectingAllAnexos, setIsSelectingAllAnexos] = useState(false)
+  const [viewingAnexoId, setViewingAnexoId] = useState<string | null>(null)
 
   const respostaQuery = useQuery({
     queryKey: RESPOSTA_QUERY_KEY(ticketId),
@@ -236,6 +244,78 @@ export function TicketDetailTabResposta({ ticketId }: Props) {
     setDirty(true)
   }, [])
 
+  const handleAbrirAnexo = useCallback(
+    async (att: RespostaAnexoSelecionado) => {
+      if (usesGcsSignedUrlAttachment(att)) {
+        try {
+          setViewingAnexoId(att.id)
+          const { signed_url: signedUrl } =
+            await getTicketServiceAttachmentPlaybackUrl(
+              ticketId,
+              att.id,
+              RESPOSTA_PLAYBACK_EXPIRATION_MINUTES,
+            )
+          window.open(signedUrl, '_blank', 'noopener,noreferrer')
+        } catch {
+          toast.error('Não foi possível abrir o anexo.')
+        } finally {
+          setViewingAnexoId(null)
+        }
+        return
+      }
+
+      try {
+        setViewingAnexoId(att.id)
+        const { blob, contentType } = await fetchTicketServiceAttachmentBlob(
+          ticketId,
+          att.id,
+        )
+        const previewBlob = new Blob([blob], { type: contentType })
+        const previewUrl = URL.createObjectURL(previewBlob)
+        window.open(previewUrl, '_blank', 'noopener,noreferrer')
+        window.setTimeout(() => URL.revokeObjectURL(previewUrl), 60_000)
+      } catch {
+        toast.error('Não foi possível abrir o anexo.')
+      } finally {
+        setViewingAnexoId(null)
+      }
+    },
+    [ticketId],
+  )
+
+  const handleSelecionarTodosAnexos = useCallback(async () => {
+    setIsSelectingAllAnexos(true)
+    try {
+      const todos = await getTicketAllServicoAnexos(ticketId)
+      const existingIds = new Set(anexosResposta.map((a) => a.id))
+      const novos = toRespostaAnexosSelecionados(
+        todos,
+        servicosIndiceQuery.data,
+      ).filter((a) => !existingIds.has(a.id))
+
+      if (novos.length === 0) {
+        if (todos.length === 0) {
+          toast.info('Nenhum anexo encontrado nos serviços deste chamado.')
+        } else {
+          toast.info('Todos os anexos já estão na lista.')
+        }
+        return
+      }
+
+      setAnexosResposta((prev) => [...prev, ...novos])
+      setDirty(true)
+      toast.success(
+        novos.length === 1
+          ? '1 anexo incluído na lista.'
+          : `${novos.length} anexos incluídos na lista.`,
+      )
+    } catch {
+      toast.error('Não foi possível carregar os anexos dos serviços.')
+    } finally {
+      setIsSelectingAllAnexos(false)
+    }
+  }, [ticketId, servicosIndiceQuery.data, anexosResposta])
+
   useEffect(() => {
     if (respostaQuery.isLoading || respostaQuery.isError || dirty) return
     const initialBody = respostaQuery.data?.conteudo_html ?? ''
@@ -354,14 +434,28 @@ export function TicketDetailTabResposta({ ticketId }: Props) {
           </div>
 
           <div className={detailStyles.respostaAnexosBlock}>
-            <div className="space-y-1.5">
-              <Label className={tcStyles.fieldLabel}>
-                Anexos de serviços (para enviar com a resposta)
-              </Label>
-              <p className={detailStyles.respostaAnexosHint}>
-                Escolha o serviço do chamado, depois um anexo, e inclua na
-                lista. A ordem na lista é a ordem enviada ao gravar a resposta.
-              </p>
+            <div className={detailStyles.respostaAnexosHeader}>
+              <div className="min-w-0 space-y-1.5">
+                <Label className={tcStyles.fieldLabel}>
+                  Anexos de serviços (para enviar com a resposta)
+                </Label>
+                <p className={detailStyles.respostaAnexosHint}>
+                  Escolha o serviço do chamado, depois um anexo, e inclua na
+                  lista. A ordem na lista é a ordem enviada ao gravar a
+                  resposta.
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                className="shrink-0"
+                disabled={isSelectingAllAnexos}
+                onClick={handleSelecionarTodosAnexos}
+              >
+                {isSelectingAllAnexos
+                  ? 'Carregando anexos…'
+                  : 'Selecionar todos os anexos'}
+              </Button>
             </div>
 
             {servicosIndiceQuery.isError ? (
@@ -493,9 +587,38 @@ export function TicketDetailTabResposta({ ticketId }: Props) {
                       className={detailStyles.respostaAnexosListaItem}
                     >
                       <div className={detailStyles.respostaAnexosListaMeta}>
-                        <span className={detailStyles.respostaAnexosListaNome}>
-                          {a.filename}
-                        </span>
+                        {usesGcsSignedUrlAttachment(a) ? (
+                          <button
+                            type="button"
+                            className={detailStyles.respostaAnexosListaNomeLink}
+                            disabled={viewingAnexoId === a.id}
+                            onClick={() => {
+                              handleAbrirAnexo(a).catch(() => {})
+                            }}
+                          >
+                            {a.filename}
+                          </button>
+                        ) : a.playback?.signed_url?.trim() ? (
+                          <a
+                            href={a.playback.signed_url.trim()}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className={detailStyles.respostaAnexosListaNomeLink}
+                          >
+                            {a.filename}
+                          </a>
+                        ) : (
+                          <button
+                            type="button"
+                            className={detailStyles.respostaAnexosListaNomeLink}
+                            disabled={viewingAnexoId === a.id}
+                            onClick={() => {
+                              handleAbrirAnexo(a).catch(() => {})
+                            }}
+                          >
+                            {a.filename}
+                          </button>
+                        )}
                         <span className={detailStyles.respostaAnexosListaSub}>
                           {a.servico_label}
                           {' · '}

--- a/src/app/(app)/demandas/[ticketId]/components/ticket-detail-view.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-detail-view.tsx
@@ -621,18 +621,6 @@ export function TicketDetailView({ ticketId }: Props) {
                 : 'Finalizar sem Encaminhar'}
             </button>
           ) : null}
-          {canSendEmail ? (
-            <button
-              type="button"
-              className={`${styles.actionSlot} ${styles.actionSecondary}`}
-              onClick={() => setWorkflowCommentAction('ENVIAR_EMAIL')}
-              disabled={workflowActionMutation.isPending}
-            >
-              {workflowActionMutation.isPending
-                ? 'Aplicando ação…'
-                : 'Enviar E-mail'}
-            </button>
-          ) : null}
           {canSendToReview ? (
             <button
               type="button"
@@ -690,6 +678,18 @@ export function TicketDetailView({ ticketId }: Props) {
               Reatribuir Demanda
             </button>
           ) : null}
+          {canSendEmail ? (
+            <button
+              type="button"
+              className={`${styles.actionSlot} ${styles.actionPrimary}`}
+              onClick={() => setWorkflowCommentAction('ENVIAR_EMAIL')}
+              disabled={workflowActionMutation.isPending}
+            >
+              {workflowActionMutation.isPending
+                ? 'Aplicando ação…'
+                : 'Enviar E-mail'}
+            </button>
+          ) : null}
         </div>
 
         <div className={styles.tabsShell}>
@@ -718,7 +718,11 @@ export function TicketDetailView({ ticketId }: Props) {
           {activeTab === 'solicitante' ? (
             <TicketDetailTabSolicitante ticketId={ticketId} />
           ) : activeTab === 'chamado' ? (
-            <TicketDetailTabChamado ticketId={ticketId} />
+            <TicketDetailTabChamado
+              ticketId={ticketId}
+              ticketStateId={allowedActionsQuery.data?.state_id}
+              ticketStatus={cab?.status}
+            />
           ) : activeTab === 'documentos' ? (
             <div className={styles.panel} role="tabpanel">
               <TicketDetailTabDocumentos ticketId={ticketId} />

--- a/src/app/(app)/demandas/[ticketId]/components/ticket-servico-anexos.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-servico-anexos.tsx
@@ -63,9 +63,6 @@ export type { PendingServiceAttachment } from './ticket-pending-attachment'
 const MAX_MULTIPART_BYTES = 10 * 1024 * 1024
 const MAX_GCS_UPLOAD_GB = 20
 const MAX_GCS_UPLOAD_BYTES = MAX_GCS_UPLOAD_GB * 1024 * 1024 * 1024
-/** Validade do link de reprodução ao atualizar (7 h, em minutos). */
-const VIDEO_PLAYBACK_EXPIRATION_MINUTES = 7 * 60
-
 const MULTIPART_ACCEPT = [
   'application/pdf',
   'image/jpeg',
@@ -365,14 +362,7 @@ export function TicketServicoAnexos({
           : await fetchTicketAttachmentBlob(ticketId, att.id)
         const previewBlob = new Blob([blob], { type: contentType })
         const previewUrl = URL.createObjectURL(previewBlob)
-        const newTab = window.open(previewUrl, '_blank', 'noopener,noreferrer')
-
-        if (!newTab) {
-          URL.revokeObjectURL(previewUrl)
-          toast.error('Não foi possível abrir a visualização do anexo.')
-          return
-        }
-
+        window.open(previewUrl, '_blank', 'noopener,noreferrer')
         window.setTimeout(() => URL.revokeObjectURL(previewUrl), 60_000)
       } catch {
         toast.error('Não foi possível visualizar o anexo.')
@@ -434,15 +424,8 @@ export function TicketServicoAnexos({
     async (att: TicketAttachmentOut) => {
       setVideoRefreshingId(att.id)
       try {
-        const { signed_url: signedUrl } =
-          await getTicketServiceAttachmentPlaybackUrl(
-            ticketId,
-            att.id,
-            VIDEO_PLAYBACK_EXPIRATION_MINUTES,
-          )
-        const expiresAt = new Date(
-          Date.now() + VIDEO_PLAYBACK_EXPIRATION_MINUTES * 60 * 1000,
-        ).toISOString()
+        const { signed_url: signedUrl, expires_at: expiresAt } =
+          await getTicketServiceAttachmentPlaybackUrl(ticketId, att.id)
         setVideoPlaybackOverrides((prev) => ({
           ...prev,
           [att.id]: { signedUrl, expiresAt },

--- a/src/app/(app)/demandas/[ticketId]/components/ticket-servicos-expanded-form.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-servicos-expanded-form.tsx
@@ -564,6 +564,110 @@ export function ServicosExpandedForm({
               </p>
             ) : null}
           </div>
+          <div className={styles.servicosFieldBlock}>
+            <span className={styles.servicosFieldLabel}>Câmeras</span>
+            <div className={styles.servicosStack}>
+              {(item.cameras ?? []).map((cam, ci) => (
+                <Fragment key={cam.id}>
+                  <div className={styles.servicosPlateRow}>
+                    <Input
+                      className={`${styles.servicosInput} ${styles.servicosPlateInput}`}
+                      placeholder="Código da câmera"
+                      value={cam.camera_code}
+                      onChange={(e) =>
+                        patch((n) => {
+                          const cameras = [
+                            ...(n.busca_por_imagem[index].cameras ?? []),
+                          ]
+                          cameras[ci] = {
+                            ...cameras[ci],
+                            camera_code: e.target.value,
+                          }
+                          n.busca_por_imagem[index] = {
+                            ...n.busca_por_imagem[index],
+                            cameras,
+                          }
+                        })
+                      }
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className={styles.servicosIconBtn}
+                      title="Remover câmera"
+                      onClick={() =>
+                        patch((n) => {
+                          const cameras = (
+                            n.busca_por_imagem[index].cameras ?? []
+                          ).filter((_, i) => i !== ci)
+                          n.busca_por_imagem[index] = {
+                            ...n.busca_por_imagem[index],
+                            cameras,
+                          }
+                        })
+                      }
+                    >
+                      <Trash className="h-4 w-4" />
+                    </Button>
+                    {ci === (item.cameras ?? []).length - 1 ? (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className={styles.servicosAddLineBtn}
+                        onClick={() =>
+                          patch((n) => {
+                            n.busca_por_imagem[index] = {
+                              ...n.busca_por_imagem[index],
+                              cameras: [
+                                ...(n.busca_por_imagem[index].cameras ?? []),
+                                {
+                                  id: newNestedEntityId(),
+                                  created_at: nowIso(),
+                                  camera_code: '',
+                                },
+                              ],
+                            }
+                          })
+                        }
+                        aria-label="Adicionar câmera"
+                        title="Adicionar câmera"
+                      >
+                        <Plus className="h-4 w-4" />
+                      </Button>
+                    ) : null}
+                  </div>
+                </Fragment>
+              ))}
+              {(item.cameras ?? []).length === 0 ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className={styles.servicosAddLineBtn}
+                  onClick={() =>
+                    patch((n) => {
+                      n.busca_por_imagem[index] = {
+                        ...n.busca_por_imagem[index],
+                        cameras: [
+                          {
+                            id: newNestedEntityId(),
+                            created_at: nowIso(),
+                            camera_code: '',
+                          },
+                        ],
+                      }
+                    })
+                  }
+                  aria-label="Adicionar câmera"
+                  title="Adicionar câmera"
+                >
+                  <Plus className="h-4 w-4" />
+                </Button>
+              ) : null}
+            </div>
+          </div>
         </div>,
       )
     }
@@ -639,6 +743,110 @@ export function ServicosExpandedForm({
               </p>
             ) : null}
           </div>
+          <div className={styles.servicosFieldBlock}>
+            <span className={styles.servicosFieldLabel}>Câmeras</span>
+            <div className={styles.servicosStack}>
+              {(item.cameras ?? []).map((cam, ci) => (
+                <Fragment key={cam.id}>
+                  <div className={styles.servicosPlateRow}>
+                    <Input
+                      className={`${styles.servicosInput} ${styles.servicosPlateInput}`}
+                      placeholder="Código da câmera"
+                      value={cam.camera_code}
+                      onChange={(e) =>
+                        patch((n) => {
+                          const cameras = [
+                            ...(n.reserva_de_imagem[index].cameras ?? []),
+                          ]
+                          cameras[ci] = {
+                            ...cameras[ci],
+                            camera_code: e.target.value,
+                          }
+                          n.reserva_de_imagem[index] = {
+                            ...n.reserva_de_imagem[index],
+                            cameras,
+                          }
+                        })
+                      }
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className={styles.servicosIconBtn}
+                      title="Remover câmera"
+                      onClick={() =>
+                        patch((n) => {
+                          const cameras = (
+                            n.reserva_de_imagem[index].cameras ?? []
+                          ).filter((_, i) => i !== ci)
+                          n.reserva_de_imagem[index] = {
+                            ...n.reserva_de_imagem[index],
+                            cameras,
+                          }
+                        })
+                      }
+                    >
+                      <Trash className="h-4 w-4" />
+                    </Button>
+                    {ci === (item.cameras ?? []).length - 1 ? (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className={styles.servicosAddLineBtn}
+                        onClick={() =>
+                          patch((n) => {
+                            n.reserva_de_imagem[index] = {
+                              ...n.reserva_de_imagem[index],
+                              cameras: [
+                                ...(n.reserva_de_imagem[index].cameras ?? []),
+                                {
+                                  id: newNestedEntityId(),
+                                  created_at: nowIso(),
+                                  camera_code: '',
+                                },
+                              ],
+                            }
+                          })
+                        }
+                        aria-label="Adicionar câmera"
+                        title="Adicionar câmera"
+                      >
+                        <Plus className="h-4 w-4" />
+                      </Button>
+                    ) : null}
+                  </div>
+                </Fragment>
+              ))}
+              {(item.cameras ?? []).length === 0 ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className={styles.servicosAddLineBtn}
+                  onClick={() =>
+                    patch((n) => {
+                      n.reserva_de_imagem[index] = {
+                        ...n.reserva_de_imagem[index],
+                        cameras: [
+                          {
+                            id: newNestedEntityId(),
+                            created_at: nowIso(),
+                            camera_code: '',
+                          },
+                        ],
+                      }
+                    })
+                  }
+                  aria-label="Adicionar câmera"
+                  title="Adicionar câmera"
+                >
+                  <Plus className="h-4 w-4" />
+                </Button>
+              ) : null}
+            </div>
+          </div>
         </div>,
       )
     }
@@ -690,6 +898,110 @@ export function ServicosExpandedForm({
                 {fieldErrors.orientation}
               </p>
             ) : null}
+          </div>
+          <div className={styles.servicosFieldBlock}>
+            <span className={styles.servicosFieldLabel}>Câmeras</span>
+            <div className={styles.servicosStack}>
+              {(item.cameras ?? []).map((cam, ci) => (
+                <Fragment key={cam.id}>
+                  <div className={styles.servicosPlateRow}>
+                    <Input
+                      className={`${styles.servicosInput} ${styles.servicosPlateInput}`}
+                      placeholder="Código da câmera"
+                      value={cam.camera_code}
+                      onChange={(e) =>
+                        patch((n) => {
+                          const cameras = [
+                            ...(n.analise_de_imagem[index].cameras ?? []),
+                          ]
+                          cameras[ci] = {
+                            ...cameras[ci],
+                            camera_code: e.target.value,
+                          }
+                          n.analise_de_imagem[index] = {
+                            ...n.analise_de_imagem[index],
+                            cameras,
+                          }
+                        })
+                      }
+                    />
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className={styles.servicosIconBtn}
+                      title="Remover câmera"
+                      onClick={() =>
+                        patch((n) => {
+                          const cameras = (
+                            n.analise_de_imagem[index].cameras ?? []
+                          ).filter((_, i) => i !== ci)
+                          n.analise_de_imagem[index] = {
+                            ...n.analise_de_imagem[index],
+                            cameras,
+                          }
+                        })
+                      }
+                    >
+                      <Trash className="h-4 w-4" />
+                    </Button>
+                    {ci === (item.cameras ?? []).length - 1 ? (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className={styles.servicosAddLineBtn}
+                        onClick={() =>
+                          patch((n) => {
+                            n.analise_de_imagem[index] = {
+                              ...n.analise_de_imagem[index],
+                              cameras: [
+                                ...(n.analise_de_imagem[index].cameras ?? []),
+                                {
+                                  id: newNestedEntityId(),
+                                  created_at: nowIso(),
+                                  camera_code: '',
+                                },
+                              ],
+                            }
+                          })
+                        }
+                        aria-label="Adicionar câmera"
+                        title="Adicionar câmera"
+                      >
+                        <Plus className="h-4 w-4" />
+                      </Button>
+                    ) : null}
+                  </div>
+                </Fragment>
+              ))}
+              {(item.cameras ?? []).length === 0 ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className={styles.servicosAddLineBtn}
+                  onClick={() =>
+                    patch((n) => {
+                      n.analise_de_imagem[index] = {
+                        ...n.analise_de_imagem[index],
+                        cameras: [
+                          {
+                            id: newNestedEntityId(),
+                            created_at: nowIso(),
+                            camera_code: '',
+                          },
+                        ],
+                      }
+                    })
+                  }
+                  aria-label="Adicionar câmera"
+                  title="Adicionar câmera"
+                >
+                  <Plus className="h-4 w-4" />
+                </Button>
+              ) : null}
+            </div>
           </div>
         </div>,
       )

--- a/src/app/(app)/demandas/[ticketId]/ticket-detail.constants.ts
+++ b/src/app/(app)/demandas/[ticketId]/ticket-detail.constants.ts
@@ -18,8 +18,8 @@ export const TICKET_DETAIL_BASE_TABS: {
 }[] = [
   { id: 'solicitante', label: 'Solicitante' },
   { id: 'chamado', label: 'Demanda' },
-  { id: 'documentos', label: 'Documentos' },
-  { id: 'servicos', label: 'Serviços' },
+  { id: 'documentos', label: 'Documentos Recebidos' },
+  { id: 'servicos', label: 'Serviços e Documentos Elaborados' },
   { id: 'parecer_interno', label: 'Parecer Interno' },
   { id: 'relatorio_demanda', label: 'Relatório de Demanda' },
   { id: 'historico', label: 'Histórico' },
@@ -30,25 +30,44 @@ export const TICKET_RESPOSTA_TAB = {
   label: 'Resposta',
 }
 
-const RESPOSTA_TAB_STATE_ID = 'AGUARDANDO_REVISAO_ADMINISTRATIVO'
-const RESPOSTA_TAB_STATUS_RESTRITO = 'RESTRITO'
+const RESPOSTA_TAB_VISIBLE_IDS = new Set([
+  'AGUARDANDO_REVISAO_ADMINISTRATIVO',
+  'RESTRITO',
+  'DEMANDA_RESPONDIDA',
+])
 
-export function shouldShowTicketRespostaTab(
+const SEI_FIELDS_VISIBLE_STATE_IDS = new Set([
+  'FINALIZADO',
+  'DEMANDA_RESPONDIDA',
+])
+
+export function shouldShowTicketSeiFields(
   stateId: string | null | undefined,
   status: string | null | undefined,
 ) {
   const normalizedStateId = stateId?.trim().toUpperCase() ?? ''
   if (
-    normalizedStateId === RESPOSTA_TAB_STATE_ID ||
-    normalizedStateId === RESPOSTA_TAB_STATUS_RESTRITO
+    normalizedStateId &&
+    SEI_FIELDS_VISIBLE_STATE_IDS.has(normalizedStateId)
   ) {
     return true
   }
 
   const normalizedStatus = status?.trim().toUpperCase() ?? ''
   if (!normalizedStatus) return false
-  return (
-    normalizedStatus === RESPOSTA_TAB_STATE_ID ||
-    normalizedStatus === RESPOSTA_TAB_STATUS_RESTRITO
-  )
+  return SEI_FIELDS_VISIBLE_STATE_IDS.has(normalizedStatus)
+}
+
+export function shouldShowTicketRespostaTab(
+  stateId: string | null | undefined,
+  status: string | null | undefined,
+) {
+  const normalizedStateId = stateId?.trim().toUpperCase() ?? ''
+  if (normalizedStateId && RESPOSTA_TAB_VISIBLE_IDS.has(normalizedStateId)) {
+    return true
+  }
+
+  const normalizedStatus = status?.trim().toUpperCase() ?? ''
+  if (!normalizedStatus) return false
+  return RESPOSTA_TAB_VISIBLE_IDS.has(normalizedStatus)
 }

--- a/src/app/(app)/demandas/[ticketId]/ticket-detail.module.css
+++ b/src/app/(app)/demandas/[ticketId]/ticket-detail.module.css
@@ -2483,7 +2483,7 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 12px;
   width: 100%;
 }
 
@@ -2535,20 +2535,20 @@
   color: var(--td-border);
 }
 
-.historicoTextRow {
+.historicoEntry {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  width: 100%;
+  min-width: 0;
+}
+
+.historicoEntryHeader {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 8px;
   row-gap: 4px;
-}
-
-.historicoNameGroup {
-  display: inline-flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 4px;
-  min-width: 0;
 }
 
 .historicoName {
@@ -2559,10 +2559,60 @@
 }
 
 .historicoAction {
+  margin: 0;
+  width: 100%;
+  min-width: 0;
   font-size: 14px;
   font-weight: 400;
   line-height: 20px;
   color: var(--td-muted);
+  white-space: pre-line;
+  overflow-wrap: anywhere;
+  word-wrap: break-word;
+}
+
+.historicoActionDetails {
+  width: 100%;
+  min-width: 0;
+}
+
+.historicoActionSummary {
+  display: block;
+  width: 100%;
+  min-width: 0;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 20px;
+  color: var(--td-muted);
+  cursor: pointer;
+  list-style-position: outside;
+  overflow-wrap: anywhere;
+  word-wrap: break-word;
+}
+
+.historicoActionSummary:hover {
+  color: var(--td-text);
+}
+
+.historicoActionDetails[open] > .historicoActionSummary {
+  color: var(--td-text);
+  margin-bottom: 4px;
+}
+
+.historicoActionBody {
+  margin: 0;
+  padding: 8px 12px;
+  width: 100%;
+  min-width: 0;
+  border-radius: var(--td-radius);
+  background: rgba(151, 162, 171, 0.08);
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 20px;
+  color: var(--td-muted);
+  white-space: pre-line;
+  overflow-wrap: anywhere;
+  word-wrap: break-word;
 }
 
 /* —— Anexos por serviço / gerais (aba Serviços) —— */
@@ -2887,6 +2937,14 @@
   border-radius: var(--td-radius);
 }
 
+.respostaAnexosHeader {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
 .respostaAnexosHint {
   margin: 0;
   font-size: 12px;
@@ -2942,6 +3000,31 @@
 .respostaAnexosListaNome {
   font-weight: 600;
   word-break: break-word;
+}
+
+.respostaAnexosListaNomeLink {
+  display: inline;
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
+  font-weight: 600;
+  line-height: inherit;
+  text-align: left;
+  word-break: break-word;
+  color: var(--td-text);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  cursor: pointer;
+}
+
+.respostaAnexosListaNomeLink:hover:not(:disabled) {
+  filter: brightness(1.12);
+}
+
+.respostaAnexosListaNomeLink:disabled {
+  cursor: wait;
+  opacity: 0.7;
 }
 
 .respostaAnexosListaSub {

--- a/src/app/(app)/demandas/[ticketId]/ticket-servicos-mapper.ts
+++ b/src/app/(app)/demandas/[ticketId]/ticket-servicos-mapper.ts
@@ -156,6 +156,9 @@ export function ticketServicosToReplacePayload(
       plate: strOrNull(x.plate),
       address: strOrNull(x.address),
       description: strOrNull(x.description),
+      cameras: (x.cameras ?? [])
+        .map((c) => c.camera_code.trim())
+        .filter(Boolean),
     })),
     placas_correlatas: n.placas_correlatas.map((x) => ({
       ...persistedId(x.id),
@@ -187,6 +190,9 @@ export function ticketServicosToReplacePayload(
       period_start: strOrNull(x.period_start as string | null | undefined),
       period_end: strOrNull(x.period_end as string | null | undefined),
       orientation: strOrNull(x.orientation),
+      cameras: (x.cameras ?? [])
+        .map((c) => c.camera_code.trim())
+        .filter(Boolean),
     })),
     analise_de_imagem: n.analise_de_imagem.map((x) => ({
       ...persistedId(x.id),
@@ -194,6 +200,9 @@ export function ticketServicosToReplacePayload(
       period_start: strOrNull(x.period_start as string | null | undefined),
       period_end: strOrNull(x.period_end as string | null | undefined),
       orientation: strOrNull(x.orientation),
+      cameras: (x.cameras ?? [])
+        .map((c) => c.camera_code.trim())
+        .filter(Boolean),
     })),
     outros: n.outros.map((x) => ({
       ...persistedId(x.id),
@@ -330,6 +339,7 @@ export function appendEmptyService(
           plate: null,
           address: null,
           description: null,
+          cameras: [],
         },
       ]
       break
@@ -375,6 +385,7 @@ export function appendEmptyService(
           period_start: null,
           period_end: null,
           orientation: null,
+          cameras: [],
         },
       ]
       break
@@ -388,6 +399,7 @@ export function appendEmptyService(
           period_start: null,
           period_end: null,
           orientation: null,
+          cameras: [],
         },
       ]
       break

--- a/src/app/(app)/demandas/arquivados/components/ticket-archive-filters.module.css
+++ b/src/app/(app)/demandas/arquivados/components/ticket-archive-filters.module.css
@@ -29,6 +29,64 @@
   color: #97a2ab;
 }
 
+.searchTooltip {
+  position: absolute;
+  top: calc(100% + 12px);
+  left: 0;
+  z-index: 50;
+
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease,
+    visibility 0.2s ease;
+
+  transform: translateY(6px);
+}
+
+.searchWrap:hover .searchTooltip {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.searchTooltipContent {
+  position: relative;
+  min-width: 280px;
+  max-width: 420px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(91, 141, 197, 0.22);
+  background: #0e1a24;
+  box-shadow:
+    0 10px 30px rgba(0, 0, 0, 0.35),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.searchTooltipContent p {
+  margin: 0;
+  color: #97a2ab;
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.searchTooltipContent::before {
+  content: '';
+  position: absolute;
+  top: -7px;
+  left: 24px;
+  width: 14px;
+  height: 14px;
+  background: #0e1a24;
+  border-top: 1px solid rgba(91, 141, 197, 0.22);
+  border-left: 1px solid rgba(91, 141, 197, 0.22);
+  transform: rotate(45deg);
+}
+
 .modalOverlay {
   position: fixed;
   inset: 0;

--- a/src/app/(app)/demandas/arquivados/components/ticket-archive-filters.tsx
+++ b/src/app/(app)/demandas/arquivados/components/ticket-archive-filters.tsx
@@ -41,6 +41,9 @@ type SearchMultiSelectProps = {
   minCharsMessage?: string
 }
 
+const SEARCH_TOOLTIP_TEXT =
+  'Buscar por nº interno, requisitante, demandante, ofício, procedimento, ponto focal, equipe, responsável, comentários, relatório da demanda, placa, orientações ou observações'
+
 const prioridadeOptions = ['URGENTE', 'ALTA', 'ROTINA', 'SEM PRIORIDADE']
 
 const servicoOptions: SearchOption[] = [
@@ -454,6 +457,11 @@ export function ArchiveSearchField({
         onChange={(event) => onChange(event.target.value)}
         placeholder="Buscar"
       />
+      <div className={styles.searchTooltip} role="tooltip">
+        <div className={styles.searchTooltipContent}>
+          <p>{SEARCH_TOOLTIP_TEXT}</p>
+        </div>
+      </div>
     </div>
   )
 }

--- a/src/app/(app)/demandas/arquivados/components/ticket-archive-list.module.css
+++ b/src/app/(app)/demandas/arquivados/components/ticket-archive-list.module.css
@@ -64,10 +64,12 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
+  overflow: visible;
 }
 
 .tableWrap {
   overflow-x: auto;
+  overflow-y: visible;
 }
 
 .table {
@@ -92,7 +94,14 @@
   font-size: 14px;
   font-weight: 400;
   line-height: 20px;
+  vertical-align: middle;
   white-space: nowrap;
+}
+
+.chamadoCell {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .chamadoLink {
@@ -100,23 +109,48 @@
   text-decoration: none;
 }
 
+.seiTooltipTrigger {
+  display: inline-flex;
+  align-items: center;
+  cursor: help;
+  flex-shrink: 0;
+}
+
+.seiIcon {
+  color: #6eb5ff;
+  flex-shrink: 0;
+}
+
 .servicesCell {
   display: flex;
   align-items: center;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: 8px;
+  overflow: visible;
 }
 
 .serviceTag {
   display: inline-flex;
   align-items: center;
   gap: 4px;
+  height: auto;
   min-height: 20px;
   padding: 2px 6px;
   border-radius: 4px;
   font-size: 10px;
   font-weight: 600;
   line-height: 16px;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+
+.serviceTagIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 12px;
+  height: 12px;
+  flex-shrink: 0;
 }
 
 .serviceTagPink {
@@ -165,18 +199,99 @@
 }
 
 .extraTag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   min-height: 20px;
-  min-width: 28px;
-  border-radius: 4px;
+  min-width: 27px;
   padding: 1px 7px;
+  border-radius: 4px;
   background: #1d3449;
+  border: none;
   color: #f9fafa;
   font-size: 10px;
   font-weight: 600;
   line-height: 16px;
+  white-space: nowrap;
+}
+
+.extraTagWrapper {
+  position: relative;
   display: inline-flex;
   align-items: center;
-  justify-content: center;
+}
+
+.extraTooltip {
+  position: absolute;
+  top: calc(100% + 12px);
+  left: 50%;
+  transform: translateX(-50%) translateY(6px);
+  z-index: 50;
+
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease,
+    visibility 0.2s ease;
+}
+
+.extraTagWrapper:hover .extraTooltip {
+  opacity: 1;
+  visibility: visible;
+  transform: translateX(-50%) translateY(0);
+  pointer-events: auto;
+}
+
+.extraTooltipContent {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  min-width: 220px;
+  max-width: 280px;
+  max-height: 320px;
+  overflow-y: auto;
+  overflow-x: hidden;
+
+  padding: 14px 16px;
+  border-radius: 16px;
+
+  border: 1px solid rgba(91, 141, 197, 0.22);
+
+  background: #0e1a24;
+
+  box-shadow:
+    0 10px 30px rgba(0, 0, 0, 0.35),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.extraTooltipContent .serviceTag {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  justify-content: flex-start;
+}
+
+.extraTooltipContent::before {
+  content: '';
+  position: absolute;
+  top: -7px;
+  left: 50%;
+
+  width: 14px;
+  height: 14px;
+
+  background: rgba(4, 24, 44, 0.98);
+
+  border-top: 1px solid rgba(91, 141, 197, 0.22);
+  border-left: 1px solid rgba(91, 141, 197, 0.22);
+
+  transform: translateX(-50%) rotate(45deg);
 }
 
 .statusBadge {

--- a/src/app/(app)/demandas/arquivados/components/ticket-archive-list.tsx
+++ b/src/app/(app)/demandas/arquivados/components/ticket-archive-list.tsx
@@ -1,12 +1,13 @@
 'use client'
 
 import { useQuery } from '@tanstack/react-query'
-import { Download, Filter, Tag } from 'lucide-react'
+import { Download, FileText, Filter, Tag } from 'lucide-react'
 import Link from 'next/link'
 import { useCallback, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 
 import { useDebounce } from '@/components/custom/multiselect-with-search'
+import { Tooltip } from '@/components/custom/tooltip'
 import { Button } from '@/components/ui/button'
 import { Pagination } from '@/components/ui/pagination'
 import {
@@ -55,6 +56,30 @@ function parseServices(rawServices: unknown): string[] {
     .filter(Boolean)
 }
 
+function pickOptionalDate(row: Record<string, unknown>, ...keys: string[]) {
+  for (const key of keys) {
+    const value = row[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return null
+}
+
+function formatArchiveDate(value?: string | null) {
+  const raw = value?.trim()
+  return raw && raw.length > 0 ? raw : '—'
+}
+
+const SEI_PREENCHIDO_TOOLTIP = 'Processo SEI preenchido.'
+
+function parseSeiPreenchido(value: unknown): boolean {
+  if (value === true || value === 1) return true
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    return normalized === 'true' || normalized === '1'
+  }
+  return false
+}
+
 function normalizeArchiveItem(item: unknown): TicketArchiveListItem {
   const row = (item as Record<string, unknown>) ?? {}
 
@@ -66,11 +91,18 @@ function normalizeArchiveItem(item: unknown): TicketArchiveListItem {
   return {
     id,
     chamado,
+    data_conclusao: pickOptionalDate(
+      row,
+      'data_conclusao',
+      'completed_at',
+      'concluded_at',
+    ),
     demandante: String(row.demandante ?? row.demandante_nome ?? '-'),
     equipe: String(row.equipe ?? row.team_name ?? '-'),
     responsavel: String(row.responsavel ?? row.responsavel_nome ?? '-'),
     servicos: parseServices(row.servicos ?? row.services),
     status: String(row.status ?? row.situacao ?? '-'),
+    sei_preenchido: parseSeiPreenchido(row.sei_preenchido),
   }
 }
 
@@ -114,6 +146,7 @@ function escapeCsvCell(value: string): string {
 function buildArchiveCsv(rows: TicketArchiveListItem[]): string {
   const header = [
     'CHAMADO',
+    'DATA CONCLUSÃO',
     'DEMANDANTE',
     'EQUIPE',
     'RESPONSÁVEL',
@@ -127,6 +160,7 @@ function buildArchiveCsv(rows: TicketArchiveListItem[]): string {
     .map((item) =>
       [
         item.chamado,
+        formatArchiveDate(item.data_conclusao),
         item.demandante,
         item.equipe,
         item.responsavel,
@@ -303,6 +337,7 @@ export function TicketArchiveList() {
             <thead>
               <tr>
                 <th>CHAMADO</th>
+                <th>DATA CONCLUSÃO</th>
                 <th>DEMANDANTE</th>
                 <th>EQUIPE</th>
                 <th>RESPONSÁVEL</th>
@@ -314,58 +349,109 @@ export function TicketArchiveList() {
             <tbody>
               {isLoading ? (
                 <tr>
-                  <td colSpan={6} className={styles.emptyRow}>
+                  <td colSpan={7} className={styles.emptyRow}>
                     Carregando arquivo...
                   </td>
                 </tr>
               ) : items.length === 0 ? (
                 <tr>
-                  <td colSpan={6} className={styles.emptyRow}>
+                  <td colSpan={7} className={styles.emptyRow}>
                     Nenhum chamado encontrado.
                   </td>
                 </tr>
               ) : (
-                items.map((item) => (
-                  <tr key={`${item.id}-${item.chamado}`}>
-                    <td>
-                      <Link
-                        href={
-                          item.id
-                            ? `/demandas/${encodeURIComponent(item.id)}`
-                            : '#'
-                        }
-                        className={styles.chamadoLink}
-                      >
-                        {item.chamado}
-                      </Link>
-                    </td>
-                    <td>{item.demandante}</td>
-                    <td>{item.equipe}</td>
-                    <td>{item.responsavel}</td>
-                    <td>
-                      <div className={styles.servicesCell}>
-                        {item.servicos.slice(0, 3).map((service) => (
-                          <span
-                            key={`${item.id}-${service}`}
-                            className={`${styles.serviceTag} ${getServiceClassName(service)}`}
-                          >
-                            <Tag size={12} />
-                            {service}
-                          </span>
-                        ))}
+                items.map((item) => {
+                  const previewServices = item.servicos.slice(0, 2)
+                  const extraCount = Math.max(
+                    item.servicos.length - previewServices.length,
+                    0,
+                  )
 
-                        {item.servicos.length > 3 ? (
-                          <span className={styles.extraTag}>
-                            +{item.servicos.length - 3}
-                          </span>
-                        ) : null}
-                      </div>
-                    </td>
-                    <td>
-                      <span className={styles.statusBadge}>{item.status}</span>
-                    </td>
-                  </tr>
-                ))
+                  return (
+                    <tr key={`${item.id}-${item.chamado}`}>
+                      <td>
+                        <div className={styles.chamadoCell}>
+                          <Link
+                            href={
+                              item.id
+                                ? `/demandas/${encodeURIComponent(item.id)}`
+                                : '#'
+                            }
+                            className={styles.chamadoLink}
+                          >
+                            {item.chamado}
+                          </Link>
+                          {item.sei_preenchido ? (
+                            <Tooltip asChild text={SEI_PREENCHIDO_TOOLTIP}>
+                              <span
+                                className={styles.seiTooltipTrigger}
+                                aria-label={SEI_PREENCHIDO_TOOLTIP}
+                              >
+                                <FileText
+                                  className={styles.seiIcon}
+                                  size={14}
+                                  aria-hidden
+                                />
+                              </span>
+                            </Tooltip>
+                          ) : null}
+                        </div>
+                      </td>
+                      <td>{formatArchiveDate(item.data_conclusao)}</td>
+                      <td>{item.demandante}</td>
+                      <td>{item.equipe}</td>
+                      <td>{item.responsavel}</td>
+                      <td>
+                        <div className={styles.servicesCell}>
+                          {previewServices.map((service, index) => (
+                            <span
+                              key={`${item.id}-${service}-${index}`}
+                              className={`${styles.serviceTag} ${getServiceClassName(service)}`}
+                            >
+                              <Tag
+                                className={styles.serviceTagIcon}
+                                strokeWidth={2}
+                              />
+                              <span>{service}</span>
+                            </span>
+                          ))}
+
+                          {extraCount > 0 ? (
+                            <div className={styles.extraTagWrapper}>
+                              <span className={styles.extraTag}>
+                                +{extraCount}
+                              </span>
+
+                              <div className={styles.extraTooltip}>
+                                <div className={styles.extraTooltipContent}>
+                                  {item.servicos
+                                    .slice(2)
+                                    .map((service, index) => (
+                                      <span
+                                        key={`${item.id}-extra-${service}-${index}`}
+                                        className={`${styles.serviceTag} ${getServiceClassName(service)}`}
+                                      >
+                                        <Tag
+                                          className={styles.serviceTagIcon}
+                                          strokeWidth={2}
+                                        />
+                                        {service}
+                                      </span>
+                                    ))}
+                                </div>
+                              </div>
+                            </div>
+                          ) : null}
+                        </div>
+                      </td>
+                      <td>
+                        <span className={styles.statusBadge}>
+                          {item.status}
+                        </span>
+                      </td>
+                    </tr>
+                  )
+                })
               )}
             </tbody>
           </table>

--- a/src/app/(app)/demandas/converter/components/email-to-ticket-view.tsx
+++ b/src/app/(app)/demandas/converter/components/email-to-ticket-view.tsx
@@ -1938,6 +1938,7 @@ export function EmailToTicketView() {
             period_end: nullIfEmpty(value.period_end),
             address: nullIfEmpty(value.address),
             description: nullIfEmpty(value.description),
+            cameras: value.cameras ?? [],
           }
           if (editIndex !== null) {
             vm.buscaPorImagem.update(editIndex, normalized)
@@ -1987,6 +1988,7 @@ export function EmailToTicketView() {
             period_start: nullIfEmpty(value.period_start),
             period_end: nullIfEmpty(value.period_end),
             orientation: nullIfEmpty(value.orientation),
+            cameras: value.cameras ?? [],
           }
           if (editIndex !== null) {
             vm.reservaDeImagem.update(editIndex, normalized)
@@ -2000,6 +2002,7 @@ export function EmailToTicketView() {
             period_start: nullIfEmpty(value.period_start),
             period_end: nullIfEmpty(value.period_end),
             orientation: nullIfEmpty(value.orientation),
+            cameras: value.cameras ?? [],
           }
           if (editIndex !== null) {
             vm.analiseDeImagem.update(editIndex, normalized)

--- a/src/app/(app)/demandas/criar/components/services/service-modal.tsx
+++ b/src/app/(app)/demandas/criar/components/services/service-modal.tsx
@@ -328,6 +328,7 @@ function normalizeBuscaPorImagemPlateForForm(
     plate: null,
     address: null,
     description: null,
+    cameras: [],
   }
   return {
     ...base,
@@ -335,6 +336,7 @@ function normalizeBuscaPorImagemPlateForForm(
       base.plate != null && String(base.plate).trim() !== ''
         ? maskPlateBR(String(base.plate))
         : '',
+    cameras: base.cameras ?? [],
   }
 }
 
@@ -711,6 +713,20 @@ function BuscaPorImagemForm({
     formState: { errors },
   } = form
 
+  const cameras = form.watch('cameras') ?? []
+
+  const addCamera = () => {
+    form.setValue('cameras', [...cameras, ''], { shouldValidate: true })
+  }
+
+  const removeCamera = (index: number) => {
+    form.setValue(
+      'cameras',
+      cameras.filter((_, i) => i !== index),
+      { shouldValidate: true },
+    )
+  }
+
   return (
     <form
       className={styles.serviceModalFormScroll}
@@ -792,6 +808,48 @@ function BuscaPorImagemForm({
                   {errors.description.message}
                 </p>
               )}
+            </div>
+
+            <div className="space-y-2">
+              <Label className={styles.fieldLabel}>Câmeras</Label>
+              {cameras.map((_, index) => (
+                <div key={index} className="flex gap-2">
+                  <Controller
+                    control={form.control}
+                    name={`cameras.${index}`}
+                    render={({ field }) => (
+                      <Input
+                        className={`h-11 min-w-0 flex-1 ${styles.inputBg}`}
+                        placeholder="Código da câmera"
+                        value={field.value ?? ''}
+                        onChange={field.onChange}
+                        onBlur={field.onBlur}
+                        name={field.name}
+                        ref={field.ref}
+                      />
+                    )}
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="h-11 w-11 shrink-0 p-0"
+                    onClick={() => removeCamera(index)}
+                    title="Remover câmera"
+                  >
+                    <Trash className="h-4 w-4" />
+                  </Button>
+                </div>
+              ))}
+              <div className="flex flex-col items-end">
+                <button
+                  type="button"
+                  onClick={addCamera}
+                  className={styles.addPointFocalButton}
+                >
+                  <Plus className="h-5 w-5 shrink-0" aria-hidden />
+                  Adicionar câmera
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -1039,6 +1097,20 @@ function ReservaImagemForm({
     formState: { errors },
   } = form
 
+  const cameras = form.watch('cameras') ?? []
+
+  const addCamera = () => {
+    form.setValue('cameras', [...cameras, ''], { shouldValidate: true })
+  }
+
+  const removeCamera = (index: number) => {
+    form.setValue(
+      'cameras',
+      cameras.filter((_, i) => i !== index),
+      { shouldValidate: true },
+    )
+  }
+
   return (
     <form
       className={styles.serviceModalFormScroll}
@@ -1083,6 +1155,48 @@ function ReservaImagemForm({
                 </p>
               )}
             </div>
+
+            <div className="space-y-2">
+              <Label className={styles.fieldLabel}>Câmeras</Label>
+              {cameras.map((_, index) => (
+                <div key={index} className="flex gap-2">
+                  <Controller
+                    control={form.control}
+                    name={`cameras.${index}`}
+                    render={({ field }) => (
+                      <Input
+                        className={`h-11 min-w-0 flex-1 ${styles.inputBg}`}
+                        placeholder="Código da câmera"
+                        value={field.value ?? ''}
+                        onChange={field.onChange}
+                        onBlur={field.onBlur}
+                        name={field.name}
+                        ref={field.ref}
+                      />
+                    )}
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="h-11 w-11 shrink-0 p-0"
+                    onClick={() => removeCamera(index)}
+                    title="Remover câmera"
+                  >
+                    <Trash className="h-4 w-4" />
+                  </Button>
+                </div>
+              ))}
+              <div className="flex flex-col items-end">
+                <button
+                  type="button"
+                  onClick={addCamera}
+                  className={styles.addPointFocalButton}
+                >
+                  <Plus className="h-5 w-5 shrink-0" aria-hidden />
+                  Adicionar câmera
+                </button>
+              </div>
+            </div>
           </div>
         </div>
       </fieldset>
@@ -1123,6 +1237,20 @@ function AnaliseImagemForm({
   const {
     formState: { errors },
   } = form
+
+  const cameras = form.watch('cameras') ?? []
+
+  const addCamera = () => {
+    form.setValue('cameras', [...cameras, ''], { shouldValidate: true })
+  }
+
+  const removeCamera = (index: number) => {
+    form.setValue(
+      'cameras',
+      cameras.filter((_, i) => i !== index),
+      { shouldValidate: true },
+    )
+  }
 
   return (
     <form
@@ -1167,6 +1295,48 @@ function AnaliseImagemForm({
                   {errors.orientation.message}
                 </p>
               )}
+            </div>
+
+            <div className="space-y-2">
+              <Label className={styles.fieldLabel}>Câmeras</Label>
+              {cameras.map((_, index) => (
+                <div key={index} className="flex gap-2">
+                  <Controller
+                    control={form.control}
+                    name={`cameras.${index}`}
+                    render={({ field }) => (
+                      <Input
+                        className={`h-11 min-w-0 flex-1 ${styles.inputBg}`}
+                        placeholder="Código da câmera"
+                        value={field.value ?? ''}
+                        onChange={field.onChange}
+                        onBlur={field.onBlur}
+                        name={field.name}
+                        ref={field.ref}
+                      />
+                    )}
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="h-11 w-11 shrink-0 p-0"
+                    onClick={() => removeCamera(index)}
+                    title="Remover câmera"
+                  >
+                    <Trash className="h-4 w-4" />
+                  </Button>
+                </div>
+              ))}
+              <div className="flex flex-col items-end">
+                <button
+                  type="button"
+                  onClick={addCamera}
+                  className={styles.addPointFocalButton}
+                >
+                  <Plus className="h-5 w-5 shrink-0" aria-hidden />
+                  Adicionar câmera
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/src/app/(app)/demandas/criar/ticket-create/ticket-create-form.tsx
+++ b/src/app/(app)/demandas/criar/ticket-create/ticket-create-form.tsx
@@ -1242,6 +1242,7 @@ export function TicketCreateForm() {
             period_end: nullIfEmpty(value.period_end),
             address: nullIfEmpty(value.address),
             description: nullIfEmpty(value.description),
+            cameras: value.cameras ?? [],
           }
 
           if (editIndex !== null) {
@@ -1297,6 +1298,7 @@ export function TicketCreateForm() {
             period_start: nullIfEmpty(value.period_start),
             period_end: nullIfEmpty(value.period_end),
             orientation: nullIfEmpty(value.orientation),
+            cameras: value.cameras ?? [],
           }
 
           if (editIndex !== null) {
@@ -1312,6 +1314,7 @@ export function TicketCreateForm() {
             period_start: nullIfEmpty(value.period_start),
             period_end: nullIfEmpty(value.period_end),
             orientation: nullIfEmpty(value.orientation),
+            cameras: value.cameras ?? [],
           }
 
           if (editIndex !== null) {

--- a/src/app/(app)/demandas/criar/ticket-create/ticket-create-schema.ts
+++ b/src/app/(app)/demandas/criar/ticket-create/ticket-create-schema.ts
@@ -76,6 +76,7 @@ export const serviceBuscaPorImagemSchema = z.object({
   plate: z.string().optional().nullable(),
   address: z.string().optional().nullable(),
   description: z.string().optional().nullable(),
+  cameras: z.array(z.string()).default([]),
 })
 
 const correlataPlateItemSchema = z.object({
@@ -104,12 +105,14 @@ export const serviceReservaDeImagemSchema = z.object({
   period_start: z.string().optional().nullable(),
   period_end: z.string().optional().nullable(),
   orientation: z.string().optional().nullable(),
+  cameras: z.array(z.string()).default([]),
 })
 
 export const serviceAnaliseDeImagemSchema = z.object({
   period_start: z.string().optional().nullable(),
   period_end: z.string().optional().nullable(),
   orientation: z.string().optional().nullable(),
+  cameras: z.array(z.string()).default([]),
 })
 
 export const serviceOutrosSchema = z.object({

--- a/src/app/(app)/demandas/criar/ticket-create/ticket-create.constant.ts
+++ b/src/app/(app)/demandas/criar/ticket-create/ticket-create.constant.ts
@@ -44,6 +44,7 @@ export type BuscaPorImagemDraft = {
   plate: string
   address: string
   description: string
+  cameras: string[]
 }
 
 export type CorrelataDraftItem = {
@@ -63,12 +64,14 @@ export type ReservaImagemDraft = {
   period_start: string
   period_end: string
   orientation: string
+  cameras: string[]
 }
 
 export type AnaliseImagemDraft = {
   period_start: string
   period_end: string
   orientation: string
+  cameras: string[]
 }
 
 export type OutrosDraft = {
@@ -200,6 +203,7 @@ export function emptyBuscaPorImagemDraft(): BuscaPorImagemDraft {
     plate: '',
     address: '',
     description: '',
+    cameras: [],
   }
 }
 
@@ -219,11 +223,11 @@ export function emptyCorrelataDraft(): CorrelataDraft {
 }
 
 export function emptyReservaImagemDraft(): ReservaImagemDraft {
-  return { period_start: '', period_end: '', orientation: '' }
+  return { period_start: '', period_end: '', orientation: '', cameras: [] }
 }
 
 export function emptyAnaliseImagemDraft(): AnaliseImagemDraft {
-  return { period_start: '', period_end: '', orientation: '' }
+  return { period_start: '', period_end: '', orientation: '', cameras: [] }
 }
 
 export function emptyOutrosDraft(): OutrosDraft {

--- a/src/app/(app)/demandas/criar/ticket-create/ticket-create.mapper.ts
+++ b/src/app/(app)/demandas/criar/ticket-create/ticket-create.mapper.ts
@@ -95,6 +95,7 @@ export function buildTicketCreatePayload(
       period_end: toIsoDateTime(item.period_end),
       address: emptyToNull(item.address),
       description: emptyToNull(item.description),
+      cameras: (item.cameras ?? []).map((c) => c.trim()).filter(Boolean),
     })),
 
     placas_correlatas: data.placas_correlatas.map((group) => ({
@@ -123,12 +124,14 @@ export function buildTicketCreatePayload(
       period_start: toIsoDateTime(item.period_start),
       period_end: toIsoDateTime(item.period_end),
       orientation: emptyToNull(item.orientation),
+      cameras: (item.cameras ?? []).map((c) => c.trim()).filter(Boolean),
     })),
 
     analise_de_imagem: data.analise_de_imagem.map((item) => ({
       period_start: toIsoDateTime(item.period_start),
       period_end: toIsoDateTime(item.period_end),
       orientation: emptyToNull(item.orientation),
+      cameras: (item.cameras ?? []).map((c) => c.trim()).filter(Boolean),
     })),
 
     outros: data.outros.map((item) => ({
@@ -226,6 +229,7 @@ export function mapTicketOutToCreateForm(
       plate: s.plate ?? null,
       address: s.address ?? null,
       description: s.description ?? null,
+      cameras: (s.cameras ?? []).map((c) => c.camera_code),
     })),
     placas_correlatas: (ticket.placas_correlatas ?? []).map((g) => ({
       period_start: isoToDatetimeLocal(g.period_start),
@@ -247,11 +251,13 @@ export function mapTicketOutToCreateForm(
       period_start: isoToDatetimeLocal(s.period_start),
       period_end: isoToDatetimeLocal(s.period_end),
       orientation: s.orientation ?? null,
+      cameras: (s.cameras ?? []).map((c) => c.camera_code),
     })),
     analise_de_imagem: (ticket.analise_de_imagem ?? []).map((s) => ({
       period_start: isoToDatetimeLocal(s.period_start),
       period_end: isoToDatetimeLocal(s.period_end),
       orientation: s.orientation ?? null,
+      cameras: (s.cameras ?? []).map((c) => c.camera_code),
     })),
     outros: (ticket.outros ?? []).map((s) => ({
       orientation: s.orientation ?? null,

--- a/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-export-dialog.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-export-dialog.tsx
@@ -1,0 +1,180 @@
+'use client'
+
+import { format } from 'date-fns'
+import { Download, FileSpreadsheet, Upload } from 'lucide-react'
+import { useCallback, useState } from 'react'
+import { toast } from 'sonner'
+
+import { Spinner } from '@/components/custom/spinner'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import {
+  getSlaDashboardTickets,
+  type SlaDashboardFilterIn,
+} from '@/http/tickets/get-sla-dashboard'
+import { dateConfig } from '@/lib/date-config'
+import { downloadFile } from '@/utils/download-file'
+import { getApiErrorMessage } from '@/utils/error-handlers'
+
+import styles from '../../volume/components/demand-volume-top.module.css'
+import {
+  buildSlaMetricsTicketsCsv,
+  slaMetricsTicketsExportFilename,
+} from './sla-metrics-export'
+import { formatSlaMetricsAdvancedFiltersSummary } from './sla-metrics-filter-utils'
+
+interface SlaMetricsExportDialogProps {
+  appliedFilters: SlaDashboardFilterIn
+  disabled?: boolean
+}
+
+function formatBrDate(iso: string | undefined): string {
+  if (!iso?.trim()) return '—'
+  const [y, m, d] = iso.split('-').map(Number)
+  if (!y || !m || !d) return iso
+  const date = new Date(y, m - 1, d)
+  return format(date, dateConfig.formats.date, { locale: dateConfig.locale })
+}
+
+export function SlaMetricsExportDialog({
+  appliedFilters,
+  disabled,
+}: SlaMetricsExportDialogProps) {
+  const [open, setOpen] = useState(false)
+  const [isExporting, setIsExporting] = useState(false)
+
+  const advancedFilterLines =
+    formatSlaMetricsAdvancedFiltersSummary(appliedFilters)
+
+  const handleExport = useCallback(async () => {
+    setIsExporting(true)
+    try {
+      const { items } = await getSlaDashboardTickets(appliedFilters)
+      if (items.length === 0) {
+        toast.message('Nenhum chamado para exportar com os filtros atuais.')
+        return
+      }
+      const exportedAt = new Date()
+      const csv = buildSlaMetricsTicketsCsv(items)
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+      downloadFile(blob, slaMetricsTicketsExportFilename(exportedAt))
+      toast.success(`Exportação concluída (${items.length} linhas).`)
+      setOpen(false)
+    } catch (error) {
+      toast.error(getApiErrorMessage(error))
+    } finally {
+      setIsExporting(false)
+    }
+  }, [appliedFilters])
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className={styles.iconButton}
+          aria-label="Exportar chamados"
+          title="Exportar"
+          disabled={disabled}
+        >
+          <Upload className="h-5 w-5" />
+        </button>
+      </DialogTrigger>
+      <DialogContent
+        className="border-[#4a5d6d] bg-[#101d28] text-[#f9fafa] sm:max-w-md"
+        style={{ maxWidth: '440px' }}
+      >
+        <DialogHeader>
+          <DialogTitle className="text-[#f9fafa]">
+            Exportar chamados
+          </DialogTitle>
+          <DialogDescription className="text-[#97a2ab]">
+            Gera um arquivo CSV com a lista de chamados do período e filtros
+            aplicados, pronto para abrir no Excel ou Google Planilhas.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div
+          className="flex flex-col gap-3 rounded-lg border border-[#4a5d6d] bg-[#152534] p-4 text-sm"
+          role="region"
+          aria-label="Parâmetros da exportação"
+        >
+          <div className="flex items-start gap-3">
+            <FileSpreadsheet
+              className="mt-0.5 h-5 w-5 shrink-0 text-[#06b2bb]"
+              aria-hidden
+            />
+            <div className="min-w-0 space-y-2">
+              <p className="font-medium text-[#f9fafa]">Conteúdo incluído</p>
+              <ul className="list-inside list-disc space-y-1 text-[#97a2ab]">
+                <li>Nº interno, data, status e prioridade</li>
+                <li>Demandante, operação e tipo de chamado</li>
+                <li>Natureza, equipe e chamado pai (quando houver)</li>
+              </ul>
+            </div>
+          </div>
+
+          <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 border-t border-[#1d3449] pt-3 text-[13px]">
+            <dt className="text-[#97a2ab]">Período da busca</dt>
+            <dd className="text-[#f9fafa]">
+              {formatBrDate(appliedFilters.date_from)} —{' '}
+              {formatBrDate(appliedFilters.date_to)}
+            </dd>
+            {advancedFilterLines.length > 0 ? (
+              <>
+                <dt className="text-[#97a2ab]">Filtros</dt>
+                <dd className="text-[#f9fafa]">
+                  <ul className="list-inside list-disc space-y-0.5">
+                    {advancedFilterLines.map((line) => (
+                      <li key={line}>{line}</li>
+                    ))}
+                  </ul>
+                </dd>
+              </>
+            ) : null}
+          </dl>
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            className="border-[#4a5d6d] bg-transparent text-[#f9fafa] hover:bg-[#1d3449]"
+            onClick={() => setOpen(false)}
+            disabled={isExporting}
+          >
+            Cancelar
+          </Button>
+          <Button
+            type="button"
+            className="gap-2 bg-[#1d3449] text-[#f9fafa] hover:bg-[#254a66]"
+            onClick={() => {
+              handleExport()
+            }}
+            disabled={isExporting}
+          >
+            {isExporting ? (
+              <>
+                <Spinner className="h-4 w-4" />
+                Exportando…
+              </>
+            ) : (
+              <>
+                <Download className="h-4 w-4" />
+                Baixar CSV
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-export.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-export.ts
@@ -1,0 +1,10 @@
+import { format } from 'date-fns'
+
+export { buildDemandVolumeTicketsCsv as buildSlaMetricsTicketsCsv } from '../../volume/components/demand-volume-export'
+
+export function slaMetricsTicketsExportFilename(
+  exportedAt = new Date(),
+): string {
+  const stamp = format(exportedAt, 'yyyy-MM-dd')
+  return `dashboard-tatico-metricas-resposta-chamados-${stamp}.csv`
+}

--- a/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-filter-modal.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-filter-modal.tsx
@@ -1,0 +1,358 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { ChevronDown, X } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import filterModalStyles from '@/app/(app)/demandas/list/components/filter/tickets-general-list-filters.module.css'
+import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
+import { getTicketTypes } from '@/http/ticket-types/get-ticket.types'
+import {
+  type SearchOption,
+  searchRequesters,
+} from '@/http/tickets/tickets-dashboard-filters'
+
+import {
+  emptySlaMetricsAdvancedFilters,
+  SLA_METRICS_PRIORITY_OPTIONS,
+  SLA_METRICS_STATUS_OPTIONS,
+  type SlaMetricsAdvancedFilterForm,
+} from './sla-metrics-filter-utils'
+
+function useDebouncedValue<T>(value: T, delay = 400) {
+  const [debouncedValue, setDebouncedValue] = useState(value)
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedValue(value)
+    }, delay)
+    return () => window.clearTimeout(timeout)
+  }, [value, delay])
+
+  return debouncedValue
+}
+
+function SearchMultiSelect({
+  label,
+  placeholder = 'Selecione',
+  value,
+  onChange,
+  searchFn,
+  staticOptions,
+  optionsLoading,
+  minCharsMessage = 'Digite ao menos 2 caracteres',
+}: {
+  label: string
+  placeholder?: string
+  value: SearchOption[]
+  onChange: (value: SearchOption[]) => void
+  searchFn?: (search: string) => Promise<SearchOption[]>
+  staticOptions?: SearchOption[]
+  optionsLoading?: boolean
+  minCharsMessage?: string
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [search, setSearch] = useState('')
+  const [isOpen, setIsOpen] = useState(false)
+  const debouncedSearch = useDebouncedValue(search, 350)
+
+  const { data, isFetching } = useQuery({
+    queryKey: ['sla-metrics-filter-search', label, debouncedSearch],
+    queryFn: () => searchFn!(debouncedSearch),
+    enabled:
+      isOpen &&
+      !staticOptions &&
+      Boolean(searchFn) &&
+      debouncedSearch.trim().length >= 2,
+    staleTime: 1000 * 60 * 5,
+  })
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!containerRef.current) return
+      if (!containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  const selectedValues = useMemo(
+    () => new Set(value.map((item) => item.value)),
+    [value],
+  )
+
+  const staticFiltered = useMemo(() => {
+    if (!staticOptions) return []
+    const q = debouncedSearch.trim().toLowerCase()
+    return staticOptions.filter(
+      (item) =>
+        !selectedValues.has(item.value) &&
+        (q === '' ||
+          item.label.toLowerCase().includes(q) ||
+          item.value.toLowerCase().includes(q)),
+    )
+  }, [staticOptions, debouncedSearch, selectedValues])
+
+  const options = useMemo(() => {
+    if (staticOptions) return staticFiltered
+    return (data ?? []).filter((item) => !selectedValues.has(item.value))
+  }, [staticOptions, staticFiltered, data, selectedValues])
+
+  const removeItem = (itemValue: string) => {
+    onChange(value.filter((item) => item.value !== itemValue))
+  }
+
+  const addItem = (item: SearchOption) => {
+    onChange([...value, item])
+    setSearch('')
+  }
+
+  return (
+    <div className={filterModalStyles.filterBlock} ref={containerRef}>
+      <span className={filterModalStyles.filterLabel}>{label}</span>
+
+      <div className={filterModalStyles.multiSelectBox}>
+        <div className={filterModalStyles.multiSelectInputWrapper}>
+          <input
+            value={search}
+            onFocus={() => setIsOpen(true)}
+            onChange={(event) => {
+              setSearch(event.target.value)
+              setIsOpen(true)
+            }}
+            placeholder={value.length > 0 ? '' : placeholder}
+            className={filterModalStyles.multiSelectInput}
+          />
+          <ChevronDown
+            className={filterModalStyles.multiSelectChevron}
+            size={16}
+          />
+          {isOpen ? (
+            <div className={filterModalStyles.multiSelectDropdown}>
+              {optionsLoading ? (
+                <div className={filterModalStyles.dropdownHint}>
+                  Buscando...
+                </div>
+              ) : !staticOptions && debouncedSearch.trim().length < 2 ? (
+                <div className={filterModalStyles.dropdownHint}>
+                  {minCharsMessage}
+                </div>
+              ) : isFetching ? (
+                <div className={filterModalStyles.dropdownHint}>
+                  Buscando...
+                </div>
+              ) : options.length === 0 ? (
+                <div className={filterModalStyles.dropdownHint}>
+                  Nenhum resultado encontrado
+                </div>
+              ) : (
+                options.map((item) => (
+                  <button
+                    key={item.value}
+                    type="button"
+                    className={filterModalStyles.dropdownOption}
+                    onClick={() => addItem(item)}
+                  >
+                    {item.label}
+                  </button>
+                ))
+              )}
+            </div>
+          ) : null}
+        </div>
+
+        {value.length > 0 ? (
+          <div className={filterModalStyles.selectedChips}>
+            {value.map((item) => (
+              <span key={item.value} className={filterModalStyles.selectedChip}>
+                {item.label}
+                <button
+                  type="button"
+                  className={filterModalStyles.selectedChipRemove}
+                  onClick={() => removeItem(item.value)}
+                >
+                  <X size={12} />
+                </button>
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function PressRelevanceField({
+  value,
+  onChange,
+}: {
+  value: boolean
+  onChange: (value: boolean) => void
+}) {
+  return (
+    <div className={filterModalStyles.filterBlock}>
+      <span className={filterModalStyles.filterLabel}>
+        RELEVANTE PARA IMPRENSA?
+      </span>
+      <div className="flex items-center gap-2 pt-1">
+        <Switch
+          id="sla-metrics-relevante-imprensa"
+          size="sm"
+          checked={value}
+          onCheckedChange={onChange}
+        />
+        <span className="text-sm text-[#91a6bc]">{value ? 'Sim' : 'Não'}</span>
+      </div>
+    </div>
+  )
+}
+
+export type SlaMetricsFilterModalProps = {
+  isOpen: boolean
+  onClose: () => void
+  filters: SlaMetricsAdvancedFilterForm
+  onApply: (filters: SlaMetricsAdvancedFilterForm) => void
+}
+
+export function SlaMetricsFilterModal({
+  isOpen,
+  onClose,
+  filters,
+  onApply,
+}: SlaMetricsFilterModalProps) {
+  const [draftFilters, setDraftFilters] =
+    useState<SlaMetricsAdvancedFilterForm>(filters)
+
+  useEffect(() => {
+    if (isOpen) {
+      setDraftFilters(filters)
+    }
+  }, [isOpen, filters])
+
+  const { data: ticketTypeOptions, isFetching: isTicketTypesLoading } =
+    useQuery({
+      queryKey: ['ticket-types', 'sla-metrics-filter'],
+      queryFn: async () => {
+        const response = await getTicketTypes({ isActive: true })
+        return (response.data ?? []).map((item) => ({
+          value: item.id,
+          label: item.name,
+        }))
+      },
+      enabled: isOpen,
+      staleTime: 1000 * 60 * 5,
+    })
+
+  const handleApply = () => {
+    onApply(draftFilters)
+    onClose()
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <div className={filterModalStyles.filterModalOverlay}>
+      <div className={filterModalStyles.filterModal}>
+        <div className={filterModalStyles.filterModalHeader}>
+          <div className={filterModalStyles.filterModalTitle} />
+          <button
+            type="button"
+            className={filterModalStyles.filterModalClose}
+            onClick={onClose}
+            aria-label="Fechar filtros"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className={filterModalStyles.filterModalBody}>
+          <div className={filterModalStyles.filterGrid}>
+            <SearchMultiSelect
+              label="REQUISITANTE"
+              value={draftFilters.requisitante}
+              onChange={(value) =>
+                setDraftFilters((current) => ({
+                  ...current,
+                  requisitante: value,
+                }))
+              }
+              searchFn={searchRequesters}
+            />
+
+            <SearchMultiSelect
+              label="URGÊNCIA"
+              placeholder="Selecione"
+              value={draftFilters.prioridade}
+              onChange={(value) =>
+                setDraftFilters((current) => ({
+                  ...current,
+                  prioridade: value,
+                }))
+              }
+              staticOptions={SLA_METRICS_PRIORITY_OPTIONS}
+            />
+
+            <SearchMultiSelect
+              label="STATUS DO CHAMADO"
+              placeholder="Selecione"
+              value={draftFilters.status}
+              onChange={(value) =>
+                setDraftFilters((current) => ({
+                  ...current,
+                  status: value,
+                }))
+              }
+              staticOptions={SLA_METRICS_STATUS_OPTIONS}
+            />
+
+            <SearchMultiSelect
+              label="TIPO DE CHAMADO"
+              placeholder="Selecione"
+              value={draftFilters.tipo_chamado_id}
+              onChange={(value) =>
+                setDraftFilters((current) => ({
+                  ...current,
+                  tipo_chamado_id: value,
+                }))
+              }
+              staticOptions={ticketTypeOptions ?? []}
+              optionsLoading={isTicketTypesLoading}
+            />
+          </div>
+
+          <div className={filterModalStyles.filterTogglesGrid}>
+            <PressRelevanceField
+              value={draftFilters.relevanteImprensa}
+              onChange={(relevanteImprensa) =>
+                setDraftFilters((current) => ({
+                  ...current,
+                  relevanteImprensa,
+                }))
+              }
+            />
+          </div>
+        </div>
+
+        <div className={filterModalStyles.filterModalFooter}>
+          <Button
+            type="button"
+            className={filterModalStyles.filterSecondaryButton}
+            onClick={() => setDraftFilters(emptySlaMetricsAdvancedFilters())}
+          >
+            Limpar Filtro
+          </Button>
+          <Button
+            type="button"
+            className={filterModalStyles.filterPrimaryButton}
+            onClick={handleApply}
+          >
+            Salvar
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-filter-utils.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-filter-utils.ts
@@ -1,0 +1,176 @@
+import type {
+  SlaDashboardFilterIn,
+  SlaTicketStatus,
+  TicketPriority,
+} from '@/http/tickets/get-sla-dashboard'
+import type { SearchOption } from '@/http/tickets/tickets-dashboard-filters'
+
+export type SlaMetricsAdvancedFilterForm = {
+  requisitante: SearchOption[]
+  prioridade: SearchOption[]
+  status: SearchOption[]
+  tipo_chamado_id: SearchOption[]
+  relevanteImprensa: boolean
+}
+
+export const SLA_METRICS_PRIORITY_OPTIONS: SearchOption[] = [
+  { value: 'URGENTE', label: 'Urgente' },
+  { value: 'ALTA', label: 'Alta' },
+  { value: 'ROTINA', label: 'Rotina' },
+]
+
+export const SLA_METRICS_STATUS_OPTIONS: SearchOption[] = [
+  { value: 'PENDENTE', label: 'Pendente' },
+  { value: 'AGUARDANDO_REVISAO_ADJUNTO', label: 'Aguardando revisão adjunto' },
+  {
+    value: 'AGUARDANDO_REVISAO_ADMINISTRATIVO',
+    label: 'Aguardando revisão administrativo',
+  },
+  { value: 'FINALIZADO', label: 'Finalizado' },
+  { value: 'DEMANDA_RESPONDIDA', label: 'Demanda respondida' },
+  { value: 'BLOQUEADO', label: 'Bloqueado' },
+  { value: 'RESTRITO', label: 'Restrito' },
+]
+
+const priorityLabelByValue = new Map(
+  SLA_METRICS_PRIORITY_OPTIONS.map((o) => [o.value, o.label]),
+)
+const statusLabelByValue = new Map(
+  SLA_METRICS_STATUS_OPTIONS.map((o) => [o.value, o.label]),
+)
+
+export function emptySlaMetricsAdvancedFilters(): SlaMetricsAdvancedFilterForm {
+  return {
+    requisitante: [],
+    prioridade: [],
+    status: [],
+    tipo_chamado_id: [],
+    relevanteImprensa: false,
+  }
+}
+
+export function countSlaMetricsAdvancedFiltersFromApi(
+  filters: SlaDashboardFilterIn,
+): number {
+  let count = 0
+  count += filters.requisitante?.length ?? 0
+  count += filters.prioridade?.length ?? 0
+  count += filters.status?.length ?? 0
+  count += filters.tipo_chamado_id?.length ?? 0
+  if (filters.relevante_imprensa === true) {
+    count += 1
+  }
+  return count
+}
+
+function toSearchOptions(
+  values: string[] | undefined,
+  labelMap: Map<string, string>,
+): SearchOption[] {
+  if (!values?.length) return []
+  return values.map((value) => ({
+    value,
+    label: labelMap.get(value) ?? value,
+  }))
+}
+
+export function advancedFiltersFromApi(
+  filters: SlaDashboardFilterIn,
+): SlaMetricsAdvancedFilterForm {
+  return {
+    requisitante: (filters.requisitante ?? []).map((value) => ({
+      value,
+      label: value,
+    })),
+    prioridade: toSearchOptions(
+      filters.prioridade,
+      priorityLabelByValue,
+    ) as SearchOption[],
+    status: toSearchOptions(
+      filters.status,
+      statusLabelByValue,
+    ) as SearchOption[],
+    tipo_chamado_id: (filters.tipo_chamado_id ?? []).map((value) => ({
+      value,
+      label: value,
+    })),
+    relevanteImprensa: filters.relevante_imprensa === true,
+  }
+}
+
+export function advancedFiltersToApiPatch(
+  form: SlaMetricsAdvancedFilterForm,
+): Pick<
+  SlaDashboardFilterIn,
+  | 'requisitante'
+  | 'prioridade'
+  | 'status'
+  | 'tipo_chamado_id'
+  | 'relevante_imprensa'
+> {
+  return {
+    requisitante: form.requisitante.length
+      ? form.requisitante.map((item) => item.value)
+      : undefined,
+    prioridade: form.prioridade.length
+      ? (form.prioridade.map((item) => item.value) as TicketPriority[])
+      : undefined,
+    status: form.status.length
+      ? (form.status.map((item) => item.value) as SlaTicketStatus[])
+      : undefined,
+    tipo_chamado_id: form.tipo_chamado_id.length
+      ? form.tipo_chamado_id.map((item) => item.value)
+      : undefined,
+    relevante_imprensa: form.relevanteImprensa ? true : null,
+  }
+}
+
+export function stripAdvancedFiltersFromApi(
+  filters: SlaDashboardFilterIn,
+): SlaDashboardFilterIn {
+  const rest = { ...filters }
+  delete rest.requisitante
+  delete rest.prioridade
+  delete rest.status
+  delete rest.tipo_chamado_id
+  delete rest.relevante_imprensa
+  return rest
+}
+
+export function formatSlaMetricsAdvancedFiltersSummary(
+  filters: SlaDashboardFilterIn,
+): string[] {
+  const lines: string[] = []
+  if (filters.requisitante?.length) {
+    lines.push(`Requisitante: ${filters.requisitante.join(', ')}`)
+  }
+  if (filters.prioridade?.length) {
+    const labels = filters.prioridade.map(
+      (p) => priorityLabelByValue.get(p) ?? p,
+    )
+    lines.push(`Urgência: ${labels.join(', ')}`)
+  }
+  if (filters.status?.length) {
+    const labels = filters.status.map((s) => statusLabelByValue.get(s) ?? s)
+    lines.push(`Status: ${labels.join(', ')}`)
+  }
+  if (filters.tipo_chamado_id?.length) {
+    lines.push(
+      `Tipo de chamado: ${filters.tipo_chamado_id.length} selecionado(s)`,
+    )
+  }
+  if (filters.relevante_imprensa === true) {
+    lines.push('Relevante para imprensa: Sim')
+  }
+  return lines
+}
+
+export const SLA_PRIORITY_ROW_LABELS: Record<string, string> = {
+  URGENTE: 'Urgente',
+  ALTA: 'Alta',
+  ROTINA: 'Rotina',
+}
+
+export function formatSlaPerformanceRowLabel(label: string): string {
+  return SLA_PRIORITY_ROW_LABELS[label] ?? label
+}

--- a/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-filters.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-filters.tsx
@@ -1,0 +1,199 @@
+'use client'
+
+import { format } from 'date-fns'
+import { CalendarIcon, Filter } from 'lucide-react'
+import { useMemo, useState } from 'react'
+
+import { Calendar } from '@/components/ui/calendar'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import type { SlaDashboardFilterIn } from '@/http/tickets/get-sla-dashboard'
+import { dateConfig } from '@/lib/date-config'
+
+import {
+  parseDemandVolumeDate,
+  toDemandVolumeDateString,
+} from '../../volume/components/demand-volume-date-range'
+import styles from '../../volume/components/demand-volume-top.module.css'
+import { SlaMetricsExportDialog } from './sla-metrics-export-dialog'
+import { SlaMetricsFilterModal } from './sla-metrics-filter-modal'
+import {
+  advancedFiltersFromApi,
+  countSlaMetricsAdvancedFiltersFromApi,
+  type SlaMetricsAdvancedFilterForm,
+} from './sla-metrics-filter-utils'
+
+interface SlaMetricsFiltersProps {
+  dateFrom: string
+  dateTo: string
+  onDateFromChange: (dateFrom: string) => void
+  onDateToChange: (dateTo: string) => void
+  isLoading: boolean
+  appliedFilters: SlaDashboardFilterIn
+  onApplyAdvancedFilters: (filters: SlaMetricsAdvancedFilterForm) => void
+}
+
+function formatTrigger(d: Date | undefined): string | null {
+  if (!d) return null
+  return format(d, dateConfig.formats.date, { locale: dateConfig.locale })
+}
+
+function DateField({
+  value,
+  placeholder,
+  ariaLabel,
+  onChange,
+  disabled,
+  minDate,
+  maxDate,
+}: {
+  value: string
+  placeholder: string
+  ariaLabel: string
+  onChange: (value: string) => void
+  disabled?: boolean
+  minDate?: Date
+  maxDate?: Date
+}) {
+  const [open, setOpen] = useState(false)
+  const date = useMemo(() => parseDemandVolumeDate(value), [value])
+
+  return (
+    <div className={styles.dateFieldWrap}>
+      <Popover
+        open={disabled ? false : open}
+        onOpenChange={(o) => {
+          if (!disabled) setOpen(o)
+        }}
+      >
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className={styles.dateTrigger}
+            disabled={disabled}
+            aria-label={ariaLabel}
+          >
+            {formatTrigger(date) ? (
+              <span className={styles.dateTriggerValue}>
+                {formatTrigger(date)}
+              </span>
+            ) : (
+              <span className={styles.dateTriggerPlaceholder}>
+                {placeholder}
+              </span>
+            )}
+            <CalendarIcon className="h-5 w-5 shrink-0 opacity-50" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          className="z-[100] w-auto p-0"
+          align="start"
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          onCloseAutoFocus={(e) => e.preventDefault()}
+        >
+          <Calendar
+            mode="single"
+            selected={date}
+            onSelect={(d) => {
+              if (!d) return
+              onChange(toDemandVolumeDateString(d))
+              setOpen(false)
+            }}
+            disabled={(d) => {
+              if (minDate && d < minDate) return true
+              if (maxDate && d > maxDate) return true
+              return false
+            }}
+            locale={dateConfig.locale}
+            defaultMonth={date ?? minDate ?? maxDate ?? new Date()}
+            initialFocus
+            className="rounded-lg border"
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}
+
+export function SlaMetricsFilters({
+  dateFrom,
+  dateTo,
+  onDateFromChange,
+  onDateToChange,
+  isLoading,
+  appliedFilters,
+  onApplyAdvancedFilters,
+}: SlaMetricsFiltersProps) {
+  const [isFilterModalOpen, setIsFilterModalOpen] = useState(false)
+  const startDate = useMemo(() => parseDemandVolumeDate(dateFrom), [dateFrom])
+  const endDate = useMemo(() => parseDemandVolumeDate(dateTo), [dateTo])
+  const activeAdvancedCount = useMemo(
+    () => countSlaMetricsAdvancedFiltersFromApi(appliedFilters),
+    [appliedFilters],
+  )
+  const advancedFiltersForm = useMemo(
+    () => advancedFiltersFromApi(appliedFilters),
+    [appliedFilters],
+  )
+
+  return (
+    <div className={styles.periodBar}>
+      <div className={styles.periodBarLabelBlock}>
+        <p className={styles.periodBarLabel}>Período da Busca</p>
+        <div className={styles.dateFieldsRow}>
+          <DateField
+            value={dateFrom}
+            placeholder="dd/mm/aaaa"
+            ariaLabel="Data inicial do período"
+            onChange={onDateFromChange}
+            disabled={isLoading}
+            maxDate={endDate}
+          />
+          <DateField
+            value={dateTo}
+            placeholder="dd/mm/aaaa"
+            ariaLabel="Data final do período"
+            onChange={onDateToChange}
+            disabled={isLoading}
+            minDate={startDate}
+          />
+        </div>
+      </div>
+
+      <div className={styles.periodBarActions}>
+        <div className={styles.filterButtonWrap}>
+          <button
+            type="button"
+            className={styles.iconButton}
+            aria-label="Filtrar dados"
+            title="Filtrar"
+            disabled={isLoading}
+            onClick={() => setIsFilterModalOpen(true)}
+          >
+            <Filter className="h-5 w-5" />
+          </button>
+          {activeAdvancedCount > 0 ? (
+            <span className={styles.filterBadge} aria-hidden>
+              {activeAdvancedCount}
+            </span>
+          ) : null}
+        </div>
+
+        <SlaMetricsExportDialog
+          appliedFilters={appliedFilters}
+          disabled={isLoading}
+        />
+      </div>
+
+      <SlaMetricsFilterModal
+        isOpen={isFilterModalOpen}
+        onClose={() => setIsFilterModalOpen(false)}
+        filters={advancedFiltersForm}
+        onApply={onApplyAdvancedFilters}
+      />
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-general-chart.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-general-chart.tsx
@@ -1,0 +1,184 @@
+'use client'
+
+import type { CSSProperties } from 'react'
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+
+import type {
+  AvgResolutionTimeGeneralItemOut,
+  SlaDashboardGranularity,
+} from '@/http/tickets/get-sla-dashboard'
+
+import { DemandVolumeChartGranularity } from '../../volume/components/demand-volume-chart-granularity'
+import { formatPeriodLabel } from '../../volume/components/demand-volume-period-label'
+import styles from '../../volume/components/demand-volume-top.module.css'
+
+interface SlaMetricsGeneralChartProps {
+  data: AvgResolutionTimeGeneralItemOut[]
+  granularity: SlaDashboardGranularity
+  onGranularityChange: (granularity: SlaDashboardGranularity) => void
+  isLoading: boolean
+}
+
+const SERIES = [
+  {
+    key: 'from_registration_days',
+    label: 'A partir do cadastro',
+    color: '#b93d52',
+  },
+  {
+    key: 'from_email_days',
+    label: 'A partir do e-mail',
+    color: '#06b2bb',
+  },
+] as const
+
+const CHART_COLORS = {
+  grid: '#1d3449',
+  axis: '#97a2ab',
+  tooltip: { bg: '#101d28', border: '#4a5d6d', text: '#f9fafa' },
+}
+
+const CHART_SHELL: CSSProperties = {
+  backgroundColor: '#101d28',
+  border: '1px solid #4a5d6d',
+  borderRadius: '8px',
+  padding: '24px',
+}
+
+function formatDaysTooltip(value: number | string | undefined): string {
+  if (value == null || value === '') return '—'
+  const n = typeof value === 'number' ? value : Number(value)
+  if (Number.isNaN(n)) return '—'
+  return `${n.toLocaleString('pt-BR', {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  })} dias`
+}
+
+export function SlaMetricsGeneralChart({
+  data,
+  granularity,
+  onGranularityChange,
+  isLoading,
+}: SlaMetricsGeneralChartProps) {
+  const chartData = data.map((item) => ({
+    ...item,
+    label: formatPeriodLabel(item.period_label, granularity),
+  }))
+
+  return (
+    <div style={CHART_SHELL}>
+      <div className={styles.chartHeaderRow}>
+        <h2
+          style={{
+            fontSize: '20px',
+            fontWeight: 600,
+            color: '#f9fafa',
+            margin: 0,
+          }}
+        >
+          Tempo Médio de Resolução de Demandas (Geral)
+        </h2>
+        <DemandVolumeChartGranularity
+          value={granularity}
+          onChange={onGranularityChange}
+          disabled={isLoading}
+        />
+      </div>
+
+      {isLoading && chartData.length === 0 ? (
+        <div
+          style={{
+            height: '280px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: '#97a2ab',
+            fontSize: '14px',
+          }}
+        >
+          Carregando…
+        </div>
+      ) : (
+        <ResponsiveContainer width="100%" height={280}>
+          <LineChart
+            data={chartData}
+            margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+          >
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke={CHART_COLORS.grid}
+              vertical={false}
+            />
+            <XAxis
+              dataKey="label"
+              tick={{ fill: CHART_COLORS.axis, fontSize: 12 }}
+              axisLine={false}
+              tickLine={false}
+              tickMargin={8}
+            />
+            <YAxis
+              tick={{ fill: CHART_COLORS.axis, fontSize: 12 }}
+              axisLine={false}
+              tickLine={false}
+              width={40}
+              tickFormatter={(v) =>
+                typeof v === 'number'
+                  ? v.toLocaleString('pt-BR', { maximumFractionDigits: 0 })
+                  : v
+              }
+            />
+            <Tooltip
+              formatter={(value) => formatDaysTooltip(value as number)}
+              contentStyle={{
+                backgroundColor: CHART_COLORS.tooltip.bg,
+                border: `1px solid ${CHART_COLORS.tooltip.border}`,
+                borderRadius: '8px',
+                color: CHART_COLORS.tooltip.text,
+                fontSize: '12px',
+              }}
+              itemStyle={{ color: CHART_COLORS.tooltip.text }}
+              labelStyle={{
+                color: CHART_COLORS.tooltip.text,
+                fontWeight: 600,
+                marginBottom: '4px',
+              }}
+            />
+            <Legend
+              wrapperStyle={{
+                paddingTop: '24px',
+                fontSize: '12px',
+                color: '#97a2ab',
+              }}
+              formatter={(value) => (
+                <span style={{ color: '#97a2ab' }}>{value}</span>
+              )}
+            />
+            {SERIES.map((s) => (
+              <Line
+                key={s.key}
+                type="monotone"
+                dataKey={s.key}
+                name={s.label}
+                stroke={s.color}
+                strokeWidth={2}
+                dot={false}
+                connectNulls
+                activeDot={{ r: 4, strokeWidth: 0 }}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-media-chart.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-media-chart.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import type { CSSProperties } from 'react'
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+
+import type {
+  DeliveryTimeMediaItemOut,
+  SlaDashboardGranularity,
+} from '@/http/tickets/get-sla-dashboard'
+
+import { DemandVolumeChartGranularity } from '../../volume/components/demand-volume-chart-granularity'
+import { formatPeriodLabel } from '../../volume/components/demand-volume-period-label'
+import styles from '../../volume/components/demand-volume-top.module.css'
+
+interface SlaMetricsMediaChartProps {
+  data: DeliveryTimeMediaItemOut[]
+  granularity: SlaDashboardGranularity
+  onGranularityChange: (granularity: SlaDashboardGranularity) => void
+  isLoading: boolean
+}
+
+const CHART_COLORS = {
+  line: '#22c1f1',
+  grid: '#1d3449',
+  axis: '#97a2ab',
+  tooltip: { bg: '#101d28', border: '#4a5d6d', text: '#f9fafa' },
+}
+
+const CHART_SHELL: CSSProperties = {
+  backgroundColor: '#101d28',
+  border: '1px solid #4a5d6d',
+  borderRadius: '8px',
+  padding: '24px',
+}
+
+function formatDaysTooltip(value: number | string | undefined): string {
+  if (value == null || value === '') return '—'
+  const n = typeof value === 'number' ? value : Number(value)
+  if (Number.isNaN(n)) return '—'
+  return `${n.toLocaleString('pt-BR', {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  })} dias`
+}
+
+export function SlaMetricsMediaChart({
+  data,
+  granularity,
+  onGranularityChange,
+  isLoading,
+}: SlaMetricsMediaChartProps) {
+  const chartData = data.map((item) => ({
+    ...item,
+    label: formatPeriodLabel(item.period_label, granularity),
+  }))
+
+  return (
+    <div style={CHART_SHELL}>
+      <div className={styles.chartHeaderRow}>
+        <h2
+          style={{
+            fontSize: '20px',
+            fontWeight: 600,
+            color: '#f9fafa',
+            margin: 0,
+          }}
+        >
+          Tempo de Entrega para Demandas Relevantes à Mídia
+        </h2>
+        <DemandVolumeChartGranularity
+          value={granularity}
+          onChange={onGranularityChange}
+          disabled={isLoading}
+        />
+      </div>
+
+      {isLoading && chartData.length === 0 ? (
+        <div
+          style={{
+            height: '280px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: '#97a2ab',
+            fontSize: '14px',
+          }}
+        >
+          Carregando…
+        </div>
+      ) : (
+        <ResponsiveContainer width="100%" height={280}>
+          <LineChart
+            data={chartData}
+            margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+          >
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke={CHART_COLORS.grid}
+              vertical={false}
+            />
+            <XAxis
+              dataKey="label"
+              tick={{ fill: CHART_COLORS.axis, fontSize: 12 }}
+              axisLine={false}
+              tickLine={false}
+              tickMargin={8}
+            />
+            <YAxis
+              tick={{ fill: CHART_COLORS.axis, fontSize: 12 }}
+              axisLine={false}
+              tickLine={false}
+              width={40}
+            />
+            <Tooltip
+              formatter={(value) => formatDaysTooltip(value as number)}
+              contentStyle={{
+                backgroundColor: CHART_COLORS.tooltip.bg,
+                border: `1px solid ${CHART_COLORS.tooltip.border}`,
+                borderRadius: '8px',
+                color: CHART_COLORS.tooltip.text,
+                fontSize: '12px',
+              }}
+              itemStyle={{ color: CHART_COLORS.tooltip.text }}
+              labelStyle={{
+                color: CHART_COLORS.tooltip.text,
+                fontWeight: 600,
+                marginBottom: '4px',
+              }}
+            />
+            <Legend
+              wrapperStyle={{ paddingTop: '24px', fontSize: '12px' }}
+              formatter={(value) => (
+                <span style={{ color: '#97a2ab' }}>{value}</span>
+              )}
+            />
+            <Line
+              type="monotone"
+              dataKey="avg_days"
+              name="Tempo médio (dias)"
+              stroke={CHART_COLORS.line}
+              strokeWidth={2}
+              dot={false}
+              connectNulls
+              activeDot={{ r: 4, strokeWidth: 0 }}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-period-presets.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-period-presets.ts
@@ -1,0 +1,24 @@
+import type { SlaDashboardFilterIn } from '@/http/tickets/get-sla-dashboard'
+
+function toDateString(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+/** Período padrão: 1º de janeiro do ano corrente → hoje. */
+export function getDefaultSlaMetricsDateRange(): Pick<
+  SlaDashboardFilterIn,
+  'date_from' | 'date_to'
+> {
+  const now = new Date()
+  return {
+    date_from: `${now.getFullYear()}-01-01`,
+    date_to: toDateString(now),
+  }
+}
+
+export function createDefaultSlaMetricsFilters(): SlaDashboardFilterIn {
+  return getDefaultSlaMetricsDateRange()
+}

--- a/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-priority-chart.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-priority-chart.tsx
@@ -1,0 +1,168 @@
+'use client'
+
+import type { CSSProperties } from 'react'
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+
+import type {
+  AvgResolutionTimeByPriorityItemOut,
+  SlaDashboardGranularity,
+} from '@/http/tickets/get-sla-dashboard'
+
+import { DemandVolumeChartGranularity } from '../../volume/components/demand-volume-chart-granularity'
+import { formatPeriodLabel } from '../../volume/components/demand-volume-period-label'
+import styles from '../../volume/components/demand-volume-top.module.css'
+
+interface SlaMetricsPriorityChartProps {
+  data: AvgResolutionTimeByPriorityItemOut[]
+  granularity: SlaDashboardGranularity
+  onGranularityChange: (granularity: SlaDashboardGranularity) => void
+  isLoading: boolean
+}
+
+const SERIES = [
+  { key: 'urgent_days', label: 'Urgente', color: '#b93d52' },
+  { key: 'high_days', label: 'Alta', color: '#5b4db2' },
+  { key: 'routine_days', label: 'Rotina', color: '#06b2bb' },
+] as const
+
+const CHART_COLORS = {
+  grid: '#1d3449',
+  axis: '#97a2ab',
+  tooltip: { bg: '#101d28', border: '#4a5d6d', text: '#f9fafa' },
+}
+
+const CHART_SHELL: CSSProperties = {
+  backgroundColor: '#101d28',
+  border: '1px solid #4a5d6d',
+  borderRadius: '8px',
+  padding: '24px',
+}
+
+function formatDaysTooltip(value: number | string | undefined): string {
+  if (value == null || value === '') return '—'
+  const n = typeof value === 'number' ? value : Number(value)
+  if (Number.isNaN(n)) return '—'
+  return `${n.toLocaleString('pt-BR', {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  })} dias`
+}
+
+export function SlaMetricsPriorityChart({
+  data,
+  granularity,
+  onGranularityChange,
+  isLoading,
+}: SlaMetricsPriorityChartProps) {
+  const chartData = data.map((item) => ({
+    ...item,
+    label: formatPeriodLabel(item.period_label, granularity),
+  }))
+
+  return (
+    <div style={CHART_SHELL}>
+      <div className={styles.chartHeaderRow}>
+        <h2
+          style={{
+            fontSize: '20px',
+            fontWeight: 600,
+            color: '#f9fafa',
+            margin: 0,
+          }}
+        >
+          Tempo Médio de Resolução de Demandas (Por prioridade)
+        </h2>
+        <DemandVolumeChartGranularity
+          value={granularity}
+          onChange={onGranularityChange}
+          disabled={isLoading}
+        />
+      </div>
+
+      {isLoading && chartData.length === 0 ? (
+        <div
+          style={{
+            height: '280px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: '#97a2ab',
+            fontSize: '14px',
+          }}
+        >
+          Carregando…
+        </div>
+      ) : (
+        <ResponsiveContainer width="100%" height={280}>
+          <LineChart
+            data={chartData}
+            margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+          >
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke={CHART_COLORS.grid}
+              vertical={false}
+            />
+            <XAxis
+              dataKey="label"
+              tick={{ fill: CHART_COLORS.axis, fontSize: 12 }}
+              axisLine={false}
+              tickLine={false}
+              tickMargin={8}
+            />
+            <YAxis
+              tick={{ fill: CHART_COLORS.axis, fontSize: 12 }}
+              axisLine={false}
+              tickLine={false}
+              width={40}
+            />
+            <Tooltip
+              formatter={(value) => formatDaysTooltip(value as number)}
+              contentStyle={{
+                backgroundColor: CHART_COLORS.tooltip.bg,
+                border: `1px solid ${CHART_COLORS.tooltip.border}`,
+                borderRadius: '8px',
+                color: CHART_COLORS.tooltip.text,
+                fontSize: '12px',
+              }}
+              itemStyle={{ color: CHART_COLORS.tooltip.text }}
+              labelStyle={{
+                color: CHART_COLORS.tooltip.text,
+                fontWeight: 600,
+                marginBottom: '4px',
+              }}
+            />
+            <Legend
+              wrapperStyle={{ paddingTop: '24px', fontSize: '12px' }}
+              formatter={(value) => (
+                <span style={{ color: '#97a2ab' }}>{value}</span>
+              )}
+            />
+            {SERIES.map((s) => (
+              <Line
+                key={s.key}
+                type="monotone"
+                dataKey={s.key}
+                name={s.label}
+                stroke={s.color}
+                strokeWidth={2}
+                dot={false}
+                connectNulls
+                activeDot={{ r: 4, strokeWidth: 0 }}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-sla-table.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-sla-table.tsx
@@ -1,0 +1,260 @@
+'use client'
+
+import type { CSSProperties } from 'react'
+
+import type { SlaPerformanceRowOut } from '@/http/tickets/get-sla-dashboard'
+
+import { formatPeriodLabel } from '../../volume/components/demand-volume-period-label'
+import { formatSlaPerformanceRowLabel } from './sla-metrics-filter-utils'
+
+interface SlaMetricsSlaTableProps {
+  title: string
+  columnHeader: string
+  rows: SlaPerformanceRowOut[]
+  periodLabels: string[]
+  isLoading: boolean
+  formatRowLabel?: (label: string) => string
+}
+
+type CellVariant = 'above' | 'below' | 'neutral'
+
+function getCellVariant(
+  slaPercent: number | null,
+  isAboveAverage: boolean,
+): CellVariant {
+  if (slaPercent == null || slaPercent === 0) return 'neutral'
+  if (isAboveAverage) return 'above'
+  return 'below'
+}
+
+const CELL_STYLES: Record<CellVariant, CSSProperties> = {
+  above: {
+    backgroundColor: 'rgba(185, 61, 82, 0.25)',
+    color: '#f9a7b3',
+    fontWeight: 600,
+  },
+  below: {
+    backgroundColor: 'rgba(6, 178, 187, 0.15)',
+    color: '#06b2bb',
+    fontWeight: 600,
+  },
+  neutral: {
+    backgroundColor: 'transparent',
+    color: '#f9fafa',
+    fontWeight: 400,
+  },
+}
+
+const HEADER_CELL: CSSProperties = {
+  padding: '10px 12px',
+  fontSize: '11px',
+  fontWeight: 600,
+  color: '#97a2ab',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+  whiteSpace: 'nowrap',
+  borderBottom: '1px solid #1d3449',
+  textAlign: 'center',
+}
+
+const ROW_LABEL_CELL: CSSProperties = {
+  padding: '10px 12px',
+  fontSize: '13px',
+  color: '#f9fafa',
+  whiteSpace: 'nowrap',
+  borderBottom: '1px solid #1d3449',
+  textAlign: 'left',
+  position: 'sticky',
+  left: 0,
+  backgroundColor: '#101d28',
+  zIndex: 1,
+}
+
+const DATA_CELL_BASE: CSSProperties = {
+  padding: '8px 12px',
+  fontSize: '13px',
+  textAlign: 'center',
+  borderBottom: '1px solid #1d3449',
+  borderRadius: '4px',
+  minWidth: '52px',
+}
+
+function formatSlaPercent(value: number): string {
+  return `${Math.round(value)}%`
+}
+
+export function SlaMetricsSlaTable({
+  title,
+  columnHeader,
+  rows,
+  periodLabels,
+  isLoading,
+  formatRowLabel = formatSlaPerformanceRowLabel,
+}: SlaMetricsSlaTableProps) {
+  const formattedHeaders = periodLabels.map((pl) =>
+    formatPeriodLabel(pl, 'monthly'),
+  )
+
+  return (
+    <div
+      style={{
+        backgroundColor: '#101d28',
+        border: '1px solid #4a5d6d',
+        borderRadius: '8px',
+        padding: '24px',
+      }}
+    >
+      <h2
+        style={{
+          fontSize: '20px',
+          fontWeight: 600,
+          color: '#f9fafa',
+          margin: '0 0 20px 0',
+        }}
+      >
+        {title}
+      </h2>
+
+      {isLoading && rows.length === 0 ? (
+        <div
+          style={{
+            height: '120px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: '#97a2ab',
+            fontSize: '14px',
+          }}
+        >
+          Carregando…
+        </div>
+      ) : rows.length === 0 ? (
+        <div
+          style={{
+            height: '80px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: '#97a2ab',
+            fontSize: '14px',
+          }}
+        >
+          Nenhum dado disponível
+        </div>
+      ) : (
+        <>
+          <div style={{ overflowX: 'auto' }}>
+            <table
+              style={{
+                width: '100%',
+                borderCollapse: 'separate',
+                borderSpacing: 0,
+              }}
+            >
+              <thead>
+                <tr>
+                  <th
+                    style={{
+                      ...HEADER_CELL,
+                      textAlign: 'left',
+                      position: 'sticky',
+                      left: 0,
+                      backgroundColor: '#101d28',
+                      zIndex: 2,
+                      minWidth: '160px',
+                    }}
+                  >
+                    {columnHeader}
+                  </th>
+                  {formattedHeaders.map((h, i) => (
+                    <th key={i} style={HEADER_CELL}>
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.label}>
+                    <td style={ROW_LABEL_CELL}>{formatRowLabel(row.label)}</td>
+                    {row.periods.map((period) => {
+                      const variant = getCellVariant(
+                        period.sla_percent,
+                        period.is_above_average,
+                      )
+                      return (
+                        <td
+                          key={period.period_label}
+                          style={{
+                            ...DATA_CELL_BASE,
+                            ...CELL_STYLES[variant],
+                          }}
+                        >
+                          {period.sla_percent == null ||
+                          period.sla_percent === 0 ? (
+                            <span style={{ opacity: 0.3 }}>—</span>
+                          ) : (
+                            formatSlaPercent(period.sla_percent)
+                          )}
+                        </td>
+                      )
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: '24px',
+              marginTop: '16px',
+              paddingTop: '12px',
+              borderTop: '1px solid #1d3449',
+            }}
+          >
+            <LegendItem
+              color="#f9a7b3"
+              bg="rgba(185, 61, 82, 0.25)"
+              label="Acima da média"
+            />
+            <LegendItem
+              color="#06b2bb"
+              bg="rgba(6, 178, 187, 0.15)"
+              label="Abaixo da média"
+            />
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+function LegendItem({
+  color,
+  bg,
+  label,
+}: {
+  color: string
+  bg: string
+  label: string
+}) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+      <span
+        style={{
+          display: 'inline-block',
+          width: '32px',
+          height: '16px',
+          backgroundColor: bg,
+          borderRadius: '4px',
+          border: `1px solid ${color}`,
+        }}
+      />
+      <span style={{ fontSize: '12px', color: '#97a2ab' }}>{label}</span>
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-summary-cards.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-summary-cards.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import type { SlaDashboardSummaryOut } from '@/http/tickets/get-sla-dashboard'
+
+import styles from '../../volume/components/demand-volume-top.module.css'
+
+interface SlaMetricsSummaryCardsProps {
+  summary: SlaDashboardSummaryOut | undefined
+  isLoading: boolean
+}
+
+interface SummaryCardProps {
+  label: string
+  sublabel: string
+  value: string
+  isLoading: boolean
+}
+
+function SummaryCard({ label, sublabel, value, isLoading }: SummaryCardProps) {
+  return (
+    <div className={styles.summaryCard}>
+      <p className={styles.summaryCardLabel}>{label}</p>
+      <p className={styles.summaryCardValue}>
+        {isLoading ? <span style={{ opacity: 0.4 }}>—</span> : value}
+      </p>
+      <p className={styles.summaryCardSublabel}>{sublabel}</p>
+    </div>
+  )
+}
+
+function formatDays(value: number | undefined): string {
+  if (value == null || Number.isNaN(value)) return '—'
+  return `${value.toLocaleString('pt-BR', {
+    minimumFractionDigits: 1,
+    maximumFractionDigits: 1,
+  })} dias`
+}
+
+function formatPercent(value: number | undefined): string {
+  if (value == null || Number.isNaN(value)) return '—'
+  return `${Math.round(value)}%`
+}
+
+export function SlaMetricsSummaryCards({
+  summary,
+  isLoading,
+}: SlaMetricsSummaryCardsProps) {
+  return (
+    <section
+      className={styles.summarySection}
+      aria-label="Resumo de métricas de resposta"
+    >
+      <div className={styles.summaryCardsRow}>
+        <SummaryCard
+          label="Tempo médio de resolução"
+          sublabel="no período selecionado"
+          value={formatDays(summary?.avg_resolution_days)}
+          isLoading={isLoading}
+        />
+        <SummaryCard
+          label="SLA geral atingido"
+          sublabel="no período selecionado"
+          value={formatPercent(summary?.overall_sla_attained_percent)}
+          isLoading={isLoading}
+        />
+        <SummaryCard
+          label="Total de demandas"
+          sublabel="no período selecionado"
+          value={
+            summary?.total_demands != null
+              ? summary.total_demands.toLocaleString('pt-BR')
+              : '—'
+          }
+          isLoading={isLoading}
+        />
+        <SummaryCard
+          label="Taxa de resolução"
+          sublabel="demandas finalizadas"
+          value={formatPercent(summary?.resolution_rate_percent)}
+          isLoading={isLoading}
+        />
+      </div>
+    </section>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-view.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-view.tsx
@@ -1,0 +1,210 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { useEffect, useMemo, useState } from 'react'
+
+import {
+  getSlaDashboard,
+  pickSlaDashboardGranularitySeries,
+  type SlaDashboardFilterIn,
+  type SlaDashboardGranularity,
+} from '@/http/tickets/get-sla-dashboard'
+
+import { normalizeDemandVolumeDateRange } from '../../volume/components/demand-volume-date-range'
+import {
+  advancedFiltersToApiPatch,
+  type SlaMetricsAdvancedFilterForm,
+  stripAdvancedFiltersFromApi,
+} from './sla-metrics-filter-utils'
+import { SlaMetricsFilters } from './sla-metrics-filters'
+import { SlaMetricsGeneralChart } from './sla-metrics-general-chart'
+import { SlaMetricsMediaChart } from './sla-metrics-media-chart'
+import {
+  createDefaultSlaMetricsFilters,
+  getDefaultSlaMetricsDateRange,
+} from './sla-metrics-period-presets'
+import { SlaMetricsPriorityChart } from './sla-metrics-priority-chart'
+import { SlaMetricsSlaTable } from './sla-metrics-sla-table'
+import { SlaMetricsSummaryCards } from './sla-metrics-summary-cards'
+
+export function SlaMetricsView() {
+  const [draftFilters, setDraftFilters] = useState<SlaDashboardFilterIn>(
+    createDefaultSlaMetricsFilters,
+  )
+  const [appliedFilters, setAppliedFilters] = useState<SlaDashboardFilterIn>(
+    createDefaultSlaMetricsFilters,
+  )
+  const [generalGranularity, setGeneralGranularity] =
+    useState<SlaDashboardGranularity>('monthly')
+  const [priorityGranularity, setPriorityGranularity] =
+    useState<SlaDashboardGranularity>('monthly')
+  const [mediaGranularity, setMediaGranularity] =
+    useState<SlaDashboardGranularity>('monthly')
+
+  useEffect(() => {
+    const fillDates = (prev: SlaDashboardFilterIn): SlaDashboardFilterIn => {
+      if (prev.date_from && prev.date_to) return prev
+      return { ...prev, ...getDefaultSlaMetricsDateRange() }
+    }
+    setDraftFilters(fillDates)
+    setAppliedFilters(fillDates)
+  }, [])
+
+  const { data, isFetching, isError } = useQuery({
+    queryKey: ['sla-dashboard', appliedFilters],
+    queryFn: () => getSlaDashboard(appliedFilters),
+    staleTime: 60_000,
+  })
+
+  const generalChartData = useMemo(
+    () =>
+      pickSlaDashboardGranularitySeries(
+        data?.avg_resolution_time_general,
+        generalGranularity,
+      ),
+    [data?.avg_resolution_time_general, generalGranularity],
+  )
+
+  const priorityChartData = useMemo(
+    () =>
+      pickSlaDashboardGranularitySeries(
+        data?.avg_resolution_time_by_priority,
+        priorityGranularity,
+      ),
+    [data?.avg_resolution_time_by_priority, priorityGranularity],
+  )
+
+  const mediaChartData = useMemo(
+    () =>
+      pickSlaDashboardGranularitySeries(
+        data?.delivery_time_for_media_relevant,
+        mediaGranularity,
+      ),
+    [data?.delivery_time_for_media_relevant, mediaGranularity],
+  )
+
+  const slaTablePeriodLabels = useMemo(() => {
+    const fromPriority = data?.sla_performance_by_priority[0]?.periods.map(
+      (p) => p.period_label,
+    )
+    if (fromPriority?.length) return fromPriority
+    return (
+      data?.sla_performance_by_service[0]?.periods.map((p) => p.period_label) ??
+      []
+    )
+  }, [data?.sla_performance_by_priority, data?.sla_performance_by_service])
+
+  function applyFilters(next: SlaDashboardFilterIn) {
+    setDraftFilters(next)
+    setAppliedFilters(next)
+  }
+
+  function handlePeriodDatesChange(
+    patch: Partial<{ dateFrom: string; dateTo: string }>,
+    changed: 'from' | 'to',
+  ) {
+    const fallback = getDefaultSlaMetricsDateRange()
+    let dateFrom =
+      patch.dateFrom ?? draftFilters.date_from ?? fallback.date_from ?? ''
+    let dateTo = patch.dateTo ?? draftFilters.date_to ?? fallback.date_to ?? ''
+
+    if (dateFrom && dateTo) {
+      ;({ dateFrom, dateTo } = normalizeDemandVolumeDateRange(
+        dateFrom,
+        dateTo,
+        changed,
+      ))
+    }
+
+    applyFilters({
+      ...appliedFilters,
+      date_from: dateFrom || undefined,
+      date_to: dateTo || undefined,
+    })
+  }
+
+  function handleApplyAdvancedFilters(form: SlaMetricsAdvancedFilterForm) {
+    applyFilters({
+      ...stripAdvancedFiltersFromApi(appliedFilters),
+      ...advancedFiltersToApiPatch(form),
+    })
+  }
+
+  return (
+    <div
+      style={{
+        paddingTop: '24px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '24px',
+      }}
+    >
+      <SlaMetricsSummaryCards summary={data?.summary} isLoading={isFetching} />
+
+      <SlaMetricsFilters
+        dateFrom={draftFilters.date_from ?? ''}
+        dateTo={draftFilters.date_to ?? ''}
+        onDateFromChange={(dateFrom) =>
+          handlePeriodDatesChange({ dateFrom }, 'from')
+        }
+        onDateToChange={(dateTo) => handlePeriodDatesChange({ dateTo }, 'to')}
+        isLoading={isFetching}
+        appliedFilters={appliedFilters}
+        onApplyAdvancedFilters={handleApplyAdvancedFilters}
+      />
+
+      {isError && (
+        <div
+          style={{
+            backgroundColor: '#1d3449',
+            border: '1px solid #4a5d6d',
+            borderRadius: '8px',
+            padding: '16px 24px',
+            color: '#f9fafa',
+            fontSize: '14px',
+          }}
+        >
+          Erro ao carregar dados. Verifique sua conexão e tente novamente.
+        </div>
+      )}
+
+      <SlaMetricsGeneralChart
+        data={generalChartData}
+        granularity={generalGranularity}
+        onGranularityChange={setGeneralGranularity}
+        isLoading={isFetching}
+      />
+
+      <SlaMetricsPriorityChart
+        data={priorityChartData}
+        granularity={priorityGranularity}
+        onGranularityChange={setPriorityGranularity}
+        isLoading={isFetching}
+      />
+
+      <SlaMetricsSlaTable
+        title="Desempenho de SLA por Prioridade"
+        columnHeader="PRIORIDADE"
+        rows={data?.sla_performance_by_priority ?? []}
+        periodLabels={slaTablePeriodLabels}
+        isLoading={isFetching}
+      />
+
+      <SlaMetricsSlaTable
+        title="Desempenho de SLA por Serviço"
+        columnHeader="SERVIÇO"
+        rows={data?.sla_performance_by_service ?? []}
+        periodLabels={slaTablePeriodLabels}
+        isLoading={isFetching}
+        formatRowLabel={(label) => label}
+      />
+
+      <SlaMetricsMediaChart
+        data={mediaChartData}
+        granularity={mediaGranularity}
+        onGranularityChange={setMediaGranularity}
+        isLoading={isFetching}
+      />
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/metricas/page.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/metricas/page.tsx
@@ -1,0 +1,5 @@
+import { SlaMetricsView } from './components/sla-metrics-view'
+
+export default function SlaMetricsPage() {
+  return <SlaMetricsView />
+}

--- a/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-chart-utils.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-chart-utils.ts
@@ -1,0 +1,184 @@
+import type {
+  OpenTicketsByTeamItemOut,
+  OpenTicketsTeamPeriodSeriesOut,
+  OperationalViewGranularity,
+  OperationalViewGranularitySeries,
+  TeamPeriodSeriesOut,
+} from '@/http/tickets/get-operational-view'
+
+import { formatPeriodLabel } from '../../volume/components/demand-volume-period-label'
+
+export type TeamLineChartPoint = {
+  label: string
+  period_label: string
+} & Record<string, number | string | null>
+
+export type OpenTicketsPeriodBarPoint = {
+  label: string
+  period_label: string
+} & Record<string, number | string>
+
+const OPEN_TICKETS_STATUS_KEYS = [
+  'pendente',
+  'bloqueado',
+  'aguardando_revisao',
+] as const
+
+export type OpenTicketsStatusKey = (typeof OPEN_TICKETS_STATUS_KEYS)[number]
+
+export function openTicketsBarDataKey(
+  team: string,
+  status: OpenTicketsStatusKey,
+): string {
+  return `${team}__${status}`
+}
+
+function isPeriodWithinDateRange(
+  periodLabel: string,
+  dateFrom: string | undefined,
+  dateTo: string | undefined,
+  granularity: OperationalViewGranularity,
+): boolean {
+  if (!dateFrom && !dateTo) return true
+
+  if (granularity === 'monthly') {
+    const [year, month] = periodLabel.split('-').map(Number)
+    if (!year || !month) return true
+    const periodStart = `${year}-${String(month).padStart(2, '0')}-01`
+    const lastDay = new Date(year, month, 0).getDate()
+    const periodEnd = `${year}-${String(month).padStart(2, '0')}-${String(lastDay).padStart(2, '0')}`
+    if (dateFrom && periodEnd < dateFrom) return false
+    if (dateTo && periodStart > dateTo) return false
+    return true
+  }
+
+  if (granularity === 'yearly') {
+    const year = Number(periodLabel)
+    if (!year) return true
+    const periodStart = `${year}-01-01`
+    const periodEnd = `${year}-12-31`
+    if (dateFrom && periodEnd < dateFrom) return false
+    if (dateTo && periodStart > dateTo) return false
+    return true
+  }
+
+  // Semanal: mantém todos os pontos retornados pelo backend no intervalo filtrado.
+  return true
+}
+
+/** Barras empilhadas por equipe ao longo dos períodos da granularidade selecionada. */
+export function pivotOpenTicketsForBarChart(
+  series:
+    | OperationalViewGranularitySeries<OpenTicketsTeamPeriodSeriesOut>
+    | undefined,
+  granularity: OperationalViewGranularity,
+  dateFrom?: string,
+  dateTo?: string,
+): { chartData: OpenTicketsPeriodBarPoint[]; teams: string[] } {
+  const teamSeries = series?.[granularity] ?? []
+  if (!teamSeries.length) return { chartData: [], teams: [] }
+
+  const teams = [...new Set(teamSeries.map((item) => item.team))].sort((a, b) =>
+    a.localeCompare(b, 'pt-BR'),
+  )
+
+  const filteredPeriodLabels = [
+    ...new Set(
+      teamSeries.flatMap(({ data }) =>
+        data
+          .filter((point) =>
+            isPeriodWithinDateRange(
+              point.period_label,
+              dateFrom,
+              dateTo,
+              granularity,
+            ),
+          )
+          .map((point) => point.period_label),
+      ),
+    ),
+  ].sort()
+
+  const periodLabels =
+    filteredPeriodLabels.length > 0
+      ? filteredPeriodLabels
+      : [
+          ...new Set(
+            teamSeries.flatMap((item) =>
+              item.data.map((point) => point.period_label),
+            ),
+          ),
+        ].sort()
+
+  const valueByTeamPeriod = new Map<string, OpenTicketsByTeamItemOut>()
+  for (const { team, data } of teamSeries) {
+    for (const point of data) {
+      valueByTeamPeriod.set(`${team}::${point.period_label}`, {
+        team,
+        pendente: point.pendente,
+        bloqueado: point.bloqueado,
+        aguardando_revisao: point.aguardando_revisao,
+      })
+    }
+  }
+
+  const chartData = periodLabels.map((periodLabel) => {
+    const row: OpenTicketsPeriodBarPoint = {
+      period_label: periodLabel,
+      label: formatPeriodLabel(periodLabel, granularity),
+    }
+
+    for (const team of teams) {
+      const values = valueByTeamPeriod.get(`${team}::${periodLabel}`)
+      for (const status of OPEN_TICKETS_STATUS_KEYS) {
+        row[openTicketsBarDataKey(team, status)] = values?.[status] ?? 0
+      }
+    }
+
+    return row
+  })
+
+  return { chartData, teams }
+}
+
+export function pivotTeamPeriodSeries(
+  series: TeamPeriodSeriesOut[],
+  granularity: OperationalViewGranularity,
+): { chartData: TeamLineChartPoint[]; teams: string[] } {
+  if (!series.length) {
+    return { chartData: [], teams: [] }
+  }
+
+  const teams = [...new Set(series.map((item) => item.team))].sort((a, b) =>
+    a.localeCompare(b, 'pt-BR'),
+  )
+
+  const periodLabels = [
+    ...new Set(
+      series.flatMap((item) => item.data.map((point) => point.period_label)),
+    ),
+  ].sort()
+
+  const valueByTeamAndPeriod = new Map<string, number>()
+  for (const item of series) {
+    for (const point of item.data) {
+      valueByTeamAndPeriod.set(
+        `${item.team}::${point.period_label}`,
+        point.value,
+      )
+    }
+  }
+
+  const chartData = periodLabels.map((periodLabel) => {
+    const row: TeamLineChartPoint = {
+      period_label: periodLabel,
+      label: formatPeriodLabel(periodLabel, granularity),
+    }
+    for (const team of teams) {
+      row[team] = valueByTeamAndPeriod.get(`${team}::${periodLabel}`) ?? null
+    }
+    return row
+  })
+
+  return { chartData, teams }
+}

--- a/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-export-dialog.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-export-dialog.tsx
@@ -1,0 +1,180 @@
+'use client'
+
+import { format } from 'date-fns'
+import { Download, FileSpreadsheet, Upload } from 'lucide-react'
+import { useCallback, useState } from 'react'
+import { toast } from 'sonner'
+
+import { Spinner } from '@/components/custom/spinner'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog'
+import {
+  getOperationalViewTickets,
+  type OperationalViewFilterIn,
+} from '@/http/tickets/get-operational-view'
+import { dateConfig } from '@/lib/date-config'
+import { downloadFile } from '@/utils/download-file'
+import { getApiErrorMessage } from '@/utils/error-handlers'
+
+import styles from '../../volume/components/demand-volume-top.module.css'
+import {
+  buildOperationalViewTicketsCsv,
+  operationalViewTicketsExportFilename,
+} from './operational-view-export'
+import { formatOperationalViewAdvancedFiltersSummary } from './operational-view-filter-utils'
+
+interface OperationalViewExportDialogProps {
+  appliedFilters: OperationalViewFilterIn
+  disabled?: boolean
+}
+
+function formatBrDate(iso: string | undefined): string {
+  if (!iso?.trim()) return '—'
+  const [y, m, d] = iso.split('-').map(Number)
+  if (!y || !m || !d) return iso
+  const date = new Date(y, m - 1, d)
+  return format(date, dateConfig.formats.date, { locale: dateConfig.locale })
+}
+
+export function OperationalViewExportDialog({
+  appliedFilters,
+  disabled,
+}: OperationalViewExportDialogProps) {
+  const [open, setOpen] = useState(false)
+  const [isExporting, setIsExporting] = useState(false)
+
+  const advancedFilterLines =
+    formatOperationalViewAdvancedFiltersSummary(appliedFilters)
+
+  const handleExport = useCallback(async () => {
+    setIsExporting(true)
+    try {
+      const { items } = await getOperationalViewTickets(appliedFilters)
+      if (items.length === 0) {
+        toast.message('Nenhum chamado para exportar com os filtros atuais.')
+        return
+      }
+      const exportedAt = new Date()
+      const csv = buildOperationalViewTicketsCsv(items)
+      const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+      downloadFile(blob, operationalViewTicketsExportFilename(exportedAt))
+      toast.success(`Exportação concluída (${items.length} linhas).`)
+      setOpen(false)
+    } catch (error) {
+      toast.error(getApiErrorMessage(error))
+    } finally {
+      setIsExporting(false)
+    }
+  }, [appliedFilters])
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className={styles.iconButton}
+          aria-label="Exportar chamados"
+          title="Exportar"
+          disabled={disabled}
+        >
+          <Upload className="h-5 w-5" />
+        </button>
+      </DialogTrigger>
+      <DialogContent
+        className="border-[#4a5d6d] bg-[#101d28] text-[#f9fafa] sm:max-w-md"
+        style={{ maxWidth: '440px' }}
+      >
+        <DialogHeader>
+          <DialogTitle className="text-[#f9fafa]">
+            Exportar chamados
+          </DialogTitle>
+          <DialogDescription className="text-[#97a2ab]">
+            Gera um arquivo CSV com a lista de chamados do período e filtros
+            aplicados, pronto para abrir no Excel ou Google Planilhas.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div
+          className="flex flex-col gap-3 rounded-lg border border-[#4a5d6d] bg-[#152534] p-4 text-sm"
+          role="region"
+          aria-label="Parâmetros da exportação"
+        >
+          <div className="flex items-start gap-3">
+            <FileSpreadsheet
+              className="mt-0.5 h-5 w-5 shrink-0 text-[#06b2bb]"
+              aria-hidden
+            />
+            <div className="min-w-0 space-y-2">
+              <p className="font-medium text-[#f9fafa]">Conteúdo incluído</p>
+              <ul className="list-inside list-disc space-y-1 text-[#97a2ab]">
+                <li>Nº interno, data, status e prioridade</li>
+                <li>Demandante, operação e tipo de chamado</li>
+                <li>Natureza, equipe e chamado pai (quando houver)</li>
+              </ul>
+            </div>
+          </div>
+
+          <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 border-t border-[#1d3449] pt-3 text-[13px]">
+            <dt className="text-[#97a2ab]">Período da busca</dt>
+            <dd className="text-[#f9fafa]">
+              {formatBrDate(appliedFilters.date_from)} —{' '}
+              {formatBrDate(appliedFilters.date_to)}
+            </dd>
+            {advancedFilterLines.length > 0 ? (
+              <>
+                <dt className="text-[#97a2ab]">Filtros</dt>
+                <dd className="text-[#f9fafa]">
+                  <ul className="list-inside list-disc space-y-0.5">
+                    {advancedFilterLines.map((line) => (
+                      <li key={line}>{line}</li>
+                    ))}
+                  </ul>
+                </dd>
+              </>
+            ) : null}
+          </dl>
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            className="border-[#4a5d6d] bg-transparent text-[#f9fafa] hover:bg-[#1d3449]"
+            onClick={() => setOpen(false)}
+            disabled={isExporting}
+          >
+            Cancelar
+          </Button>
+          <Button
+            type="button"
+            className="gap-2 bg-[#1d3449] text-[#f9fafa] hover:bg-[#254a66]"
+            onClick={() => {
+              handleExport()
+            }}
+            disabled={isExporting}
+          >
+            {isExporting ? (
+              <>
+                <Spinner className="h-4 w-4" />
+                Exportando…
+              </>
+            ) : (
+              <>
+                <Download className="h-4 w-4" />
+                Baixar CSV
+              </>
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-export.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-export.ts
@@ -1,0 +1,10 @@
+import { format } from 'date-fns'
+
+export { buildDemandVolumeTicketsCsv as buildOperationalViewTicketsCsv } from '../../volume/components/demand-volume-export'
+
+export function operationalViewTicketsExportFilename(
+  exportedAt = new Date(),
+): string {
+  const stamp = format(exportedAt, 'yyyy-MM-dd')
+  return `dashboard-tatico-visao-operacional-chamados-${stamp}.csv`
+}

--- a/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-filter-modal.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-filter-modal.tsx
@@ -1,0 +1,360 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { ChevronDown, X } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+import filterModalStyles from '@/app/(app)/demandas/list/components/filter/tickets-general-list-filters.module.css'
+import { Button } from '@/components/ui/button'
+import { Switch } from '@/components/ui/switch'
+import { getTicketTypes } from '@/http/ticket-types/get-ticket.types'
+import {
+  type SearchOption,
+  searchRequesters,
+} from '@/http/tickets/tickets-dashboard-filters'
+
+import {
+  emptyOperationalViewAdvancedFilters,
+  OPERATIONAL_VIEW_PRIORITY_OPTIONS,
+  OPERATIONAL_VIEW_STATUS_OPTIONS,
+  type OperationalViewAdvancedFilterForm,
+} from './operational-view-filter-utils'
+
+function useDebouncedValue<T>(value: T, delay = 400) {
+  const [debouncedValue, setDebouncedValue] = useState(value)
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      setDebouncedValue(value)
+    }, delay)
+    return () => window.clearTimeout(timeout)
+  }, [value, delay])
+
+  return debouncedValue
+}
+
+function SearchMultiSelect({
+  label,
+  placeholder = 'Selecione',
+  value,
+  onChange,
+  searchFn,
+  staticOptions,
+  optionsLoading,
+  minCharsMessage = 'Digite ao menos 2 caracteres',
+}: {
+  label: string
+  placeholder?: string
+  value: SearchOption[]
+  onChange: (value: SearchOption[]) => void
+  searchFn?: (search: string) => Promise<SearchOption[]>
+  staticOptions?: SearchOption[]
+  optionsLoading?: boolean
+  minCharsMessage?: string
+}) {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [search, setSearch] = useState('')
+  const [isOpen, setIsOpen] = useState(false)
+  const debouncedSearch = useDebouncedValue(search, 350)
+
+  const { data, isFetching } = useQuery({
+    queryKey: ['sla-metrics-filter-search', label, debouncedSearch],
+    queryFn: () => searchFn!(debouncedSearch),
+    enabled:
+      isOpen &&
+      !staticOptions &&
+      Boolean(searchFn) &&
+      debouncedSearch.trim().length >= 2,
+    staleTime: 1000 * 60 * 5,
+  })
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!containerRef.current) return
+      if (!containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  const selectedValues = useMemo(
+    () => new Set(value.map((item) => item.value)),
+    [value],
+  )
+
+  const staticFiltered = useMemo(() => {
+    if (!staticOptions) return []
+    const q = debouncedSearch.trim().toLowerCase()
+    return staticOptions.filter(
+      (item) =>
+        !selectedValues.has(item.value) &&
+        (q === '' ||
+          item.label.toLowerCase().includes(q) ||
+          item.value.toLowerCase().includes(q)),
+    )
+  }, [staticOptions, debouncedSearch, selectedValues])
+
+  const options = useMemo(() => {
+    if (staticOptions) return staticFiltered
+    return (data ?? []).filter((item) => !selectedValues.has(item.value))
+  }, [staticOptions, staticFiltered, data, selectedValues])
+
+  const removeItem = (itemValue: string) => {
+    onChange(value.filter((item) => item.value !== itemValue))
+  }
+
+  const addItem = (item: SearchOption) => {
+    onChange([...value, item])
+    setSearch('')
+  }
+
+  return (
+    <div className={filterModalStyles.filterBlock} ref={containerRef}>
+      <span className={filterModalStyles.filterLabel}>{label}</span>
+
+      <div className={filterModalStyles.multiSelectBox}>
+        <div className={filterModalStyles.multiSelectInputWrapper}>
+          <input
+            value={search}
+            onFocus={() => setIsOpen(true)}
+            onChange={(event) => {
+              setSearch(event.target.value)
+              setIsOpen(true)
+            }}
+            placeholder={value.length > 0 ? '' : placeholder}
+            className={filterModalStyles.multiSelectInput}
+          />
+          <ChevronDown
+            className={filterModalStyles.multiSelectChevron}
+            size={16}
+          />
+          {isOpen ? (
+            <div className={filterModalStyles.multiSelectDropdown}>
+              {optionsLoading ? (
+                <div className={filterModalStyles.dropdownHint}>
+                  Buscando...
+                </div>
+              ) : !staticOptions && debouncedSearch.trim().length < 2 ? (
+                <div className={filterModalStyles.dropdownHint}>
+                  {minCharsMessage}
+                </div>
+              ) : isFetching ? (
+                <div className={filterModalStyles.dropdownHint}>
+                  Buscando...
+                </div>
+              ) : options.length === 0 ? (
+                <div className={filterModalStyles.dropdownHint}>
+                  Nenhum resultado encontrado
+                </div>
+              ) : (
+                options.map((item) => (
+                  <button
+                    key={item.value}
+                    type="button"
+                    className={filterModalStyles.dropdownOption}
+                    onClick={() => addItem(item)}
+                  >
+                    {item.label}
+                  </button>
+                ))
+              )}
+            </div>
+          ) : null}
+        </div>
+
+        {value.length > 0 ? (
+          <div className={filterModalStyles.selectedChips}>
+            {value.map((item) => (
+              <span key={item.value} className={filterModalStyles.selectedChip}>
+                {item.label}
+                <button
+                  type="button"
+                  className={filterModalStyles.selectedChipRemove}
+                  onClick={() => removeItem(item.value)}
+                >
+                  <X size={12} />
+                </button>
+              </span>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}
+
+function PressRelevanceField({
+  value,
+  onChange,
+}: {
+  value: boolean
+  onChange: (value: boolean) => void
+}) {
+  return (
+    <div className={filterModalStyles.filterBlock}>
+      <span className={filterModalStyles.filterLabel}>
+        RELEVANTE PARA IMPRENSA?
+      </span>
+      <div className="flex items-center gap-2 pt-1">
+        <Switch
+          id="operational-view-relevante-imprensa"
+          size="sm"
+          checked={value}
+          onCheckedChange={onChange}
+        />
+        <span className="text-sm text-[#91a6bc]">{value ? 'Sim' : 'Não'}</span>
+      </div>
+    </div>
+  )
+}
+
+export type OperationalViewFilterModalProps = {
+  isOpen: boolean
+  onClose: () => void
+  filters: OperationalViewAdvancedFilterForm
+  onApply: (filters: OperationalViewAdvancedFilterForm) => void
+}
+
+export function OperationalViewFilterModal({
+  isOpen,
+  onClose,
+  filters,
+  onApply,
+}: OperationalViewFilterModalProps) {
+  const [draftFilters, setDraftFilters] =
+    useState<OperationalViewAdvancedFilterForm>(filters)
+
+  useEffect(() => {
+    if (isOpen) {
+      setDraftFilters(filters)
+    }
+  }, [isOpen, filters])
+
+  const { data: ticketTypeOptions, isFetching: isTicketTypesLoading } =
+    useQuery({
+      queryKey: ['ticket-types', 'operational-view-filter'],
+      queryFn: async () => {
+        const response = await getTicketTypes({ isActive: true })
+        return (response.data ?? []).map((item) => ({
+          value: item.id,
+          label: item.name,
+        }))
+      },
+      enabled: isOpen,
+      staleTime: 1000 * 60 * 5,
+    })
+
+  const handleApply = () => {
+    onApply(draftFilters)
+    onClose()
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <div className={filterModalStyles.filterModalOverlay}>
+      <div className={filterModalStyles.filterModal}>
+        <div className={filterModalStyles.filterModalHeader}>
+          <div className={filterModalStyles.filterModalTitle} />
+          <button
+            type="button"
+            className={filterModalStyles.filterModalClose}
+            onClick={onClose}
+            aria-label="Fechar filtros"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className={filterModalStyles.filterModalBody}>
+          <div className={filterModalStyles.filterGrid}>
+            <SearchMultiSelect
+              label="REQUISITANTE"
+              value={draftFilters.requisitante}
+              onChange={(value) =>
+                setDraftFilters((current) => ({
+                  ...current,
+                  requisitante: value,
+                }))
+              }
+              searchFn={searchRequesters}
+            />
+
+            <SearchMultiSelect
+              label="URGÊNCIA"
+              placeholder="Selecione"
+              value={draftFilters.prioridade}
+              onChange={(value) =>
+                setDraftFilters((current) => ({
+                  ...current,
+                  prioridade: value,
+                }))
+              }
+              staticOptions={OPERATIONAL_VIEW_PRIORITY_OPTIONS}
+            />
+
+            <SearchMultiSelect
+              label="STATUS DO CHAMADO"
+              placeholder="Selecione"
+              value={draftFilters.status}
+              onChange={(value) =>
+                setDraftFilters((current) => ({
+                  ...current,
+                  status: value,
+                }))
+              }
+              staticOptions={OPERATIONAL_VIEW_STATUS_OPTIONS}
+            />
+
+            <SearchMultiSelect
+              label="TIPO DE CHAMADO"
+              placeholder="Selecione"
+              value={draftFilters.tipo_chamado_id}
+              onChange={(value) =>
+                setDraftFilters((current) => ({
+                  ...current,
+                  tipo_chamado_id: value,
+                }))
+              }
+              staticOptions={ticketTypeOptions ?? []}
+              optionsLoading={isTicketTypesLoading}
+            />
+          </div>
+
+          <div className={filterModalStyles.filterTogglesGrid}>
+            <PressRelevanceField
+              value={draftFilters.relevanteImprensa}
+              onChange={(relevanteImprensa) =>
+                setDraftFilters((current) => ({
+                  ...current,
+                  relevanteImprensa,
+                }))
+              }
+            />
+          </div>
+        </div>
+
+        <div className={filterModalStyles.filterModalFooter}>
+          <Button
+            type="button"
+            className={filterModalStyles.filterSecondaryButton}
+            onClick={() =>
+              setDraftFilters(emptyOperationalViewAdvancedFilters())
+            }
+          >
+            Limpar Filtro
+          </Button>
+          <Button
+            type="button"
+            className={filterModalStyles.filterPrimaryButton}
+            onClick={handleApply}
+          >
+            Salvar
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-filter-utils.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-filter-utils.ts
@@ -1,0 +1,169 @@
+import type {
+  OperationalViewFilterIn,
+  OperationalViewPriority,
+  OperationalViewStatus,
+} from '@/http/tickets/get-operational-view'
+import type { SearchOption } from '@/http/tickets/tickets-dashboard-filters'
+
+export type OperationalViewAdvancedFilterForm = {
+  requisitante: SearchOption[]
+  prioridade: SearchOption[]
+  status: SearchOption[]
+  tipo_chamado_id: SearchOption[]
+  relevanteImprensa: boolean
+}
+
+export const OPERATIONAL_VIEW_PRIORITY_OPTIONS: SearchOption[] = [
+  { value: 'URGENTE', label: 'Urgente' },
+  { value: 'ALTA', label: 'Alta' },
+  { value: 'ROTINA', label: 'Rotina' },
+]
+
+export const OPERATIONAL_VIEW_STATUS_OPTIONS: SearchOption[] = [
+  { value: 'PENDENTE', label: 'Pendente' },
+  { value: 'BLOQUEADO', label: 'Bloqueado' },
+  {
+    value: 'AGUARDANDO_REVISAO_ADJUNTO',
+    label: 'Aguardando revisão adjunto',
+  },
+  {
+    value: 'AGUARDANDO_REVISAO_ADMINISTRATIVO',
+    label: 'Aguardando revisão administrativo',
+  },
+  { value: 'FINALIZADO', label: 'Finalizado' },
+  { value: 'DEMANDA_RESPONDIDA', label: 'Demanda respondida' },
+  { value: 'RESTRITO', label: 'Restrito' },
+]
+
+const priorityLabelByValue = new Map(
+  OPERATIONAL_VIEW_PRIORITY_OPTIONS.map((o) => [o.value, o.label]),
+)
+const statusLabelByValue = new Map(
+  OPERATIONAL_VIEW_STATUS_OPTIONS.map((o) => [o.value, o.label]),
+)
+
+export function emptyOperationalViewAdvancedFilters(): OperationalViewAdvancedFilterForm {
+  return {
+    requisitante: [],
+    prioridade: [],
+    status: [],
+    tipo_chamado_id: [],
+    relevanteImprensa: false,
+  }
+}
+
+export function countOperationalViewAdvancedFiltersFromApi(
+  filters: OperationalViewFilterIn,
+): number {
+  let count = 0
+  count += filters.requisitante?.length ?? 0
+  count += filters.prioridade?.length ?? 0
+  count += filters.status?.length ?? 0
+  count += filters.tipo_chamado_id?.length ?? 0
+  if (filters.relevante_imprensa === true) {
+    count += 1
+  }
+  return count
+}
+
+function toSearchOptions(
+  values: string[] | undefined,
+  labelMap: Map<string, string>,
+): SearchOption[] {
+  if (!values?.length) return []
+  return values.map((value) => ({
+    value,
+    label: labelMap.get(value) ?? value,
+  }))
+}
+
+export function advancedFiltersFromApi(
+  filters: OperationalViewFilterIn,
+): OperationalViewAdvancedFilterForm {
+  return {
+    requisitante: (filters.requisitante ?? []).map((value) => ({
+      value,
+      label: value,
+    })),
+    prioridade: toSearchOptions(
+      filters.prioridade,
+      priorityLabelByValue,
+    ) as SearchOption[],
+    status: toSearchOptions(
+      filters.status,
+      statusLabelByValue,
+    ) as SearchOption[],
+    tipo_chamado_id: (filters.tipo_chamado_id ?? []).map((value) => ({
+      value,
+      label: value,
+    })),
+    relevanteImprensa: filters.relevante_imprensa === true,
+  }
+}
+
+export function advancedFiltersToApiPatch(
+  form: OperationalViewAdvancedFilterForm,
+): Pick<
+  OperationalViewFilterIn,
+  | 'requisitante'
+  | 'prioridade'
+  | 'status'
+  | 'tipo_chamado_id'
+  | 'relevante_imprensa'
+> {
+  return {
+    requisitante: form.requisitante.length
+      ? form.requisitante.map((item) => item.value)
+      : undefined,
+    prioridade: form.prioridade.length
+      ? (form.prioridade.map((item) => item.value) as OperationalViewPriority[])
+      : undefined,
+    status: form.status.length
+      ? (form.status.map((item) => item.value) as OperationalViewStatus[])
+      : undefined,
+    tipo_chamado_id: form.tipo_chamado_id.length
+      ? form.tipo_chamado_id.map((item) => item.value)
+      : undefined,
+    relevante_imprensa: form.relevanteImprensa ? true : null,
+  }
+}
+
+export function stripAdvancedFiltersFromApi(
+  filters: OperationalViewFilterIn,
+): OperationalViewFilterIn {
+  const rest = { ...filters }
+  delete rest.requisitante
+  delete rest.prioridade
+  delete rest.status
+  delete rest.tipo_chamado_id
+  delete rest.relevante_imprensa
+  return rest
+}
+
+export function formatOperationalViewAdvancedFiltersSummary(
+  filters: OperationalViewFilterIn,
+): string[] {
+  const lines: string[] = []
+  if (filters.requisitante?.length) {
+    lines.push(`Requisitante: ${filters.requisitante.join(', ')}`)
+  }
+  if (filters.prioridade?.length) {
+    const labels = filters.prioridade.map(
+      (p) => priorityLabelByValue.get(p) ?? p,
+    )
+    lines.push(`Urgência: ${labels.join(', ')}`)
+  }
+  if (filters.status?.length) {
+    const labels = filters.status.map((s) => statusLabelByValue.get(s) ?? s)
+    lines.push(`Status: ${labels.join(', ')}`)
+  }
+  if (filters.tipo_chamado_id?.length) {
+    lines.push(
+      `Tipo de chamado: ${filters.tipo_chamado_id.length} selecionado(s)`,
+    )
+  }
+  if (filters.relevante_imprensa === true) {
+    lines.push('Relevante para imprensa: Sim')
+  }
+  return lines
+}

--- a/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-filters.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-filters.tsx
@@ -1,0 +1,220 @@
+'use client'
+
+import { format } from 'date-fns'
+import { CalendarIcon, Filter } from 'lucide-react'
+import { useMemo, useState } from 'react'
+
+import { Calendar } from '@/components/ui/calendar'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import type { OperationalViewFilterIn } from '@/http/tickets/get-operational-view'
+import { dateConfig } from '@/lib/date-config'
+
+import {
+  parseDemandVolumeDate,
+  toDemandVolumeDateString,
+} from '../../volume/components/demand-volume-date-range'
+import styles from '../../volume/components/demand-volume-top.module.css'
+import { OperationalViewExportDialog } from './operational-view-export-dialog'
+import { OperationalViewFilterModal } from './operational-view-filter-modal'
+import {
+  advancedFiltersFromApi,
+  countOperationalViewAdvancedFiltersFromApi,
+  type OperationalViewAdvancedFilterForm,
+} from './operational-view-filter-utils'
+
+interface OperationalViewFiltersProps {
+  dateFrom: string
+  dateTo: string
+  onDateFromChange: (dateFrom: string) => void
+  onDateToChange: (dateTo: string) => void
+  isLoading: boolean
+  appliedFilters: OperationalViewFilterIn
+  onApplyAdvancedFilters: (filters: OperationalViewAdvancedFilterForm) => void
+}
+
+function formatTrigger(d: Date | undefined): string | null {
+  if (!d) return null
+  return format(d, dateConfig.formats.date, { locale: dateConfig.locale })
+}
+
+function DateField({
+  value,
+  placeholder,
+  ariaLabel,
+  onChange,
+  disabled,
+  minDate,
+  maxDate,
+}: {
+  value: string
+  placeholder: string
+  ariaLabel: string
+  onChange: (value: string) => void
+  disabled?: boolean
+  minDate?: Date
+  maxDate?: Date
+}) {
+  const [open, setOpen] = useState(false)
+  const date = useMemo(() => parseDemandVolumeDate(value), [value])
+
+  return (
+    <div className={styles.dateFieldWrap}>
+      <Popover
+        open={disabled ? false : open}
+        onOpenChange={(o) => {
+          if (!disabled) setOpen(o)
+        }}
+      >
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className={styles.dateTrigger}
+            disabled={disabled}
+            aria-label={ariaLabel}
+          >
+            {formatTrigger(date) ? (
+              <span className={styles.dateTriggerValue}>
+                {formatTrigger(date)}
+              </span>
+            ) : (
+              <span className={styles.dateTriggerPlaceholder}>
+                {placeholder}
+              </span>
+            )}
+            <CalendarIcon className="h-5 w-5 shrink-0 opacity-50" />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent
+          className="z-[100] w-auto p-0"
+          align="start"
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          onCloseAutoFocus={(e) => e.preventDefault()}
+        >
+          <Calendar
+            mode="single"
+            selected={date}
+            onSelect={(d) => {
+              if (!d) return
+              onChange(toDemandVolumeDateString(d))
+              setOpen(false)
+            }}
+            disabled={(d) => {
+              if (minDate && d < minDate) return true
+              if (maxDate && d > maxDate) return true
+              return false
+            }}
+            locale={dateConfig.locale}
+            defaultMonth={date ?? minDate ?? maxDate ?? new Date()}
+            initialFocus
+            className="rounded-lg border"
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}
+
+export function OperationalViewFilters({
+  dateFrom,
+  dateTo,
+  onDateFromChange,
+  onDateToChange,
+  isLoading,
+  appliedFilters,
+  onApplyAdvancedFilters,
+}: OperationalViewFiltersProps) {
+  const [isFilterModalOpen, setIsFilterModalOpen] = useState(false)
+  const startDate = useMemo(() => parseDemandVolumeDate(dateFrom), [dateFrom])
+  const endDate = useMemo(() => parseDemandVolumeDate(dateTo), [dateTo])
+  const activeAdvancedCount = useMemo(
+    () => countOperationalViewAdvancedFiltersFromApi(appliedFilters),
+    [appliedFilters],
+  )
+  const advancedFiltersForm = useMemo(
+    () => advancedFiltersFromApi(appliedFilters),
+    [appliedFilters],
+  )
+
+  return (
+    <div className={styles.periodBar}>
+      <div className={styles.periodBarLabelBlock}>
+        <p className={styles.periodBarLabel}>Período da Busca</p>
+        <div className={styles.dateFieldsRow}>
+          <DateField
+            value={dateFrom}
+            placeholder="dd/mm/aaaa"
+            ariaLabel="Data inicial do período"
+            onChange={onDateFromChange}
+            disabled={isLoading}
+            maxDate={endDate}
+          />
+          <DateField
+            value={dateTo}
+            placeholder="dd/mm/aaaa"
+            ariaLabel="Data final do período"
+            onChange={onDateToChange}
+            disabled={isLoading}
+            minDate={startDate}
+          />
+        </div>
+      </div>
+
+      <PeriodBarActions
+        isLoading={isLoading}
+        activeAdvancedCount={activeAdvancedCount}
+        appliedFilters={appliedFilters}
+        onOpenFilter={() => setIsFilterModalOpen(true)}
+      />
+
+      <OperationalViewFilterModal
+        isOpen={isFilterModalOpen}
+        onClose={() => setIsFilterModalOpen(false)}
+        filters={advancedFiltersForm}
+        onApply={onApplyAdvancedFilters}
+      />
+    </div>
+  )
+}
+
+function PeriodBarActions({
+  isLoading,
+  activeAdvancedCount,
+  appliedFilters,
+  onOpenFilter,
+}: {
+  isLoading: boolean
+  activeAdvancedCount: number
+  appliedFilters: OperationalViewFilterIn
+  onOpenFilter: () => void
+}) {
+  return (
+    <div className={styles.periodBarActions}>
+      <div className={styles.filterButtonWrap}>
+        <button
+          type="button"
+          className={styles.iconButton}
+          aria-label="Filtrar dados"
+          title="Filtrar"
+          disabled={isLoading}
+          onClick={onOpenFilter}
+        >
+          <Filter className="h-5 w-5" />
+        </button>
+        {activeAdvancedCount > 0 ? (
+          <span className={styles.filterBadge} aria-hidden>
+            {activeAdvancedCount}
+          </span>
+        ) : null}
+      </div>
+
+      <OperationalViewExportDialog
+        appliedFilters={appliedFilters}
+        disabled={isLoading}
+      />
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-open-tickets-chart.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-open-tickets-chart.tsx
@@ -1,0 +1,217 @@
+'use client'
+
+import type { CSSProperties } from 'react'
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+
+import type { OperationalViewGranularity } from '@/http/tickets/get-operational-view'
+
+import { DemandVolumeChartGranularity } from '../../volume/components/demand-volume-chart-granularity'
+import styles from '../../volume/components/demand-volume-top.module.css'
+import {
+  openTicketsBarDataKey,
+  type OpenTicketsPeriodBarPoint,
+} from './operational-view-chart-utils'
+
+interface OperationalViewOpenTicketsChartProps {
+  chartData: OpenTicketsPeriodBarPoint[]
+  teams: string[]
+  granularity: OperationalViewGranularity
+  onGranularityChange: (granularity: OperationalViewGranularity) => void
+  isLoading: boolean
+}
+
+const STATUS_SERIES = [
+  { key: 'pendente', label: 'Pendente' },
+  { key: 'bloqueado', label: 'Bloqueado' },
+  { key: 'aguardando_revisao', label: 'Aguardando revisão' },
+] as const
+
+const STATUS_COLORS: Record<(typeof STATUS_SERIES)[number]['key'], string> = {
+  pendente: '#06b2bb',
+  bloqueado: '#b93d52',
+  aguardando_revisao: '#5b4db2',
+}
+
+const CHART_SHELL: CSSProperties = {
+  backgroundColor: '#101d28',
+  border: '1px solid #4a5d6d',
+  borderRadius: '8px',
+  padding: '24px',
+}
+
+const CHART_COLORS = {
+  grid: '#1d3449',
+  axis: '#97a2ab',
+  tooltip: { bg: '#101d28', border: '#4a5d6d', text: '#f9fafa' },
+}
+
+export function OperationalViewOpenTicketsChart({
+  chartData,
+  teams,
+  granularity,
+  onGranularityChange,
+  isLoading,
+}: OperationalViewOpenTicketsChartProps) {
+  return (
+    <div style={CHART_SHELL}>
+      <ChartHeaderBlock
+        granularity={granularity}
+        onGranularityChange={onGranularityChange}
+        isLoading={isLoading}
+      />
+
+      {isLoading && chartData.length === 0 ? (
+        <ChartMessage message="Carregando…" />
+      ) : chartData.length === 0 ? (
+        <ChartMessage message="Nenhum dado disponível" />
+      ) : (
+        <ResponsiveContainer width="100%" height={280}>
+          <BarChart
+            key={granularity}
+            data={chartData}
+            margin={{ top: 8, right: 16, left: 0, bottom: 8 }}
+          >
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke={CHART_COLORS.grid}
+              vertical={false}
+            />
+            <XAxis
+              dataKey="label"
+              tick={{ fill: CHART_COLORS.axis, fontSize: 12 }}
+              axisLine={false}
+              tickLine={false}
+              tickMargin={8}
+            />
+            <YAxis
+              tick={{ fill: CHART_COLORS.axis, fontSize: 12 }}
+              axisLine={false}
+              tickLine={false}
+              width={40}
+              allowDecimals={false}
+            />
+            <Tooltip
+              formatter={(value, _name, item) => {
+                const dataKey = String(item.dataKey ?? '')
+                const team = teams.find((name) =>
+                  dataKey.startsWith(`${name}__`),
+                )
+                const status = STATUS_SERIES.find((s) =>
+                  dataKey.endsWith(`__${s.key}`),
+                )
+                const numeric =
+                  typeof value === 'number' ? value : Number(value ?? 0)
+                return [
+                  numeric.toLocaleString('pt-BR'),
+                  team && status ? `${team} — ${status.label}` : status?.label,
+                ]
+              }}
+              labelFormatter={(label) => String(label)}
+              contentStyle={{
+                backgroundColor: CHART_COLORS.tooltip.bg,
+                border: `1px solid ${CHART_COLORS.tooltip.border}`,
+                borderRadius: '8px',
+                color: CHART_COLORS.tooltip.text,
+                fontSize: '12px',
+              }}
+              itemStyle={{ color: CHART_COLORS.tooltip.text }}
+              labelStyle={{
+                color: CHART_COLORS.tooltip.text,
+                fontWeight: 600,
+                marginBottom: '4px',
+              }}
+            />
+            <Legend
+              verticalAlign="bottom"
+              align="center"
+              iconType="square"
+              wrapperStyle={{
+                paddingTop: '24px',
+                fontSize: '12px',
+                color: '#97a2ab',
+              }}
+              payload={STATUS_SERIES.map((status) => ({
+                value: status.label,
+                type: 'square' as const,
+                color: STATUS_COLORS[status.key],
+                id: status.key,
+              }))}
+              formatter={(value) => (
+                <span style={{ color: '#97a2ab' }}>{value}</span>
+              )}
+            />
+            {teams.flatMap((team) =>
+              STATUS_SERIES.map((status) => (
+                <Bar
+                  key={`${team}-${status.key}`}
+                  dataKey={openTicketsBarDataKey(team, status.key)}
+                  name={status.label}
+                  stackId={team}
+                  fill={STATUS_COLORS[status.key]}
+                  legendType="none"
+                  radius={[0, 0, 0, 0]}
+                />
+              )),
+            )}
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  )
+}
+
+function ChartHeaderBlock({
+  granularity,
+  onGranularityChange,
+  isLoading,
+}: {
+  granularity: OperationalViewGranularity
+  onGranularityChange: (granularity: OperationalViewGranularity) => void
+  isLoading: boolean
+}) {
+  return (
+    <div className={styles.chartHeaderRow}>
+      <h2
+        style={{
+          fontSize: '20px',
+          fontWeight: 600,
+          color: '#f9fafa',
+          margin: 0,
+        }}
+      >
+        Chamados em aberto com cada equipe
+      </h2>
+      <DemandVolumeChartGranularity
+        value={granularity}
+        onChange={onGranularityChange}
+        disabled={isLoading}
+      />
+    </div>
+  )
+}
+
+function ChartMessage({ message }: { message: string }) {
+  return (
+    <div
+      style={{
+        height: '280px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: '#97a2ab',
+        fontSize: '14px',
+      }}
+    >
+      {message}
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-period-presets.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-period-presets.ts
@@ -1,0 +1,26 @@
+import type { OperationalViewFilterIn } from '@/http/tickets/get-operational-view'
+
+function toDateString(d: Date): string {
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+export function getDefaultOperationalViewDateRange(): Pick<
+  OperationalViewFilterIn,
+  'date_from' | 'date_to'
+> {
+  const now = new Date()
+  return {
+    date_from: `${now.getFullYear()}-01-01`,
+    date_to: toDateString(now),
+  }
+}
+
+export function createDefaultOperationalViewFilters(): OperationalViewFilterIn {
+  return {
+    summary_period: 'current_year',
+    ...getDefaultOperationalViewDateRange(),
+  }
+}

--- a/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-sla-table.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-sla-table.tsx
@@ -1,0 +1,265 @@
+'use client'
+
+import type { CSSProperties } from 'react'
+
+import type { SlaPerformanceByTeamRowOut } from '@/http/tickets/get-operational-view'
+
+import { formatPeriodLabel } from '../../volume/components/demand-volume-period-label'
+
+interface OperationalViewSlaTableProps {
+  rows: SlaPerformanceByTeamRowOut[]
+  periodLabels: string[]
+  isLoading: boolean
+}
+
+type CellVariant = 'above' | 'below' | 'neutral'
+
+function getCellVariant(
+  slaPercent: number | null,
+  isAboveAverage: boolean,
+): CellVariant {
+  if (slaPercent == null || slaPercent === 0) return 'neutral'
+  if (isAboveAverage) return 'above'
+  return 'below'
+}
+
+const CELL_STYLES: Record<CellVariant, CSSProperties> = {
+  above: {
+    backgroundColor: 'rgba(185, 61, 82, 0.25)',
+    color: '#f9a7b3',
+    fontWeight: 600,
+  },
+  below: {
+    backgroundColor: 'rgba(6, 178, 187, 0.15)',
+    color: '#06b2bb',
+    fontWeight: 600,
+  },
+  neutral: {
+    backgroundColor: 'transparent',
+    color: '#f9fafa',
+    fontWeight: 400,
+  },
+}
+
+const HEADER_CELL: CSSProperties = {
+  padding: '10px 12px',
+  fontSize: '11px',
+  fontWeight: 600,
+  color: '#97a2ab',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+  whiteSpace: 'nowrap',
+  borderBottom: '1px solid #1d3449',
+  textAlign: 'center',
+}
+
+const ROW_LABEL_CELL: CSSProperties = {
+  padding: '10px 12px',
+  fontSize: '13px',
+  color: '#f9fafa',
+  whiteSpace: 'nowrap',
+  borderBottom: '1px solid #1d3449',
+  textAlign: 'left',
+  position: 'sticky',
+  left: 0,
+  backgroundColor: '#101d28',
+  zIndex: 1,
+}
+
+const DATA_CELL_BASE: CSSProperties = {
+  padding: '8px 12px',
+  fontSize: '13px',
+  textAlign: 'center',
+  borderBottom: '1px solid #1d3449',
+  borderRadius: '4px',
+  minWidth: '52px',
+}
+
+function formatSlaPercent(value: number): string {
+  return `${Math.round(value)}%`
+}
+
+export function OperationalViewSlaTable({
+  rows,
+  periodLabels,
+  isLoading,
+}: OperationalViewSlaTableProps) {
+  const formattedHeaders = periodLabels.map((pl) =>
+    formatPeriodLabel(pl, 'monthly'),
+  )
+
+  return (
+    <div
+      style={{
+        backgroundColor: '#101d28',
+        border: '1px solid #4a5d6d',
+        borderRadius: '8px',
+        padding: '24px',
+      }}
+    >
+      <h2
+        style={{
+          fontSize: '20px',
+          fontWeight: 600,
+          color: '#f9fafa',
+          margin: '0 0 20px 0',
+        }}
+      >
+        Desempenho de SLA por Equipe
+      </h2>
+
+      {isLoading && rows.length === 0 ? (
+        <LoadingState />
+      ) : rows.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <>
+          <div style={{ overflowX: 'auto' }}>
+            <table
+              style={{
+                width: '100%',
+                borderCollapse: 'separate',
+                borderSpacing: 0,
+              }}
+            >
+              <thead>
+                <tr>
+                  <th
+                    style={{
+                      ...HEADER_CELL,
+                      textAlign: 'left',
+                      position: 'sticky',
+                      left: 0,
+                      backgroundColor: '#101d28',
+                      zIndex: 2,
+                      minWidth: '160px',
+                    }}
+                  >
+                    EQUIPE
+                  </th>
+                  {formattedHeaders.map((h, i) => (
+                    <th key={i} style={HEADER_CELL}>
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.label}>
+                    <td style={ROW_LABEL_CELL}>{row.label}</td>
+                    {row.periods.map((period) => {
+                      const variant = getCellVariant(
+                        period.sla_percent,
+                        period.is_above_average,
+                      )
+                      return (
+                        <td
+                          key={period.period_label}
+                          style={{
+                            ...DATA_CELL_BASE,
+                            ...CELL_STYLES[variant],
+                          }}
+                        >
+                          {period.sla_percent == null ||
+                          period.sla_percent === 0 ? (
+                            <span style={{ opacity: 0.3 }}>—</span>
+                          ) : (
+                            formatSlaPercent(period.sla_percent)
+                          )}
+                        </td>
+                      )
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: '24px',
+              marginTop: '16px',
+              paddingTop: '12px',
+              borderTop: '1px solid #1d3449',
+            }}
+          >
+            <LegendItem
+              color="#f9a7b3"
+              bg="rgba(185, 61, 82, 0.25)"
+              label="Acima da média"
+            />
+            <LegendItem
+              color="#06b2bb"
+              bg="rgba(6, 178, 187, 0.15)"
+              label="Abaixo da média"
+            />
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+function LoadingState() {
+  return (
+    <div
+      style={{
+        height: '120px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: '#97a2ab',
+        fontSize: '14px',
+      }}
+    >
+      Carregando…
+    </div>
+  )
+}
+
+function EmptyState() {
+  return (
+    <div
+      style={{
+        height: '80px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: '#97a2ab',
+        fontSize: '14px',
+      }}
+    >
+      Nenhum dado disponível
+    </div>
+  )
+}
+
+function LegendItem({
+  color,
+  bg,
+  label,
+}: {
+  color: string
+  bg: string
+  label: string
+}) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+      <span
+        style={{
+          display: 'inline-block',
+          width: '32px',
+          height: '16px',
+          backgroundColor: bg,
+          borderRadius: '4px',
+          border: `1px solid ${color}`,
+        }}
+      />
+      <span style={{ fontSize: '12px', color: '#97a2ab' }}>{label}</span>
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-summary-cards.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-summary-cards.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import type { OperationalViewSummaryOut } from '@/http/tickets/get-operational-view'
+
+import styles from '../../volume/components/demand-volume-top.module.css'
+
+interface OperationalViewSummaryCardsProps {
+  summary: OperationalViewSummaryOut | undefined
+  isLoading: boolean
+}
+
+function SummaryCard({
+  label,
+  value,
+  isLoading,
+}: {
+  label: string
+  value: number | undefined
+  isLoading: boolean
+}) {
+  return (
+    <div className={styles.summaryCard}>
+      <p className={styles.summaryCardLabel}>{label}</p>
+      <p className={styles.summaryCardValue}>
+        {isLoading ? (
+          <span style={{ opacity: 0.4 }}>—</span>
+        ) : (
+          (value?.toLocaleString('pt-BR') ?? '—')
+        )}
+      </p>
+    </div>
+  )
+}
+
+export function OperationalViewSummaryCards({
+  summary,
+  isLoading,
+}: OperationalViewSummaryCardsProps) {
+  return (
+    <section
+      className={styles.summarySection}
+      aria-label="Resumo operacional de chamados"
+    >
+      <div className={styles.summaryCardsRow}>
+        <SummaryCard
+          label="Pendentes"
+          value={summary?.total_pendentes}
+          isLoading={isLoading}
+        />
+        <SummaryCard
+          label="Bloqueados"
+          value={summary?.total_bloqueados}
+          isLoading={isLoading}
+        />
+        <SummaryCard
+          label="Aguardando Revisão"
+          value={summary?.total_aguardando_revisao}
+          isLoading={isLoading}
+        />
+        <SummaryCard
+          label="Finalizados"
+          value={summary?.total_finalizados}
+          isLoading={isLoading}
+        />
+      </div>
+    </section>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-team-colors.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-team-colors.ts
@@ -1,0 +1,28 @@
+const TEAM_PALETTE = [
+  '#b93d52',
+  '#5b4db2',
+  '#3d8cb9',
+  '#06b2bb',
+  '#c97b3d',
+  '#7b3db9',
+  '#3db97b',
+  '#b9a03d',
+] as const
+
+export function getTeamColor(team: string, teams: string[]): string {
+  const index = teams.indexOf(team)
+  if (index >= 0) {
+    return TEAM_PALETTE[index % TEAM_PALETTE.length]
+  }
+  let hash = 0
+  for (let i = 0; i < team.length; i += 1) {
+    hash = (hash + team.charCodeAt(i) * (i + 1)) % TEAM_PALETTE.length
+  }
+  return TEAM_PALETTE[hash]
+}
+
+export function collectTeamsFromSeries(series: { team: string }[]): string[] {
+  return [...new Set(series.map((item) => item.team))].sort((a, b) =>
+    a.localeCompare(b, 'pt-BR'),
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-team-line-chart.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-team-line-chart.tsx
@@ -1,0 +1,206 @@
+'use client'
+
+import type { CSSProperties } from 'react'
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+
+import type { OperationalViewGranularity } from '@/http/tickets/get-operational-view'
+
+import { DemandVolumeChartGranularity } from '../../volume/components/demand-volume-chart-granularity'
+import styles from '../../volume/components/demand-volume-top.module.css'
+import type { TeamLineChartPoint } from './operational-view-chart-utils'
+import { getTeamColor } from './operational-view-team-colors'
+
+interface OperationalViewTeamLineChartProps {
+  title: string
+  chartData: TeamLineChartPoint[]
+  teams: string[]
+  granularity: OperationalViewGranularity
+  onGranularityChange: (granularity: OperationalViewGranularity) => void
+  isLoading: boolean
+  valueFormatter?: (value: number) => string
+}
+
+const CHART_SHELL: CSSProperties = {
+  backgroundColor: '#101d28',
+  border: '1px solid #4a5d6d',
+  borderRadius: '8px',
+  padding: '24px',
+}
+
+const CHART_COLORS = {
+  grid: '#1d3449',
+  axis: '#97a2ab',
+  tooltip: { bg: '#101d28', border: '#4a5d6d', text: '#f9fafa' },
+}
+
+export function OperationalViewTeamLineChart({
+  title,
+  chartData,
+  teams,
+  granularity,
+  onGranularityChange,
+  isLoading,
+  valueFormatter = (value) =>
+    value.toLocaleString('pt-BR', { maximumFractionDigits: 0 }),
+}: OperationalViewTeamLineChartProps) {
+  return (
+    <div style={CHART_SHELL}>
+      <ChartHeader
+        title={title}
+        granularity={granularity}
+        onGranularityChange={onGranularityChange}
+        isLoading={isLoading}
+      />
+
+      {isLoading && chartData.length === 0 ? (
+        <LoadingState />
+      ) : chartData.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <ResponsiveContainer width="100%" height={280}>
+          <LineChart
+            data={chartData}
+            margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+          >
+            <CartesianGrid
+              strokeDasharray="3 3"
+              stroke={CHART_COLORS.grid}
+              vertical={false}
+            />
+            <XAxis
+              dataKey="label"
+              tick={{ fill: CHART_COLORS.axis, fontSize: 12 }}
+              axisLine={false}
+              tickLine={false}
+              tickMargin={8}
+            />
+            <YAxis
+              tick={{ fill: CHART_COLORS.axis, fontSize: 12 }}
+              axisLine={false}
+              tickLine={false}
+              width={40}
+            />
+            <Tooltip
+              formatter={(value) =>
+                value == null || value === ''
+                  ? '—'
+                  : valueFormatter(Number(value))
+              }
+              contentStyle={{
+                backgroundColor: CHART_COLORS.tooltip.bg,
+                border: `1px solid ${CHART_COLORS.tooltip.border}`,
+                borderRadius: '8px',
+                color: CHART_COLORS.tooltip.text,
+                fontSize: '12px',
+              }}
+              itemStyle={{ color: CHART_COLORS.tooltip.text }}
+              labelStyle={{
+                color: CHART_COLORS.tooltip.text,
+                fontWeight: 600,
+                marginBottom: '4px',
+              }}
+            />
+            <Legend
+              wrapperStyle={{
+                paddingTop: '24px',
+                fontSize: '12px',
+                color: '#97a2ab',
+              }}
+              formatter={(value) => (
+                <span style={{ color: '#97a2ab' }}>{value}</span>
+              )}
+            />
+            {teams.map((team) => (
+              <Line
+                key={team}
+                type="monotone"
+                dataKey={team}
+                name={team}
+                stroke={getTeamColor(team, teams)}
+                strokeWidth={2}
+                dot={false}
+                connectNulls
+                activeDot={{ r: 4, strokeWidth: 0 }}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      )}
+    </div>
+  )
+}
+
+function ChartHeader({
+  title,
+  granularity,
+  onGranularityChange,
+  isLoading,
+}: {
+  title: string
+  granularity: OperationalViewGranularity
+  onGranularityChange: (granularity: OperationalViewGranularity) => void
+  isLoading: boolean
+}) {
+  return (
+    <div className={styles.chartHeaderRow}>
+      <h2
+        style={{
+          fontSize: '20px',
+          fontWeight: 600,
+          color: '#f9fafa',
+          margin: 0,
+        }}
+      >
+        {title}
+      </h2>
+      <DemandVolumeChartGranularity
+        value={granularity}
+        onChange={onGranularityChange}
+        disabled={isLoading}
+      />
+    </div>
+  )
+}
+
+function LoadingState() {
+  return (
+    <div
+      style={{
+        height: '280px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: '#97a2ab',
+        fontSize: '14px',
+      }}
+    >
+      Carregando…
+    </div>
+  )
+}
+
+function EmptyState() {
+  return (
+    <div
+      style={{
+        height: '280px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: '#97a2ab',
+        fontSize: '14px',
+      }}
+    >
+      Nenhum dado disponível
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-view.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-view.tsx
@@ -1,0 +1,232 @@
+'use client'
+
+import { useQuery } from '@tanstack/react-query'
+import { useEffect, useMemo, useState } from 'react'
+
+import {
+  getOperationalView,
+  type OperationalViewFilterIn,
+  type OperationalViewGranularity,
+  pickOperationalViewGranularitySeries,
+} from '@/http/tickets/get-operational-view'
+
+import { normalizeDemandVolumeDateRange } from '../../volume/components/demand-volume-date-range'
+import {
+  pivotOpenTicketsForBarChart,
+  pivotTeamPeriodSeries,
+} from './operational-view-chart-utils'
+import {
+  advancedFiltersToApiPatch,
+  type OperationalViewAdvancedFilterForm,
+  stripAdvancedFiltersFromApi,
+} from './operational-view-filter-utils'
+import { OperationalViewFilters } from './operational-view-filters'
+import { OperationalViewOpenTicketsChart } from './operational-view-open-tickets-chart'
+import {
+  createDefaultOperationalViewFilters,
+  getDefaultOperationalViewDateRange,
+} from './operational-view-period-presets'
+import { OperationalViewSlaTable } from './operational-view-sla-table'
+import { OperationalViewSummaryCards } from './operational-view-summary-cards'
+import { OperationalViewTeamLineChart } from './operational-view-team-line-chart'
+
+export function OperationalViewView() {
+  const [draftFilters, setDraftFilters] = useState<OperationalViewFilterIn>(
+    createDefaultOperationalViewFilters,
+  )
+  const [appliedFilters, setAppliedFilters] = useState<OperationalViewFilterIn>(
+    createDefaultOperationalViewFilters,
+  )
+  const [openTicketsGranularity, setOpenTicketsGranularity] =
+    useState<OperationalViewGranularity>('monthly')
+  const [closedVolumeGranularity, setClosedVolumeGranularity] =
+    useState<OperationalViewGranularity>('monthly')
+  const [resolutionTimeGranularity, setResolutionTimeGranularity] =
+    useState<OperationalViewGranularity>('monthly')
+
+  useEffect(() => {
+    const fillDates = (
+      prev: OperationalViewFilterIn,
+    ): OperationalViewFilterIn => {
+      if (prev.date_from && prev.date_to) return prev
+      return { ...prev, ...getDefaultOperationalViewDateRange() }
+    }
+    setDraftFilters(fillDates)
+    setAppliedFilters(fillDates)
+  }, [])
+
+  const { data, isFetching, isError } = useQuery({
+    queryKey: ['operational-view', appliedFilters],
+    queryFn: () => getOperationalView(appliedFilters),
+    staleTime: 60_000,
+  })
+
+  const openTicketsChart = useMemo(
+    () =>
+      pivotOpenTicketsForBarChart(
+        data?.open_tickets_by_team,
+        openTicketsGranularity,
+        appliedFilters.date_from,
+        appliedFilters.date_to,
+      ),
+    [
+      data?.open_tickets_by_team,
+      openTicketsGranularity,
+      appliedFilters.date_from,
+      appliedFilters.date_to,
+    ],
+  )
+
+  const closedVolumeSeries = useMemo(
+    () =>
+      pickOperationalViewGranularitySeries(
+        data?.closed_volume_by_team,
+        closedVolumeGranularity,
+      ),
+    [data?.closed_volume_by_team, closedVolumeGranularity],
+  )
+
+  const resolutionTimeSeries = useMemo(
+    () =>
+      pickOperationalViewGranularitySeries(
+        data?.avg_resolution_time_by_team,
+        resolutionTimeGranularity,
+      ),
+    [data?.avg_resolution_time_by_team, resolutionTimeGranularity],
+  )
+
+  const closedVolumeChart = useMemo(
+    () => pivotTeamPeriodSeries(closedVolumeSeries, closedVolumeGranularity),
+    [closedVolumeSeries, closedVolumeGranularity],
+  )
+
+  const resolutionTimeChart = useMemo(
+    () =>
+      pivotTeamPeriodSeries(resolutionTimeSeries, resolutionTimeGranularity),
+    [resolutionTimeSeries, resolutionTimeGranularity],
+  )
+
+  const slaTablePeriodLabels = useMemo(
+    () =>
+      data?.sla_performance_by_team[0]?.periods.map((p) => p.period_label) ??
+      [],
+    [data?.sla_performance_by_team],
+  )
+
+  function applyFilters(next: OperationalViewFilterIn) {
+    setDraftFilters(next)
+    setAppliedFilters(next)
+  }
+
+  function handlePeriodDatesChange(
+    patch: Partial<{ dateFrom: string; dateTo: string }>,
+    changed: 'from' | 'to',
+  ) {
+    const fallback = getDefaultOperationalViewDateRange()
+    let dateFrom =
+      patch.dateFrom ?? draftFilters.date_from ?? fallback.date_from ?? ''
+    let dateTo = patch.dateTo ?? draftFilters.date_to ?? fallback.date_to ?? ''
+
+    if (dateFrom && dateTo) {
+      ;({ dateFrom, dateTo } = normalizeDemandVolumeDateRange(
+        dateFrom,
+        dateTo,
+        changed,
+      ))
+    }
+
+    applyFilters({
+      ...appliedFilters,
+      date_from: dateFrom || undefined,
+      date_to: dateTo || undefined,
+    })
+  }
+
+  function handleApplyAdvancedFilters(form: OperationalViewAdvancedFilterForm) {
+    applyFilters({
+      ...stripAdvancedFiltersFromApi(appliedFilters),
+      ...advancedFiltersToApiPatch(form),
+    })
+  }
+
+  return (
+    <div
+      style={{
+        paddingTop: '24px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '24px',
+      }}
+    >
+      <OperationalViewSummaryCards
+        summary={data?.summary}
+        isLoading={isFetching}
+      />
+
+      <OperationalViewFilters
+        dateFrom={draftFilters.date_from ?? ''}
+        dateTo={draftFilters.date_to ?? ''}
+        onDateFromChange={(dateFrom) =>
+          handlePeriodDatesChange({ dateFrom }, 'from')
+        }
+        onDateToChange={(dateTo) => handlePeriodDatesChange({ dateTo }, 'to')}
+        isLoading={isFetching}
+        appliedFilters={appliedFilters}
+        onApplyAdvancedFilters={handleApplyAdvancedFilters}
+      />
+
+      {isError && (
+        <div
+          style={{
+            backgroundColor: '#1d3449',
+            border: '1px solid #4a5d6d',
+            borderRadius: '8px',
+            padding: '16px 24px',
+            color: '#f9fafa',
+            fontSize: '14px',
+          }}
+        >
+          Erro ao carregar dados. Verifique sua conexão e tente novamente.
+        </div>
+      )}
+
+      <OperationalViewOpenTicketsChart
+        chartData={openTicketsChart.chartData}
+        teams={openTicketsChart.teams}
+        granularity={openTicketsGranularity}
+        onGranularityChange={setOpenTicketsGranularity}
+        isLoading={isFetching}
+      />
+
+      <OperationalViewTeamLineChart
+        title="Volume de Chamados Fechados por Equipe"
+        chartData={closedVolumeChart.chartData}
+        teams={closedVolumeChart.teams}
+        granularity={closedVolumeGranularity}
+        onGranularityChange={setClosedVolumeGranularity}
+        isLoading={isFetching}
+      />
+
+      <OperationalViewTeamLineChart
+        title="Tempo Médio de Resolução por Equipe"
+        chartData={resolutionTimeChart.chartData}
+        teams={resolutionTimeChart.teams}
+        granularity={resolutionTimeGranularity}
+        onGranularityChange={setResolutionTimeGranularity}
+        isLoading={isFetching}
+        valueFormatter={(value) =>
+          `${value.toLocaleString('pt-BR', {
+            minimumFractionDigits: 1,
+            maximumFractionDigits: 1,
+          })} dias`
+        }
+      />
+
+      <OperationalViewSlaTable
+        rows={data?.sla_performance_by_team ?? []}
+        periodLabels={slaTablePeriodLabels}
+        isLoading={isFetching}
+      />
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/visao-operacional/page.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/visao-operacional/page.tsx
@@ -1,0 +1,5 @@
+import { OperationalViewView } from './components/operational-view-view'
+
+export default function OperationalViewPage() {
+  return <OperationalViewView />
+}

--- a/src/app/(app)/demandas/list/tickets-general-list.module.css
+++ b/src/app/(app)/demandas/list/tickets-general-list.module.css
@@ -123,6 +123,64 @@
   color: #97a2ab;
 }
 
+.searchTooltip {
+  position: absolute;
+  top: calc(100% + 12px);
+  left: 0;
+  z-index: 50;
+
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease,
+    visibility 0.2s ease;
+
+  transform: translateY(6px);
+}
+
+.searchWrapper:hover .searchTooltip {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.searchTooltipContent {
+  position: relative;
+  min-width: 280px;
+  max-width: 420px;
+  padding: 14px 16px;
+  border-radius: 16px;
+  border: 1px solid rgba(91, 141, 197, 0.22);
+  background: #0e1a24;
+  box-shadow:
+    0 10px 30px rgba(0, 0, 0, 0.35),
+    inset 0 1px 0 rgba(255, 255, 255, 0.04);
+}
+
+.searchTooltipContent p {
+  margin: 0;
+  color: #97a2ab;
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.searchTooltipContent::before {
+  content: '';
+  position: absolute;
+  top: -7px;
+  left: 24px;
+  width: 14px;
+  height: 14px;
+  background: #0e1a24;
+  border-top: 1px solid rgba(91, 141, 197, 0.22);
+  border-left: 1px solid rgba(91, 141, 197, 0.22);
+  transform: rotate(45deg);
+}
+
 .toolbarActions {
   display: flex;
   gap: 16px;

--- a/src/app/(app)/demandas/list/tickets-general-list.tsx
+++ b/src/app/(app)/demandas/list/tickets-general-list.tsx
@@ -37,6 +37,9 @@ type DashboardServiceTag = {
 
 const LEVANTAMENTO_PREVIO_TIPO_NOME = 'Levantamento Prévio'
 
+const SEARCH_TOOLTIP_TEXT =
+  'Buscar por nº interno, requisitante, demandante, ofício, procedimento, ponto focal, equipe, responsável, comentários, relatório da demanda, placa, orientações ou observações'
+
 type DashboardItem = {
   id: string
   numero_interno: number
@@ -575,6 +578,11 @@ export function TicketsGeneralList() {
             placeholder="Buscar"
             className={styles.searchInput}
           />
+          <div className={styles.searchTooltip} role="tooltip">
+            <div className={styles.searchTooltipContent}>
+              <p>{SEARCH_TOOLTIP_TEXT}</p>
+            </div>
+          </div>
         </div>
 
         <div className={styles.toolbarActions}>

--- a/src/http/tickets/get-operational-view.ts
+++ b/src/http/tickets/get-operational-view.ts
@@ -1,0 +1,145 @@
+import { api } from '@/lib/api'
+
+import type {
+  DemandVolumeTicketItemOut,
+  DemandVolumeTicketsOut,
+} from './get-demand-volume'
+
+export type OperationalViewGranularity = 'monthly' | 'weekly' | 'yearly'
+
+export type OperationalViewSummaryPeriod =
+  | 'current_year'
+  | 'current_month'
+  | 'current_week'
+
+export type OperationalViewPriority = 'URGENTE' | 'ALTA' | 'ROTINA'
+
+export type OperationalViewStatus =
+  | 'PENDENTE'
+  | 'BLOQUEADO'
+  | 'AGUARDANDO_REVISAO_ADJUNTO'
+  | 'AGUARDANDO_REVISAO_ADMINISTRATIVO'
+  | 'FINALIZADO'
+  | 'DEMANDA_RESPONDIDA'
+  | 'RESTRITO'
+
+export interface OperationalViewFilterIn {
+  date_from?: string
+  date_to?: string
+  summary_period?: OperationalViewSummaryPeriod
+  requisitante?: string[]
+  prioridade?: OperationalViewPriority[]
+  status?: OperationalViewStatus[]
+  tipo_chamado_id?: string[]
+  relevante_imprensa?: boolean | null
+}
+
+export interface OperationalViewSummaryOut {
+  total_pendentes: number
+  total_bloqueados: number
+  total_aguardando_revisao: number
+  total_finalizados: number
+}
+
+export interface OpenTicketsByTeamItemOut {
+  team: string
+  pendente: number
+  bloqueado: number
+  aguardando_revisao: number
+}
+
+export interface OpenTicketsPeriodPointOut {
+  period_label: string
+  pendente: number
+  bloqueado: number
+  aguardando_revisao: number
+}
+
+export interface OpenTicketsTeamPeriodSeriesOut {
+  team: string
+  data: OpenTicketsPeriodPointOut[]
+}
+
+export interface TeamPeriodValueOut {
+  period_label: string
+  value: number
+}
+
+export interface TeamPeriodSeriesOut {
+  team: string
+  data: TeamPeriodValueOut[]
+}
+
+export interface OperationalViewGranularitySeries<T> {
+  monthly: T[]
+  weekly: T[]
+  yearly: T[]
+}
+
+export interface SlaPerformancePeriodOut {
+  period_label: string
+  sla_percent: number
+  is_above_average: boolean
+}
+
+export interface SlaPerformanceByTeamRowOut {
+  label: string
+  periods: SlaPerformancePeriodOut[]
+}
+
+export interface OperationalViewOut {
+  summary: OperationalViewSummaryOut
+  open_tickets_by_team: OperationalViewGranularitySeries<OpenTicketsTeamPeriodSeriesOut>
+  closed_volume_by_team: OperationalViewGranularitySeries<TeamPeriodSeriesOut>
+  avg_resolution_time_by_team: OperationalViewGranularitySeries<TeamPeriodSeriesOut>
+  sla_performance_by_team: SlaPerformanceByTeamRowOut[]
+}
+
+export function pickOperationalViewGranularitySeries<T>(
+  series: OperationalViewGranularitySeries<T> | undefined,
+  granularity: OperationalViewGranularity,
+): T[] {
+  if (!series) return []
+  return series[granularity] ?? []
+}
+
+export function sanitizeOperationalViewFilters(
+  filters: OperationalViewFilterIn,
+): OperationalViewFilterIn {
+  const payload: OperationalViewFilterIn = { ...filters }
+
+  if (!payload.requisitante?.length) delete payload.requisitante
+  if (!payload.prioridade?.length) delete payload.prioridade
+  if (!payload.status?.length) delete payload.status
+  if (!payload.tipo_chamado_id?.length) delete payload.tipo_chamado_id
+  if (payload.relevante_imprensa === undefined) {
+    delete payload.relevante_imprensa
+  }
+
+  return payload
+}
+
+export async function getOperationalView(
+  filters: OperationalViewFilterIn,
+): Promise<OperationalViewOut> {
+  const response = await api.post(
+    '/ticket-dashboard/operational-view',
+    sanitizeOperationalViewFilters(filters),
+  )
+  return response.data
+}
+
+/** Mesmos campos do export de volume de demandas (DemandVolumeTicketExportItemOut). */
+export type OperationalViewTicketItemOut = DemandVolumeTicketItemOut
+
+export type OperationalViewTicketsOut = DemandVolumeTicketsOut
+
+export async function getOperationalViewTickets(
+  filters: OperationalViewFilterIn,
+): Promise<OperationalViewTicketsOut> {
+  const response = await api.post<OperationalViewTicketsOut>(
+    '/ticket-dashboard/operational-view/tickets',
+    sanitizeOperationalViewFilters(filters),
+  )
+  return response.data
+}

--- a/src/http/tickets/get-sla-dashboard.ts
+++ b/src/http/tickets/get-sla-dashboard.ts
@@ -1,0 +1,132 @@
+import { api } from '@/lib/api'
+
+import type {
+  DemandVolumeTicketItemOut,
+  DemandVolumeTicketsOut,
+} from './get-demand-volume'
+
+export type SlaDashboardGranularity = 'monthly' | 'weekly' | 'yearly'
+
+export type TicketPriority = 'URGENTE' | 'ALTA' | 'ROTINA'
+
+export type SlaTicketStatus =
+  | 'PENDENTE'
+  | 'AGUARDANDO_REVISAO_ADJUNTO'
+  | 'AGUARDANDO_REVISAO_ADMINISTRATIVO'
+  | 'FINALIZADO'
+  | 'DEMANDA_RESPONDIDA'
+  | 'BLOQUEADO'
+  | 'RESTRITO'
+
+export interface SlaDashboardFilterIn {
+  date_from?: string
+  date_to?: string
+  /** Herdado do volume; ignorado no SLA. */
+  summary_period?: 'current_week' | 'current_month' | 'current_year'
+  requisitante?: string[]
+  prioridade?: TicketPriority[]
+  status?: SlaTicketStatus[]
+  tipo_chamado_id?: string[]
+  relevante_imprensa?: boolean | null
+}
+
+export interface SlaDashboardSummaryOut {
+  total_demands: number
+  avg_resolution_days: number
+  overall_sla_attained_percent: number
+  resolution_rate_percent: number
+}
+
+export interface AvgResolutionTimeGeneralItemOut {
+  period_label: string
+  from_registration_days: number | null
+  from_email_days: number | null
+}
+
+export interface AvgResolutionTimeByPriorityItemOut {
+  period_label: string
+  urgent_days: number | null
+  high_days: number | null
+  routine_days: number | null
+}
+
+export interface DeliveryTimeMediaItemOut {
+  period_label: string
+  avg_days: number | null
+}
+
+export interface SlaPerformancePeriodOut {
+  period_label: string
+  sla_percent: number
+  is_above_average: boolean
+}
+
+export interface SlaPerformanceRowOut {
+  label: string
+  periods: SlaPerformancePeriodOut[]
+}
+
+export interface SlaDashboardGranularitySeries<T> {
+  monthly: T[]
+  weekly: T[]
+  yearly: T[]
+}
+
+export interface SlaDashboardOut {
+  summary: SlaDashboardSummaryOut
+  avg_resolution_time_general: SlaDashboardGranularitySeries<AvgResolutionTimeGeneralItemOut>
+  avg_resolution_time_by_priority: SlaDashboardGranularitySeries<AvgResolutionTimeByPriorityItemOut>
+  sla_performance_by_priority: SlaPerformanceRowOut[]
+  sla_performance_by_service: SlaPerformanceRowOut[]
+  delivery_time_for_media_relevant: SlaDashboardGranularitySeries<DeliveryTimeMediaItemOut>
+}
+
+export function pickSlaDashboardGranularitySeries<T>(
+  series: SlaDashboardGranularitySeries<T> | undefined,
+  granularity: SlaDashboardGranularity,
+): T[] {
+  if (!series) return []
+  return series[granularity] ?? []
+}
+
+export function sanitizeSlaDashboardFilters(
+  filters: SlaDashboardFilterIn,
+): SlaDashboardFilterIn {
+  const payload: SlaDashboardFilterIn = { ...filters }
+
+  delete payload.summary_period
+  if (!payload.requisitante?.length) delete payload.requisitante
+  if (!payload.prioridade?.length) delete payload.prioridade
+  if (!payload.status?.length) delete payload.status
+  if (!payload.tipo_chamado_id?.length) delete payload.tipo_chamado_id
+  if (payload.relevante_imprensa === undefined) {
+    delete payload.relevante_imprensa
+  }
+
+  return payload
+}
+
+export async function getSlaDashboard(
+  filters: SlaDashboardFilterIn,
+): Promise<SlaDashboardOut> {
+  const response = await api.post(
+    '/ticket-dashboard/sla',
+    sanitizeSlaDashboardFilters(filters),
+  )
+  return response.data
+}
+
+/** Mesmos campos do export de volume de demandas (DemandVolumeTicketExportItemOut). */
+export type SlaTicketExportItemOut = DemandVolumeTicketItemOut
+
+export type SlaTicketExportOut = DemandVolumeTicketsOut
+
+export async function getSlaDashboardTickets(
+  filters: SlaDashboardFilterIn,
+): Promise<SlaTicketExportOut> {
+  const response = await api.post<SlaTicketExportOut>(
+    '/ticket-dashboard/sla/tickets',
+    sanitizeSlaDashboardFilters(filters),
+  )
+  return response.data
+}

--- a/src/http/tickets/get-ticket-all-servico-anexos.ts
+++ b/src/http/tickets/get-ticket-all-servico-anexos.ts
@@ -1,0 +1,10 @@
+import { api } from '@/lib/api'
+
+import type { TicketAttachmentWithPlaybackOut } from './ticket-resposta'
+
+export async function getTicketAllServicoAnexos(ticketId: string) {
+  const { data } = await api.get<TicketAttachmentWithPlaybackOut[]>(
+    `/tickets/${encodeURIComponent(ticketId)}/servicos/anexos`,
+  )
+  return data ?? []
+}

--- a/src/http/tickets/get-ticket-archive.ts
+++ b/src/http/tickets/get-ticket-archive.ts
@@ -30,11 +30,13 @@ export type TicketArchiveFilters = {
 export type TicketArchiveListItem = {
   id: string
   chamado: string
+  data_conclusao?: string | null
   demandante: string
   equipe: string
   responsavel: string
   servicos: string[]
   status: string
+  sei_preenchido?: boolean
 }
 
 export type TicketArchivePageOut = {

--- a/src/http/tickets/get-ticket-by-id.ts
+++ b/src/http/tickets/get-ticket-by-id.ts
@@ -60,6 +60,12 @@ export type ServiceCercoEletronicoOut = {
   anexos?: TicketAttachmentOut[]
 }
 
+export type ServiceCameraOut = {
+  id: string
+  created_at: string
+  camera_code: string
+}
+
 export type ServiceBuscaPorImagemOut = {
   id: string
   created_at: string
@@ -69,6 +75,7 @@ export type ServiceBuscaPorImagemOut = {
   plate?: string | null
   address?: string | null
   description?: string | null
+  cameras?: ServiceCameraOut[]
   anexos?: TicketAttachmentOut[]
 }
 
@@ -113,6 +120,7 @@ export type ServiceReservaDeImagemOut = {
   period_start?: string | null
   period_end?: string | null
   orientation?: string | null
+  cameras?: ServiceCameraOut[]
   anexos?: TicketAttachmentOut[]
 }
 
@@ -123,6 +131,7 @@ export type ServiceAnaliseDeImagemOut = {
   period_start?: string | null
   period_end?: string | null
   orientation?: string | null
+  cameras?: ServiceCameraOut[]
   anexos?: TicketAttachmentOut[]
 }
 

--- a/src/http/tickets/ticket-attachments.ts
+++ b/src/http/tickets/ticket-attachments.ts
@@ -47,7 +47,7 @@ export type TicketAttachmentMultipartMetadata = {
 
 export type TicketAttachmentPlaybackUrlOut = {
   signed_url: string
-  expires_in_seconds: number
+  expires_at: string
 }
 
 export async function getTicketAttachments(ticketId: string) {

--- a/src/http/tickets/ticket-ficha.ts
+++ b/src/http/tickets/ticket-ficha.ts
@@ -13,6 +13,8 @@ export type TicketFichaOut = {
   possui_apelido_imprensa: boolean
   apelido_imprensa?: string | null
   link_materia?: string | null
+  numero_processo_sei?: string | null
+  link_processo_sei?: string | null
   chamados_relacionados: TicketRelacionadoOut[]
 }
 
@@ -24,6 +26,8 @@ export type TicketFichaUpdateIn = {
   possui_apelido_imprensa: boolean
   apelido_imprensa?: string | null
   link_materia?: string | null
+  numero_processo_sei?: string | null
+  link_processo_sei?: string | null
 }
 
 export async function getTicketFicha(ticketId: string) {

--- a/src/http/tickets/ticket-servicos-types.ts
+++ b/src/http/tickets/ticket-servicos-types.ts
@@ -33,6 +33,7 @@ export type TicketServicosReplaceIn = {
     plate?: string | null
     address?: string | null
     description?: string | null
+    cameras?: string[]
   }>
   placas_correlatas: Array<{
     id?: string
@@ -60,6 +61,7 @@ export type TicketServicosReplaceIn = {
     period_start?: string | null
     period_end?: string | null
     orientation?: string | null
+    cameras?: string[]
   }>
   analise_de_imagem: Array<{
     id?: string
@@ -67,6 +69,7 @@ export type TicketServicosReplaceIn = {
     period_start?: string | null
     period_end?: string | null
     orientation?: string | null
+    cameras?: string[]
   }>
   outros: Array<{
     id?: string


### PR DESCRIPTION
## Description

This branch consolidates the **Demandas** module (formerly under `/chamados`), focused on **shift closing**, tactical dashboards, and improvements to the ticket detail experience.

### Shift closing (primary feature)
- New **Fechamentos** section in the sidebar (`/demandas/fechamentos`).
- **Listing** of shift closings with filters (team, closed-by user, shift date), pagination, and link to detail.
- **Close shift** flow (`/demandas/fechamentos/fechar`): preview and persist via API (`POST /tickets/shift-closing`, `POST /tickets/shift-closings`, `GET /tickets/shift-closings/:id`).
- **Detail** view with ticket cards for the period, service tags, and period formatting.
- Access control via screen permission `shift_closing` and feature flag `config.enableChamados`.

### Chamados → Demandas migration
- Routes, layouts, and pages moved to `/demandas` (inbox, create, convert, responded, spam, teams, profiles, listing, etc.).
- `notFound()` when `enableChamados` is disabled.
- **Impersonation** bar and context limited to the `/demandas` path.

### Ticket detail
- Full view with tabs: ticket, documents, history, internal opinion, report, response, services, requester.
- GCS upload (video, ZIP, service attachments), upload progress, rename pending attachments, reassign with comment.
- **Archived** page with filters and listing.
- Integration with workflow, module permissions, and demand report.

### Tactical dashboard (`/demandas/dashboard-tatico`)
- **SLA metrics**: charts, SLA table, filters, export.
- **Operational view**: team charts, open tickets, SLA table, export.
- **Demand volume**: matrix, media/urgency/total charts, CSV export (`toCsvScalar`), “relevant to press” filter.

### Dashboard configuration (`/demandas/dashboard`)
- **SLA** and **widgets** configuration forms with HTTP integration and react-hook-form `watch` state.

### Other (included in branch history)
- Ticket module screen permissions (`permissoes-telas`, per-screen gates).
- **Workflow** page by role.
- Map/LPR updates (SENTRY, DC3, radar → equipment/LPR renaming).
- Docker/Cloud Build and dependency updates (`pnpm-lock`).

## Related Issue
<!--- Add issue link if applicable -->

## Motivation and Context

Operators need to **close shifts** by recording which tickets were handled in a time window, with searchable history and permissions aligned with the rest of the Demandas module. In parallel, the team unified routes under `/demandas`, expanded tactical analytics (SLA, operational view, volume), and refined ticket detail (attachments, GCS, workflow) for day-to-day operations.

## How has this been tested?
<!--- Fill in what was validated manually/automated -->

Suggested test plan:
- [ ] List shift closings with filters and pagination
- [ ] Create a shift closing (preview → confirm) at `/demandas/fechamentos/fechar`
- [ ] Open an existing shift closing detail
- [ ] Verify blocking without `shift_closing` permission and with `enableChamados=false`
- [ ] Sidebar navigation: Fechamentos, Tactical dashboard, Demandas
- [ ] Tactical dashboard: filters, charts, and CSV export on metrics / operational view / volume
- [ ] SLA and widgets config at `/demandas/dashboard`
- [ ] Ticket detail: tabs, GCS upload, archived list, impersonation
- [ ] Build/`pnpm` and existing map tests, if relevant to the merge

## Screenshots (if appropriate):
<!--- Add screenshots for Fechamentos, close shift, and dashboards -->

## Types of changes

- [x] fix: impersonation limited to `/demandas`; map layer fixes (disabled layers)
- [x] feat: shift closing, tactical dashboards, Demandas migration, ticket detail
- [ ] perf
- [ ] test (point updates to map tests)
- [x] refactor: chamados→demandas routes, SLA/widgets forms, status normalization
- [ ] style
- [x] chore: Docker, cloudbuild, lockfile
- [ ] docs
- [x] build
- [ ] ci
- [ ] revert

## Checklist:
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.