### PR TITLE
feat: enhance team member form and teams list components to support m…

### DIFF
--- a/src/app/(app)/demandas/equipes/components/team-member-form-dialog.tsx
+++ b/src/app/(app)/demandas/equipes/components/team-member-form-dialog.tsx
@@ -11,6 +11,7 @@ import { z } from 'zod'
 import { InputError } from '@/components/custom/input-error'
 import { Spinner } from '@/components/custom/spinner'
 import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
 import {
   Dialog,
   DialogContent,
@@ -49,17 +50,34 @@ const memberFormSchema = z
     team_id: z.string().min(1, 'Equipe obrigatória'),
     role: z.string().min(1, 'Função obrigatória').pipe(z.enum(roleEnumValues)),
     island_id: z.string().nullable().optional(),
+    islands_ids: z.array(z.string()).optional(),
     is_active: z.boolean(),
   })
   .superRefine((data, ctx) => {
-    const needsIsland =
-      data.role === 'Operador' || data.role === 'Líder de Ilha'
-
-    if (needsIsland && !data.island_id) {
+    if (data.role === 'Operador' && !data.island_id) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ['island_id'],
-        message: 'Ilha obrigatória para Operador ou Líder de Ilha',
+        message: 'Ilha obrigatória para Operador',
+      })
+    }
+
+    if (data.role === 'Líder de Ilha' && !data.island_id) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['island_id'],
+        message: 'Ilha obrigatória para Líder de Ilha',
+      })
+    }
+
+    if (
+      data.role === 'Líder de Ilha' &&
+      (!data.islands_ids || data.islands_ids.length === 0)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['islands_ids'],
+        message: 'Selecione ao menos uma ilha visível',
       })
     }
   })
@@ -110,6 +128,7 @@ export function TeamMemberFormDialog({
       team_id: '',
       role: '' as unknown as MemberForm['role'],
       island_id: null,
+      islands_ids: [],
       is_active: true,
     },
   })
