### PR TITLE
refactor(ticket): remove normalization and masking functions for offi…

### DIFF
--- a/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-chamado.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-chamado.tsx
@@ -36,10 +36,6 @@ import {
 } from '@/http/tickets/ticket-ficha'
 import { isApiError } from '@/lib/api'
 import { getApiErrorMessage } from '@/utils/error-handlers'
-import {
-  maskNumeroOficio,
-  normalizeNumeroOficio,
-} from '@/utils/string-formatters'
 
 import { shouldShowTicketSeiFields } from '../ticket-detail.constants'
 import styles from '../ticket-detail.module.css'
@@ -93,12 +89,9 @@ function mapOutToDraft(f: TicketFichaOut): TicketFichaUpdateIn {
     procedure_number: f.procedure_number?.trim()
       ? f.procedure_number.trim()
       : null,
-    official_letter_number: (() => {
-      const t = f.official_letter_number?.trim()
-      if (!t) return null
-      const n = normalizeNumeroOficio(t)
-      return n || null
-    })(),
+    official_letter_number: f.official_letter_number?.trim()
+      ? f.official_letter_number.trim()
+      : null,
     nature_id: f.nature_id?.trim() ? f.nature_id.trim() : null,
     has_press_alias: f.has_press_alias,
     press_alias: f.press_alias?.trim() ? f.press_alias.trim() : null,
@@ -133,11 +126,9 @@ function buildChamadoPayload(
     return null
   }
 
-  const oficio = normalizeNumeroOficio(
-    draft.official_letter_number?.trim() ?? '',
-  )
+  const oficio = draft.official_letter_number?.trim() ?? ''
   const proc = draft.procedure_number?.trim() ?? ''
-  if (oficio && !/^[A-Z0-9/]+$/.test(oficio)) {
+  if (oficio && !/^[A-Za-z0-9/]+$/.test(oficio)) {
     toast.error(
       'Nº de ofício: use apenas letras, números e barra (/), ou deixe em branco.',
     )
@@ -440,13 +431,9 @@ export const TicketDetailTabChamado = forwardRef<TicketDetailTabHandle, Props>(
                         const raw = (prev.official_letter_number ?? '').trim()
                         if (!raw)
                           return { ...prev, official_letter_number: null }
-                        const normalized = normalizeNumeroOficio(raw)
-                        return normalized === prev.official_letter_number
+                        return raw === prev.official_letter_number
                           ? prev
-                          : {
-                              ...prev,
-                              official_letter_number: normalized || null,
-                            }
+                          : { ...prev, official_letter_number: raw }
                       })
                     }
                     onChange={(e) =>
@@ -454,8 +441,7 @@ export const TicketDetailTabChamado = forwardRef<TicketDetailTabHandle, Props>(
                         prev
                           ? {
                               ...prev,
-                              official_letter_number:
-                                maskNumeroOficio(e.target.value) || null,
+                              official_letter_number: e.target.value || null,
                             }
                           : prev,
                       )

--- a/src/app/(app)/demandas/converter/components/email-to-ticket-view.tsx
+++ b/src/app/(app)/demandas/converter/components/email-to-ticket-view.tsx
@@ -54,9 +54,7 @@ import { markEmailAsAguardandoResposta } from '@/http/emails/mark-email-aguardan
 import { getFirstFormErrorMessage } from '@/utils/form-errors'
 import {
   maskDigitsOnly,
-  maskNumeroOficio,
   maskPhoneBR,
-  normalizeNumeroOficio,
   padDigitsLeft,
 } from '@/utils/string-formatters'
 
@@ -900,20 +898,10 @@ export function EmailToTicketView() {
                               disabled={vm.isLoading}
                               autoComplete="off"
                               value={field.value ?? ''}
-                              onBlur={() => {
-                                field.onBlur()
-                                const raw = (field.value ?? '').trim()
-                                if (raw === '') return
-                                const normalized = normalizeNumeroOficio(raw)
-                                if (normalized !== field.value) {
-                                  field.onChange(normalized || null)
-                                }
-                              }}
+                              onBlur={field.onBlur}
                               ref={field.ref}
                               onChange={(e) =>
-                                field.onChange(
-                                  maskNumeroOficio(e.target.value) || null,
-                                )
+                                field.onChange(e.target.value || null)
                               }
                             />
                           )}

--- a/src/app/(app)/demandas/criar/ticket-create/ticket-create-form.tsx
+++ b/src/app/(app)/demandas/criar/ticket-create/ticket-create-form.tsx
@@ -40,9 +40,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { getFirstFormErrorMessage } from '@/utils/form-errors'
 import {
   maskDigitsOnly,
-  maskNumeroOficio,
   maskPhoneBR,
-  normalizeNumeroOficio,
   padDigitsLeft,
 } from '@/utils/string-formatters'
 
@@ -367,19 +365,9 @@ export function TicketCreateForm() {
                     disabled={fieldDisabled}
                     autoComplete="off"
                     value={field.value ?? ''}
-                    onBlur={() => {
-                      field.onBlur()
-                      const raw = (field.value ?? '').trim()
-                      if (raw === '') return
-                      const normalized = normalizeNumeroOficio(raw)
-                      if (normalized !== field.value) {
-                        field.onChange(normalized || null)
-                      }
-                    }}
+                    onBlur={field.onBlur}
                     ref={field.ref}
-                    onChange={(e) =>
-                      field.onChange(maskNumeroOficio(e.target.value) || null)
-                    }
+                    onChange={(e) => field.onChange(e.target.value || null)}
                   />
                 )}
               />

