### PR TITLE
update(ticket-create): increase official letter number limit from 10 …

### DIFF
--- a/src/app/(app)/demandas/criar/ticket-create/ticket-create.constant.ts
+++ b/src/app/(app)/demandas/criar/ticket-create/ticket-create.constant.ts
@@ -89,7 +89,7 @@ export type AtlasCivitasDraft = {
 
 export const TICKET_CREATE_STRING_LIMITS = {
   procedure_number: 12,
-  official_letter_number: 10,
+  official_letter_number: 50,
   press_alias: 120,
   article_link: 2048,
   correspondence_neighborhood: 120,


### PR DESCRIPTION
## Description

This branch brings improvements to the demandas (tickets) module, focused on two areas:

### 1. Attachment upload on the Services tab (committed)

- Refactored the upload progress panel on the ticket detail **Services** tab.
- Replaced simple per-file tracking with an upload queue (`uploadQueue`) and per-file states: `queued`, `preparing`, `uploading`, `finalizing`, `done`, `error`.
- Improved UI with status icons (waiting, in progress, done, error), an "X of Y completed" counter, and a progress bar only for GCS uploads with known byte counts.
- `GcsUploadProgress` now includes `pendingAttachmentId` to correlate progress with the correct attachment in the queue.
- More granular error handling: GCS upload or mutation failures mark items as `error` while keeping the panel visible.
- Updated CSS styles for the new upload panel.

### 2. Services mapper fix (committed)

- `ticket-servicos-mapper.ts`: null-safe handling for `address` and `camera_code` when building the payload (`(a.address ?? '').trim()`), preventing runtime errors when saving services with empty fields.

### 3. "Official letter number" — free-form input (staged, pending commit)

- Removed `maskNumeroOficio` and `normalizeNumeroOficio` from `string-formatters.ts`.
- Official letter number fields now accept free text (no automatic `XXXXX/YYYY` mask or zero-padding on blur).
- Validation updated from `^[A-Z0-9/]+$` to `^[A-Za-z0-9/]+$`, allowing lowercase letters.
- Changes applied in:
  - Ticket creation (`ticket-create-form`, `ticket-create-schema`, `ticket-create.mapper`)
  - Email-to-ticket conversion (`email-to-ticket-view`)
  - Chamado tab editing on ticket detail (`ticket-detail-tab-chamado`)

## Related Issue

N/A

## Motivation and Context

- **Upload:** The previous panel only showed percentage progress by filename, with no distinction between queued files, intermediate states, or clear visual feedback. The new queue improves the experience when saving services with multiple attachments (especially videos/ZIP via GCS).
- **Mapper:** Addresses or cameras with `null` values caused failures when calling `.trim()` during save.
- **Official letter number:** The rigid mask (5 alphanumeric + `/` + 4 digits) and forced blur normalization blocked valid formats used in practice and auto-uppercased letters.

## How has this been tested?

- [ ] Automated tests were not run in this review.
- [ ] Manually verify upload of multiple attachments (ZIP/video) on the Services tab: queue, progress, completion, and error states.
- [ ] Save a service with empty or null address/camera fields — should not crash.
- [ ] Create/edit a ticket with varied official letter number formats (e.g. `abc/2026`, `12345/2026`, text without slash) — should accept without reformatting on blur.
- [ ] Convert email to ticket with official letter number filled in.

## Screenshots (if appropriate):
<img width="705" height="152" alt="image" src="https://github.com/user-attachments/assets/c2a029db-532b-45fe-9088-a0d59ec22757" />


## Types of changes

- [x] fix: null-safe address/camera_code in services mapper
- [x] feat: upload queue with per-attachment status on Services tab
- [x] refactor: remove official letter number mask/normalization (staged)
- [ ] perf
- [ ] test
- [ ] style
- [ ] chore
- [ ] docs
- [ ] build
- [ ] ci
- [ ] revert

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.