@@ -140,8 +159,9 @@ export function TeamMemberFormDialog({
   const users = usersResponse?.data || []
   const islands = islandsResponse?.data?.items ?? []
 
-  const shouldShowIsland =
+  const shouldShowIslandSelect =
     selectedRole === 'Operador' || selectedRole === 'Líder de Ilha'
+  const shouldShowIslandsMultiSelect = selectedRole === 'Líder de Ilha'
 
   const { mutateAsync: createTeamMemberMutation, isPending: isPendingCreate } =
     useMutation({
@@ -183,10 +203,17 @@ export function TeamMemberFormDialog({
   }
 
   async function onSubmit(data: MemberForm) {
+    const isLiderDeIlha = data.role === 'Líder de Ilha'
+    const needsIslandId = data.role === 'Operador' || isLiderDeIlha
+    const islandsPayload = isLiderDeIlha
+      ? { islands_ids: data.islands_ids ?? [] }
+      : {}
+
     if (memberDialogInitialData?.id) {
       await updateTeamMemberMutation({
         memberId: memberDialogInitialData.id,
-        island_id: shouldShowIsland ? (data.island_id ?? null) : null,
+        island_id: needsIslandId ? (data.island_id ?? null) : null,
+        ...islandsPayload,
         role: data.role,
         is_active: data.is_active,
       })
@@ -194,7 +221,8 @@ export function TeamMemberFormDialog({
       await createTeamMemberMutation({
         user_id: data.user_id,
         team_id: data.team_id,
-        island_id: shouldShowIsland ? (data.island_id ?? null) : null,
+        island_id: needsIslandId ? (data.island_id ?? null) : null,
+        ...islandsPayload,
         role: data.role,
         is_active: data.is_active,
       })
@@ -221,16 +249,19 @@ export function TeamMemberFormDialog({
         (roleEnumValues as readonly string[]).includes(initialRole)
           ? (initialRole as MemberForm['role'])
           : ('' as unknown as MemberForm['role'])
-      const needsIsland =
-        roleInForm === 'Operador' || roleInForm === 'Líder de Ilha'
+      const isOperador = roleInForm === 'Operador'
+      const isLiderDeIlha = roleInForm === 'Líder de Ilha'
+      const needsIslandId = isOperador || isLiderDeIlha
+      const initialIslandsIds = memberDialogInitialData.islands_ids ?? []
 
       reset({
         user_id: memberDialogInitialData.user_id || '',
         team_id: memberDialogInitialData.team_id,
         role: roleInForm,
-        island_id: needsIsland
+        island_id: needsIslandId
           ? (memberDialogInitialData.island_id ?? null)
           : null,
+        islands_ids: isLiderDeIlha ? initialIslandsIds : [],
         is_active: memberDialogInitialData.is_active ?? true,
       })
       return
@@ -242,6 +273,7 @@ export function TeamMemberFormDialog({
         team_id: memberDialogInitialData.team_id,
         role: '' as unknown as MemberForm['role'],
         island_id: null,
+        islands_ids: [],
         is_active: true,
       })
     }
@@ -252,11 +284,18 @@ export function TeamMemberFormDialog({
 
     setValue('user_id', '', { shouldDirty: true, shouldValidate: false })
     setValue('island_id', null, { shouldDirty: true, shouldValidate: false })
+    setValue('islands_ids', [], { shouldDirty: true, shouldValidate: false })
   }, [selectedRole, memberDialogInitialData?.id, setValue])
 
   useEffect(() => {
+    if (!selectedRole) return
+
     if (selectedRole !== 'Operador' && selectedRole !== 'Líder de Ilha') {
       setValue('island_id', null, { shouldDirty: true, shouldValidate: true })
+    }
+
+    if (selectedRole !== 'Líder de Ilha') {
+      setValue('islands_ids', [], { shouldDirty: true, shouldValidate: true })
     }
   }, [selectedRole, setValue])
 
@@ -496,7 +535,7 @@ export function TeamMemberFormDialog({
                 </div>
               )}
 
-              {shouldShowIsland && (
+              {shouldShowIslandSelect && (
                 <div className="flex flex-col gap-1">
                   <div className="flex gap-2">
                     <Label htmlFor="island_id" className="equipes-modal-label">
@@ -543,21 +582,83 @@ export function TeamMemberFormDialog({
                           sideOffset={8}
                           className="equipes-select-dropdown w-[var(--radix-popover-trigger-width)] !rounded-[10px] !border !border-[rgba(77,109,137,0.55)] !bg-[#0d1c28] p-0 !shadow-[0_20px_40px_rgba(0,0,0,0.28)]"
                         >
-                          {islands.map((island) => (
-                            <button
-                              key={island.id}
-                              type="button"
-                              className="equipes-select-option w-full"
-                              onClick={() => {
-                                field.onChange(island.id)
-                                setIslandSelectOpen(false)
-                              }}
-                            >
-                              {island.name}
-                            </button>
-                          ))}
+                          {islands.length === 0 ? (
+                            <p className="equipes-select-option text-left text-sm text-[var(--equipes-text-subtle)]">
+                              Nenhuma ilha disponível nesta equipe.
+                            </p>
+                          ) : (
+                            islands.map((island) => (
+                              <button
+                                key={island.id}
+                                type="button"
+                                className="equipes-select-option w-full"
+                                onClick={() => {
+                                  field.onChange(island.id)
+                                  setIslandSelectOpen(false)
+                                }}
+                              >
+                                {island.name}
+                              </button>
+                            ))
+                          )}
                         </PopoverContent>
                       </Popover>
+                    )}
+                  />
+                </div>
+              )}
+
+              {shouldShowIslandsMultiSelect && (
+                <div className="flex flex-col gap-1">
+                  <div className="flex gap-2">
+                    <Label className="equipes-modal-label">
+                      Ilhas visíveis
+                    </Label>
+                    <InputError message={errors.islands_ids?.message} />
+                  </div>
+
+                  <Controller
+                    control={control}
+                    name="islands_ids"
+                    render={({ field }) => (
+                      <div className="equipes-islands-checkbox-list">
+                        {islands.length === 0 ? (
+                          <p className="text-sm text-[var(--equipes-text-subtle)]">
+                            Nenhuma ilha disponível nesta equipe.
+                          </p>
+                        ) : (
+                          islands.map((island) => {
+                            const isChecked = field.value?.includes(island.id)
+
+                            return (
+                              <label
+                                key={island.id}
+                                htmlFor={`island-${island.id}`}
+                                className="equipes-islands-checkbox-item"
+                              >
+                                <Checkbox
+                                  id={`island-${island.id}`}
+                                  checked={isChecked}
+                                  disabled={isLoading}
+                                  onCheckedChange={(checked) => {
+                                    const current = field.value ?? []
+
+                                    if (checked) {
+                                      field.onChange([...current, island.id])
+                                      return
+                                    }
+
+                                    field.onChange(
+                                      current.filter((id) => id !== island.id),
+                                    )
+                                  }}
+                                />
+                                <span>{island.name}</span>
+                              </label>
+                            )
+                          })
+                        )}
+                      </div>
                     )}
                   />
                 </div>

--- a/src/app/(app)/demandas/equipes/components/team-member-form-dialog.tsx
+++ b/src/app/(app)/demandas/equipes/components/team-member-form-dialog.tsx
@@ -84,6 +84,15 @@ const memberFormSchema = z
 
 type MemberForm = z.infer<typeof memberFormSchema>
 
+function withAssignedIslandVisible(
+  islandId: string | null | undefined,
+  islandsIds: string[] = [],
+) {
+  if (!islandId) return islandsIds
+  if (islandsIds.includes(islandId)) return islandsIds
+  return [...islandsIds, islandId]
+}
+
 function userDisplayName(
   user: Pick<UserRoleListItem, 'full_name' | 'username'>,
 ) {
@@ -119,6 +128,7 @@ export function TeamMemberFormDialog({
     watch,
     reset,
     setValue,
+    getValues,
     control,
     formState: { errors, isSubmitting },
   } = useForm<MemberForm>({
@@ -134,6 +144,7 @@ export function TeamMemberFormDialog({
   })
 
   const selectedRole = watch('role')
+  const watchedIslandId = watch('island_id')
   const watchedTeamId = watch('team_id')
   const teamIdForIslands =
     watchedTeamId || memberDialogInitialData?.team_id || ''
@@ -206,7 +217,12 @@ export function TeamMemberFormDialog({
     const isLiderDeIlha = data.role === 'Líder de Ilha'
     const needsIslandId = data.role === 'Operador' || isLiderDeIlha
     const islandsPayload = isLiderDeIlha
-      ? { islands_ids: data.islands_ids ?? [] }
+      ? {
+          islands_ids: withAssignedIslandVisible(
+            data.island_id,
+            data.islands_ids ?? [],
+          ),
+        }
       : {}
 
     if (memberDialogInitialData?.id) {
@@ -252,7 +268,12 @@ export function TeamMemberFormDialog({
       const isOperador = roleInForm === 'Operador'
       const isLiderDeIlha = roleInForm === 'Líder de Ilha'
       const needsIslandId = isOperador || isLiderDeIlha
-      const initialIslandsIds = memberDialogInitialData.islands_ids ?? []
+      const initialIslandsIds = isLiderDeIlha
+        ? withAssignedIslandVisible(
+            memberDialogInitialData.island_id,
+            memberDialogInitialData.islands_ids ?? [],
+          )
+        : []
 
       reset({
         user_id: memberDialogInitialData.user_id || '',
@@ -298,6 +319,18 @@ export function TeamMemberFormDialog({
       setValue('islands_ids', [], { shouldDirty: true, shouldValidate: true })
     }
   }, [selectedRole, setValue])
+
+  useEffect(() => {
+    if (selectedRole !== 'Líder de Ilha' || !watchedIslandId) return
+
+    const current = getValues('islands_ids') ?? []
+    if (current.includes(watchedIslandId)) return
+
+    setValue('islands_ids', [...current, watchedIslandId], {
+      shouldDirty: true,
+      shouldValidate: true,
+    })
+  }, [selectedRole, watchedIslandId, getValues, setValue])
 
   const isLoading = isSubmitting || isPendingCreate || isPendingUpdate
 
@@ -594,6 +627,20 @@ export function TeamMemberFormDialog({
                                 className="equipes-select-option w-full"
                                 onClick={() => {
                                   field.onChange(island.id)
+                                  if (selectedRole === 'Líder de Ilha') {
+                                    const current =
+                                      getValues('islands_ids') ?? []
+                                    if (!current.includes(island.id)) {
+                                      setValue(
+                                        'islands_ids',
+                                        [...current, island.id],
+                                        {
+                                          shouldDirty: true,
+                                          shouldValidate: true,
+                                        },
+                                      )
+                                    }
+                                  }
                                   setIslandSelectOpen(false)
                                 }}
                               >
@@ -629,6 +676,8 @@ export function TeamMemberFormDialog({
                         ) : (
                           islands.map((island) => {
                             const isChecked = field.value?.includes(island.id)
+                            const isAssignedIsland =
+                              island.id === watchedIslandId
 
                             return (
                               <label
@@ -639,8 +688,10 @@ export function TeamMemberFormDialog({
                                 <Checkbox
                                   id={`island-${island.id}`}
                                   checked={isChecked}
-                                  disabled={isLoading}
+                                  disabled={isLoading || isAssignedIsland}
                                   onCheckedChange={(checked) => {
+                                    if (isAssignedIsland) return
+
                                     const current = field.value ?? []
 
                                     if (checked) {

--- a/src/app/(app)/demandas/equipes/components/teams-list.tsx
+++ b/src/app/(app)/demandas/equipes/components/teams-list.tsx
@@ -11,7 +11,7 @@ import {
 import { useMemo, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
-import type { Team, TeamMember } from '@/http/teams/get-teams'
+import type { Team, TeamIsland, TeamMember } from '@/http/teams/get-teams'
 import { getTeams } from '@/http/teams/get-teams'
 import type { UserRoleEnum } from '@/http/user-roles/get-users-with-roles'
 
@@ -32,6 +32,27 @@ function formatRole(role: UserRoleEnum) {
 
 function resolveIsland(member: TeamMember) {
   return member.island_name || '-'
+}
+
+function resolveVisibleIslands(
+  member: TeamMember,
+  teamIslands: TeamIsland[] = [],
+) {
+  if (member.islands?.length) {
+    return member.islands.map((island) => island.name).join(', ')
+  }
+
+  if (member.islands_ids?.length) {
+    const names = member.islands_ids
+      .map((id) => teamIslands.find((island) => island.id === id)?.name)
+      .filter((name): name is string => Boolean(name))
+
+    if (names.length) {
+      return names.join(', ')
+    }
+  }
+
+  return '-'
 }
 
 interface TeamsListProps {
@@ -123,6 +144,9 @@ export function TeamsList({ controller }: TeamsListProps) {
                     <div className="equipes-table-cell equipes-table-cell-ilha">
                       Ilha
                     </div>
+                    <div className="equipes-table-cell equipes-table-cell-ilhas-visiveis">
+                      Ilhas visíveis
+                    </div>
                     <div className="equipes-table-cell equipes-table-cell-funcao">
                       Função
                     </div>
@@ -132,64 +156,85 @@ export function TeamsList({ controller }: TeamsListProps) {
                     <div className="ml-auto w-[80px] shrink-0" />
                   </div>
 
-                  {team.members.map((member) => (
-                    <div
-                      key={member.id}
-                      className="equipes-table-row group items-center justify-between"
-                    >
-                      <div className="flex min-w-0 flex-1 items-center">
-                        <div className="equipes-table-cell equipes-table-cell-ilha">
-                          {resolveIsland(member)}
+                  {team.members.map((member) => {
+                    const visibleIslands = resolveVisibleIslands(
+                      member,
+                      team.islands ?? [],
+                    )
+
+                    return (
+                      <div
+                        key={member.id}
+                        className="equipes-table-row equipes-table-row-member group items-center justify-between"
+                      >
+                        <div className="flex min-w-0 flex-1 items-center">
+                          <div className="equipes-table-cell equipes-table-cell-ilha">
+                            {resolveIsland(member)}
+                          </div>
+                          <div
+                            className="equipes-table-cell equipes-table-cell-ilhas-visiveis"
+                            title={
+                              visibleIslands !== '-'
+                                ? visibleIslands
+                                : undefined
+                            }
+                          >
+                            {visibleIslands}
+                          </div>
+                          <div className="equipes-table-cell equipes-table-cell-funcao">
+                            {formatRole(member.role)}
+                          </div>
+                          <div className="equipes-table-cell equipes-table-cell-nome">
+                            {member.user_name || '-'}
+                          </div>
                         </div>
-                        <div className="equipes-table-cell equipes-table-cell-funcao">
-                          {formatRole(member.role)}
-                        </div>
-                        <div className="equipes-table-cell equipes-table-cell-nome">
-                          {member.user_name || '-'}
+
+                        <div className="flex shrink-0 items-center justify-end gap-2">
+                          <Button
+                            type="button"
+                            className="equipes-btn-editar flex items-center gap-1"
+                            onClick={() => {
+                              openEditMemberDialog({
+                                id: member.id,
+                                team_id: team.id,
+                                team_name: team.name,
+                                user_id: member.user_id,
+                                user_name: member.user_name,
+                                island_id: member.island_id,
+                                island_name: member.island_name,
+                                islands_ids:
+                                  member.islands_ids ??
+                                  member.islands?.map((island) => island.id) ??
+                                  [],
+                                role: member.role,
+                                is_active: member.is_active,
+                              })
+                            }}
+                          >
+                            <PencilLine className="size-3.5" />
+                            Editar
+                          </Button>
+
+                          <Button
+                            type="button"
+                            variant="outline"
+                            className="h-6 border-red-900/50 bg-transparent px-2 text-[10px] text-red-300 hover:bg-red-950/30 hover:text-red-200"
+                            onClick={() => {
+                              openDeleteTeamMemberDialog({
+                                id: member.id,
+                                user_name: member.user_name || 'Colaborador',
+                                team_id: team.id,
+                                team_name: team.name,
+                              })
+                            }}
+                          >
+                            <Trash2 className="size-3.5" />
+                            Remover
+                          </Button>
                         </div>
                       </div>
-
-                      <div className="flex shrink-0 items-center justify-end gap-2">
-                        <Button
-                          type="button"
-                          className="equipes-btn-editar flex items-center gap-1"
-                          onClick={() => {
-                            openEditMemberDialog({
-                              id: member.id,
-                              team_id: team.id,
-                              team_name: team.name,
-                              user_id: member.user_id,
-                              user_name: member.user_name,
-                              island_id: member.island_id,
-                              island_name: member.island_name,
-                              role: member.role,
-                              is_active: member.is_active,
-                            })
-                          }}
-                        >
-                          <PencilLine className="size-3.5" />
-                          Editar
-                        </Button>
-
-                        <Button
-                          type="button"
-                          variant="outline"
-                          className="h-6 border-red-900/50 bg-transparent px-2 text-[10px] text-red-300 hover:bg-red-950/30 hover:text-red-200"
-                          onClick={() => {
-                            openDeleteTeamMemberDialog({
-                              id: member.id,
-                              user_name: member.user_name || 'Colaborador',
-                              team_id: team.id,
-                              team_name: team.name,
-                            })
-                          }}
-                        >
-                          <Trash2 className="size-3.5" />
-                          Remover
-                        </Button>
-                      </div>
-                    </div>
-                  ))}
+                    )
+                  })}
                 </div>
 
                 <div className="equipes-table-footer">

--- a/src/app/(app)/demandas/equipes/equipes.css
+++ b/src/app/(app)/demandas/equipes/equipes.css
@@ -93,11 +93,17 @@
 }
 
 .equipes-table-row {
-  height: 40px;
+  min-height: 40px;
   padding: 0 24px;
   display: flex;
   align-items: center;
   border-bottom: 0.8px solid var(--equipes-border);
+}
+
+.equipes-table-row-member {
+  height: auto;
+  padding-top: 4px;
+  padding-bottom: 4px;
 }
 
 .equipes-table-row:last-child {
@@ -117,13 +123,23 @@
 }
 
 .equipes-table-cell-ilha {
-  width: 160px;
+  width: 120px;
+  min-width: 120px;
+}
+
+.equipes-table-cell-ilhas-visiveis {
+  width: 180px;
   min-width: 160px;
+  flex: 1;
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .equipes-table-cell-funcao {
-  width: 160px;
-  min-width: 160px;
+  width: 140px;
+  min-width: 140px;
 }
 
 .equipes-table-cell-nome {
@@ -393,6 +409,34 @@ textarea.equipes-modal-input-wrap {
 
 .equipes-modal-btn-salvar:hover {
   background-color: var(--equipes-btn-primary-hover);
+}
+
+.equipes-islands-checkbox-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 200px;
+  overflow-y: auto;
+  padding: 8px;
+  border: 1px solid rgba(77, 109, 137, 0.55);
+  border-radius: 8px;
+  background: #0d1c28;
+}
+
+.equipes-islands-checkbox-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 40px;
+  padding: 0 6px;
+  border-radius: 6px;
+  color: #e4eef9;
+  font-size: 14px;
+  cursor: pointer;
+}
+
+.equipes-islands-checkbox-item:hover {
+  background: rgba(255, 255, 255, 0.04);
 }
 
 .equipes-alert-content {

--- a/src/app/(app)/demandas/equipes/hooks/use-teams-controller.ts
+++ b/src/app/(app)/demandas/equipes/hooks/use-teams-controller.ts
@@ -25,6 +25,7 @@ export interface TeamMemberDialogInitialData {
   user_name?: string | null
   island_id?: string | null
   island_name?: string | null
+  islands_ids?: string[]
   role?: string
   is_active?: boolean
 }

--- a/src/http/teams/create-team-member.ts
+++ b/src/http/teams/create-team-member.ts
@@ -7,6 +7,7 @@ interface CreateTeamMemberRequest {
   user_id: string
   team_id: string
   island_id?: string | null
+  islands_ids?: string[]
   role: UserRoleEnum
   is_active?: boolean
 }

--- a/src/http/teams/get-teams.ts
+++ b/src/http/teams/get-teams.ts
@@ -2,6 +2,11 @@ import { api } from '@/lib/api'
 
 import type { UserRoleEnum } from '../user-roles/get-users-with-roles'
 
+export interface TeamMemberIsland {
+  id: string
+  name: string
+}
+
 export interface TeamMember {
   id: string
   created_at: string
@@ -11,6 +16,8 @@ export interface TeamMember {
   user_name: string | null
   island_id: string | null
   island_name: string | null
+  islands_ids?: string[]
+  islands?: TeamMemberIsland[]
   is_active: boolean
   role: UserRoleEnum
 }

--- a/src/http/teams/update-team-member.ts
+++ b/src/http/teams/update-team-member.ts
@@ -6,6 +6,7 @@ import type { TeamMember } from './get-teams'
 interface UpdateTeamMemberRequest {
   memberId: string
   island_id?: string | null
+  islands_ids?: string[]
   role?: UserRoleEnum
   is_active?: boolean
 }


### PR DESCRIPTION
## Description

This PR consolidates the **Demandas** module (migration from `/chamados` to `/demandas`), the **ticket detail view**, tactical dashboards, shift closings, screen/module permissions, and incremental UX improvements for attachments, services, and workflow.

### Main deliverables

**1. Demandas module**
- Routes moved from `chamados` → `demandas` (inbox, convert, create, lists, spam, responded, archived).
- `config.enableChamados` with `notFound()` on pages when the feature is disabled.
- **Impersonation** bar and context limited to the `/demandas` path.
- Sidebar filtered by module permissions (`filter-chamados-sidebar-modules`).

**2. Ticket detail (`/demandas/[ticketId]`)**
- Full view with tabs: Ticket, Documents, History, Internal opinion, Demand report, Response, Services, Requester.
- GCS upload (video, ZIP, progress), pending attachments with rename/preview, unsaved-changes guard.
- Reassignment with comment, workflow actions, expanded services form and per-service attachments.
- Terminology standardization: **“attachments” → “anexos”** in labels and variables.

**3. Tactical dashboard & configuration**
- Tabs: SLA metrics, Operational view, Demand volume (filters, charts, CSV export).
- SLA and widget configuration on the demands dashboard.
- SLA/widget forms using `watch` for reactive state; press-relevance filter on volume.

**4. Shift closings**
- Listing, filters, detail, and close-shift flow at `/demandas/fechamentos`.

**5. Permissions & teams**
- Permissions screens by role and ticket module.
- **Assessor** role in team forms.
- Module permissions integrated into sidebar and ticket detail.

**6. Workflow (latest local commit)**
- **Restore defaults** button on `/demandas/workflow`.
- Confirmation dialog + success/error toasts.
- HTTP client `resetWorkflowToDefaults` → `POST /workflow/reset-to-defaults`.

**7. Other areas in the diff vs `staging`**
- Map/LPR improvements (SENTRY, DC3, layers, tests).
- Operational GCS upload, Docker/Cloud Build, API and HTTP type updates for tickets.

---

## Related Issue

_Not specified in commit history._

---

## Motivation and Context

The tickets module evolved into **Demandas**, with a full view, services, attachments, and dashboards. This branch closes UX gaps (attachments, cameras, service validation, permissions), adds operational tooling (tactical dashboard, closings, archived tickets), and allows **resetting workflow** to factory defaults with a safe confirmation flow.

**Branch:** `feat/fixes-and-improvements-ticket` → `staging`  
**Scope:** ~59 commits (no merges) · 325 files (+41,566 / −9,299 lines)  
**Remote:** 1 unpushed commit (`c89bf86` — workflow reset)

---

## How has this been tested?

_Manual validation recommended:_

- [ ] Navigation on `/demandas/*` with `enableChamados` on/off
- [ ] Ticket detail: tabs, GCS upload, attachments, services, response, reassignment
- [ ] Tactical dashboard: filters, charts, and CSV export on all three views
- [ ] Shift closings: list, filter, open detail, close shift
- [ ] Permissions: sidebar and role-restricted screens
- [ ] Workflow: edit config by type/role, save, **restore defaults** (confirm toasts and data reload)
- [ ] Impersonation only on `/demandas` routes
- [ ] Regression on map/LPR and existing tests (`pnpm test` / CI)

---

## Screenshots (if appropriate)

_Add screenshots of ticket detail, tactical dashboard, workflow (restore button), and shift closings._

---

## Types of changes

- [x] **fix:** impersonation only on `/demandas`; status normalization; inherited build/CI fixes
- [x] **feat:** Demandas module, ticket detail, tactical dashboard, closings, archived, workflow reset, permissions, GCS
- [ ] **perf**
- [ ] **test:** map test updates (from other features)
- [x] **refactor:** “anexos” terminology; chamados → demandas layout; status simplification
- [ ] **style**
- [x] **chore:** remove obsolete `pr.md`; Docker/lockfile updates
- [ ] **docs**
- [x] **build:** `.dockerignore`, `cloudbuild`, `pnpm-lock.yaml`
- [ ] **ci**
- [ ] **revert**

---

## Checklist

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

---

## Recent commits

| Commit | Summary |
|--------|---------|
| `c89bf86` | Workflow reset with dialog and toasts *(local, not pushed)* |
| `2960522` | Standardize “anexos” in detail and operational view |
| `bbedd16` | Attachment handling refactor in ticket detail |
| `2468ea2` | Sidebar permissions + service validation |
| `c03e445` | Camera fields and attachment improvements |
| `785ff62` / `5bd4c0e` | Tactical dashboard + SLA/widget config |
| `e5bff3e` … | Demandas module base and ticket detail |