--- a/src/app/(app)/demandas/criar/ticket-create/ticket-create-schema.ts
+++ b/src/app/(app)/demandas/criar/ticket-create/ticket-create-schema.ts
@@ -169,7 +169,7 @@ export const ticketCreateSchema = z.object({
     .optional()
     .nullable()
     .refine(
-      (v) => v == null || v === '' || /^[A-Z0-9/]+$/.test(v),
+      (v) => v == null || v === '' || /^[A-Za-z0-9/]+$/.test(v),
       'Use apenas letras, números e barra (/)',
     ),
   base_date: z.string().optional().nullable(),

--- a/src/app/(app)/demandas/criar/ticket-create/ticket-create.mapper.ts
+++ b/src/app/(app)/demandas/criar/ticket-create/ticket-create.mapper.ts
@@ -1,9 +1,5 @@
 import type { TicketOut } from '@/http/tickets/get-ticket-by-id'
-import {
-  normalizeNumeroOficio,
-  padDigitsLeft,
-  unmaskPlateBR,
-} from '@/utils/string-formatters'
+import { padDigitsLeft, unmaskPlateBR } from '@/utils/string-formatters'
 
 import { TICKET_CREATE_STRING_LIMITS as L } from './ticket-create.constant'
 import type { TicketCreateForm } from './ticket-create-schema'
@@ -44,9 +40,7 @@ export function buildTicketCreatePayload(
     procedure_number: emptyToNull(
       padDigitsLeft(data.procedure_number, L.procedure_number),
     ),
-    official_letter_number: emptyToNull(
-      normalizeNumeroOficio(data.official_letter_number ?? ''),
-    ),
+    official_letter_number: emptyToNull(data.official_letter_number ?? ''),
     base_date: emptyToNull(data.base_date),
     nature_id: data.nature_id.trim(),
     press_alias: emptyToNull(data.press_alias),
@@ -183,12 +177,7 @@ export function mapTicketOutToCreateForm(
     procedure_number: ticket.procedure_number
       ? padDigitsLeft(ticket.procedure_number, L.procedure_number)
       : null,
-    official_letter_number: (() => {
-      const raw = ticket.official_letter_number?.trim()
-      if (!raw) return null
-      const normalized = normalizeNumeroOficio(raw)
-      return normalized || null
-    })(),
+    official_letter_number: ticket.official_letter_number?.trim() || null,
     base_date: apiDateToDataBaseString(ticket.base_date),
     nature_id: ticket.nature_id ?? '',
     has_press_alias: ticket.has_press_alias,

--- a/src/utils/string-formatters.ts
+++ b/src/utils/string-formatters.ts
@@ -86,46 +86,6 @@ export function unmaskPlateBR(value: string): string {
   return value.replace(/[^a-zA-Z0-9]/g, '').toUpperCase()
 }
 
-const NUMERO_OFICIO_NUM_LEN = 5
-const NUMERO_OFICIO_YEAR_LEN = 4
-const NUMERO_OFICIO_MAX_DIGITS = NUMERO_OFICIO_NUM_LEN + NUMERO_OFICIO_YEAR_LEN
-
-function splitNumeroOficioAlnum(value: string): { num: string; year: string } {
-  const alnum = value
-    .replace(/[^a-zA-Z0-9]/g, '')
-    .toUpperCase()
-    .slice(0, NUMERO_OFICIO_MAX_DIGITS)
-  return {
-    num: alnum.slice(0, NUMERO_OFICIO_NUM_LEN),
-    year: alnum.slice(NUMERO_OFICIO_NUM_LEN),
-  }
-}
-
-/** Máscara visual: até 5 alfanuméricos + / + até 4 (ex.: 12A45/2026 ou 00123/2026). */
-export function maskNumeroOficio(value: string): string {
-  const { num, year } = splitNumeroOficioAlnum(value)
-  if (!year) return num
-  return `${num}/${year}`
-}
-
-/**
- * Normaliza no blur: 5 + / + 4; trechos só numéricos recebem zeros à esquerda.
- */
-export function normalizeNumeroOficio(value: string): string {
-  const trimmed = value.trim()
-  if (!trimmed) return ''
-  const { num: numRaw, year: yearRaw } = splitNumeroOficioAlnum(trimmed)
-  if (!numRaw) return ''
-  const num = /[A-Z]/.test(numRaw)
-    ? numRaw
-    : padDigitsLeft(numRaw, NUMERO_OFICIO_NUM_LEN)
-  if (!yearRaw) return num
-  const year = /[A-Z]/.test(yearRaw)
-    ? yearRaw
-    : padDigitsLeft(yearRaw, NUMERO_OFICIO_YEAR_LEN)
-  return `${num}/${year}`
-}
-
 export function maskPhoneBR(value: string) {
   const n = value.replace(/\D/g, '').slice(0, 11)
   if (n.length === 0) return ''


### PR DESCRIPTION
## Description

This branch brings improvements to the demandas (tickets) module, focused on two areas:

### 1. Attachment upload on the Services tab (committed)

- Refactored the upload progress panel on the ticket detail **Services** tab.
- Replaced simple per-file tracking with an upload queue (`uploadQueue`) and per-file states: `queued`, `preparing`, `uploading`, `finalizing`, `done`, `error`.
- Improved UI with status icons (waiting, in progress, done, error), an "X of Y completed" counter, and a progress bar only for GCS uploads with known byte counts.
- `GcsUploadProgress` now includes `pendingAttachmentId` to correlate progress with the correct attachment in the queue.
- More granular error handling: GCS upload or mutation failures mark items as `error` while keeping the panel visible.
- Updated CSS styles for the new upload panel.

### 2. Services mapper fix (committed)

- `ticket-servicos-mapper.ts`: null-safe handling for `address` and `camera_code` when building the payload (`(a.address ?? '').trim()`), preventing runtime errors when saving services with empty fields.

### 3. "Official letter number" — free-form input (staged, pending commit)

- Removed `maskNumeroOficio` and `normalizeNumeroOficio` from `string-formatters.ts`.
- Official letter number fields now accept free text (no automatic `XXXXX/YYYY` mask or zero-padding on blur).
- Validation updated from `^[A-Z0-9/]+$` to `^[A-Za-z0-9/]+$`, allowing lowercase letters.
- Changes applied in:
  - Ticket creation (`ticket-create-form`, `ticket-create-schema`, `ticket-create.mapper`)
  - Email-to-ticket conversion (`email-to-ticket-view`)
  - Chamado tab editing on ticket detail (`ticket-detail-tab-chamado`)

## Related Issue

N/A

## Motivation and Context

- **Upload:** The previous panel only showed percentage progress by filename, with no distinction between queued files, intermediate states, or clear visual feedback. The new queue improves the experience when saving services with multiple attachments (especially videos/ZIP via GCS).
- **Mapper:** Addresses or cameras with `null` values caused failures when calling `.trim()` during save.
- **Official letter number:** The rigid mask (5 alphanumeric + `/` + 4 digits) and forced blur normalization blocked valid formats used in practice and auto-uppercased letters.

## How has this been tested?

- [ ] Automated tests were not run in this review.
- [ ] Manually verify upload of multiple attachments (ZIP/video) on the Services tab: queue, progress, completion, and error states.
- [ ] Save a service with empty or null address/camera fields — should not crash.
- [ ] Create/edit a ticket with varied official letter number formats (e.g. `abc/2026`, `12345/2026`, text without slash) — should accept without reformatting on blur.
- [ ] Convert email to ticket with official letter number filled in.

## Screenshots (if appropriate):
<img width="705" height="152" alt="image" src="https://github.com/user-attachments/assets/c2a029db-532b-45fe-9088-a0d59ec22757" />


## Types of changes

- [x] fix: null-safe address/camera_code in services mapper
- [x] feat: upload queue with per-attachment status on Services tab
- [x] refactor: remove official letter number mask/normalization (staged)
- [ ] perf
- [ ] test
- [ ] style
- [ ] chore
- [ ] docs
- [ ] build
- [ ] ci
- [ ] revert

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.