### PR TITLE
refactor(dashboard): integrate DashboardTaticoDataState for loading a…

### DIFF
--- a/src/app/(app)/demandas/dashboard-tatico/components/dashboard-tatico-data-state.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/components/dashboard-tatico-data-state.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import type { CSSProperties } from 'react'
+
+const BASE_STYLE: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  color: '#97a2ab',
+  fontSize: '14px',
+}
+
+interface DashboardTaticoDataStateProps {
+  isLoading: boolean
+  isEmpty: boolean
+  height?: number
+}
+
+export function DashboardTaticoDataState({
+  isLoading,
+  isEmpty,
+  height = 280,
+}: DashboardTaticoDataStateProps) {
+  if (!isEmpty) return null
+
+  return (
+    <div style={{ ...BASE_STYLE, height: `${height}px` }}>
+      {isLoading ? 'Carregando…' : 'Nenhum Registro Localizado'}
+    </div>
+  )
+}

--- a/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-general-chart.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-general-chart.tsx
@@ -17,6 +17,7 @@ import type {
   SlaDashboardGranularity,
 } from '@/http/tickets/get-sla-dashboard'
 
+import { DashboardTaticoDataState } from '../../components/dashboard-tatico-data-state'
 import { DemandVolumeChartGranularity } from '../../volume/components/demand-volume-chart-granularity'
 import { formatPeriodLabel } from '../../volume/components/demand-volume-period-label'
 import styles from '../../volume/components/demand-volume-top.module.css'
@@ -26,6 +27,7 @@ interface SlaMetricsGeneralChartProps {
   granularity: SlaDashboardGranularity
   onGranularityChange: (granularity: SlaDashboardGranularity) => void
   isLoading: boolean
+  isAvailable: boolean
 }
 
 const SERIES = [
@@ -69,13 +71,14 @@ export function SlaMetricsGeneralChart({
   granularity,
   onGranularityChange,
   isLoading,
+  isAvailable,
 }: SlaMetricsGeneralChartProps) {
   const chartData = data.map((item) => ({
     ...item,
     label: formatPeriodLabel(item.period_label, granularity),
   }))
 
-  if (!isLoading && chartData.length === 0) {
+  if (!isLoading && !isAvailable) {
     return null
   }
 
@@ -99,19 +102,8 @@ export function SlaMetricsGeneralChart({
         />
       </div>
 
-      {isLoading && chartData.length === 0 ? (
-        <div
-          style={{
-            height: '280px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            color: '#97a2ab',
-            fontSize: '14px',
-          }}
-        >
-          Carregando…
-        </div>
+      {chartData.length === 0 ? (
+        <DashboardTaticoDataState isLoading={isLoading} isEmpty />
       ) : (
         <ResponsiveContainer width="100%" height={280}>
           <LineChart

--- a/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-media-chart.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-media-chart.tsx
@@ -17,6 +17,7 @@ import type {
   SlaDashboardGranularity,
 } from '@/http/tickets/get-sla-dashboard'
 
+import { DashboardTaticoDataState } from '../../components/dashboard-tatico-data-state'
 import { DemandVolumeChartGranularity } from '../../volume/components/demand-volume-chart-granularity'
 import { formatPeriodLabel } from '../../volume/components/demand-volume-period-label'
 import styles from '../../volume/components/demand-volume-top.module.css'
@@ -26,6 +27,7 @@ interface SlaMetricsMediaChartProps {
   granularity: SlaDashboardGranularity
   onGranularityChange: (granularity: SlaDashboardGranularity) => void
   isLoading: boolean
+  isAvailable: boolean
 }
 
 const CHART_COLORS = {
@@ -57,13 +59,14 @@ export function SlaMetricsMediaChart({
   granularity,
   onGranularityChange,
   isLoading,
+  isAvailable,
 }: SlaMetricsMediaChartProps) {
   const chartData = data.map((item) => ({
     ...item,
     label: formatPeriodLabel(item.period_label, granularity),
   }))
 
-  if (!isLoading && chartData.length === 0) {
+  if (!isLoading && !isAvailable) {
     return null
   }
 
@@ -87,19 +90,8 @@ export function SlaMetricsMediaChart({
         />
       </div>
 
-      {isLoading && chartData.length === 0 ? (
-        <div
-          style={{
-            height: '280px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            color: '#97a2ab',
-            fontSize: '14px',
-          }}
-        >
-          Carregando…
-        </div>
+      {chartData.length === 0 ? (
+        <DashboardTaticoDataState isLoading={isLoading} isEmpty />
       ) : (
         <ResponsiveContainer width="100%" height={280}>
           <LineChart

--- a/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-priority-chart.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-priority-chart.tsx
@@ -17,6 +17,7 @@ import type {
   SlaDashboardGranularity,
 } from '@/http/tickets/get-sla-dashboard'
 
+import { DashboardTaticoDataState } from '../../components/dashboard-tatico-data-state'
 import { DemandVolumeChartGranularity } from '../../volume/components/demand-volume-chart-granularity'
 import { formatPeriodLabel } from '../../volume/components/demand-volume-period-label'
 import styles from '../../volume/components/demand-volume-top.module.css'
@@ -26,6 +27,7 @@ interface SlaMetricsPriorityChartProps {
   granularity: SlaDashboardGranularity
   onGranularityChange: (granularity: SlaDashboardGranularity) => void
   isLoading: boolean
+  isAvailable: boolean
 }
 
 const SERIES = [
@@ -63,13 +65,14 @@ export function SlaMetricsPriorityChart({
   granularity,
   onGranularityChange,
   isLoading,
+  isAvailable,
 }: SlaMetricsPriorityChartProps) {
   const chartData = data.map((item) => ({
     ...item,
     label: formatPeriodLabel(item.period_label, granularity),
   }))
 
-  if (!isLoading && chartData.length === 0) {
+  if (!isLoading && !isAvailable) {
     return null
   }
 
@@ -93,19 +96,8 @@ export function SlaMetricsPriorityChart({
         />
       </div>
 
-      {isLoading && chartData.length === 0 ? (
-        <div
-          style={{
-            height: '280px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            color: '#97a2ab',
-            fontSize: '14px',
-          }}
-        >
-          Carregando…
-        </div>
+      {chartData.length === 0 ? (
+        <DashboardTaticoDataState isLoading={isLoading} isEmpty />
       ) : (
         <ResponsiveContainer width="100%" height={280}>
           <LineChart

--- a/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-sla-table.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-sla-table.tsx
@@ -4,6 +4,7 @@ import type { CSSProperties } from 'react'
 
 import type { SlaPerformanceRowOut } from '@/http/tickets/get-sla-dashboard'
 
+import { DashboardTaticoDataState } from '../../components/dashboard-tatico-data-state'
 import { formatPeriodLabel } from '../../volume/components/demand-volume-period-label'
 import { formatSlaPerformanceRowLabel } from './sla-metrics-filter-utils'
 
@@ -13,6 +14,7 @@ interface SlaMetricsSlaTableProps {
   rows: SlaPerformanceRowOut[]
   periodLabels: string[]
   isLoading: boolean
+  isAvailable: boolean
   formatRowLabel?: (label: string) => string
 }
 
@@ -89,13 +91,14 @@ export function SlaMetricsSlaTable({
   rows,
   periodLabels,
   isLoading,
+  isAvailable,
   formatRowLabel = formatSlaPerformanceRowLabel,
 }: SlaMetricsSlaTableProps) {
   const formattedHeaders = periodLabels.map((pl) =>
     formatPeriodLabel(pl, 'monthly'),
   )
 
-  if (!isLoading && rows.length === 0) {
+  if (!isLoading && !isAvailable) {
     return null
   }
 
@@ -119,19 +122,8 @@ export function SlaMetricsSlaTable({
         {title}
       </h2>
 
-      {isLoading && rows.length === 0 ? (
-        <div
-          style={{
-            height: '120px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            color: '#97a2ab',
-            fontSize: '14px',
-          }}
-        >
-          Carregando…
-        </div>
+      {rows.length === 0 ? (
+        <DashboardTaticoDataState isLoading={isLoading} isEmpty height={120} />
       ) : (
         <>
           <div style={{ overflowX: 'auto' }}>

--- a/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-view.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-view.tsx
@@ -209,6 +209,7 @@ export function SlaMetricsView() {
         granularity={generalGranularity}
         onGranularityChange={setGeneralGranularity}
         isLoading={isFetching}
+        isAvailable={data?.avg_resolution_time_general != null}
       />
 
       <SlaMetricsPriorityChart
@@ -216,6 +217,7 @@ export function SlaMetricsView() {
         granularity={priorityGranularity}
         onGranularityChange={setPriorityGranularity}
         isLoading={isFetching}
+        isAvailable={data?.avg_resolution_time_by_priority != null}
       />
 
       <SlaMetricsSlaTable
@@ -224,6 +226,7 @@ export function SlaMetricsView() {
         rows={slaPerformanceByPriorityRows}
         periodLabels={slaTablePeriodLabels}
         isLoading={isFetching}
+        isAvailable={data?.sla_performance_by_priority != null}
       />
 
       <SlaMetricsSlaTable
@@ -232,6 +235,7 @@ export function SlaMetricsView() {
         rows={slaPerformanceByServiceRows}
         periodLabels={slaTablePeriodLabels}
         isLoading={isFetching}
+        isAvailable={data?.sla_performance_by_service != null}
         formatRowLabel={(label) => label}
       />
 
@@ -240,6 +244,7 @@ export function SlaMetricsView() {
         granularity={mediaGranularity}
         onGranularityChange={setMediaGranularity}
         isLoading={isFetching}
+        isAvailable={data?.delivery_time_for_media_relevant != null}
       />
     </div>
   )

--- a/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-open-tickets-chart.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-open-tickets-chart.tsx
@@ -14,6 +14,7 @@ import {
 
 import type { OpenTicketsByTeamItemOut } from '@/http/tickets/get-operational-view'
 
+import { DashboardTaticoDataState } from '../../components/dashboard-tatico-data-state'
 import {
   getOpenTicketsStatusSeries,
   type OpenTicketsTeamBarPoint,
@@ -50,7 +51,7 @@ export function OperationalViewOpenTicketsChart({
     [openTicketsByTeam],
   )
 
-  if (!isLoading && chartData.length === 0) {
+  if (!isLoading && openTicketsByTeam == null) {
     return null
   }
 
@@ -68,8 +69,8 @@ export function OperationalViewOpenTicketsChart({
         Chamados em aberto por equipe
       </h2>
 
-      {isLoading && chartData.length === 0 ? (
-        <ChartMessage message="Carregando…" />
+      {chartData.length === 0 ? (
+        <DashboardTaticoDataState isLoading={isLoading} isEmpty />
       ) : (
         <ResponsiveContainer width="100%" height={280}>
           <BarChart
@@ -145,23 +146,6 @@ export function OperationalViewOpenTicketsChart({
           </BarChart>
         </ResponsiveContainer>
       )}
-    </div>
-  )
-}
-
-function ChartMessage({ message }: { message: string }) {
-  return (
-    <div
-      style={{
-        height: '280px',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        color: '#97a2ab',
-        fontSize: '14px',
-      }}
-    >
-      {message}
     </div>
   )
 }

--- a/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-sla-table.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-sla-table.tsx
@@ -4,12 +4,14 @@ import type { CSSProperties } from 'react'
 
 import type { SlaPerformanceByTeamRowOut } from '@/http/tickets/get-operational-view'
 
+import { DashboardTaticoDataState } from '../../components/dashboard-tatico-data-state'
 import { formatPeriodLabel } from '../../volume/components/demand-volume-period-label'
 
 interface OperationalViewSlaTableProps {
   rows: SlaPerformanceByTeamRowOut[]
   periodLabels: string[]
   isLoading: boolean
+  isAvailable: boolean
 }
 
 type CellVariant = 'above' | 'below' | 'neutral'
@@ -83,12 +85,13 @@ export function OperationalViewSlaTable({
   rows,
   periodLabels,
   isLoading,
+  isAvailable,
 }: OperationalViewSlaTableProps) {
   const formattedHeaders = periodLabels.map((pl) =>
     formatPeriodLabel(pl, 'monthly'),
   )
 
-  if (!isLoading && rows.length === 0) {
+  if (!isLoading && !isAvailable) {
     return null
   }
 
@@ -112,8 +115,8 @@ export function OperationalViewSlaTable({
         Desempenho de SLA por Equipe
       </h2>
 
-      {isLoading && rows.length === 0 ? (
-        <LoadingState />
+      {rows.length === 0 ? (
+        <DashboardTaticoDataState isLoading={isLoading} isEmpty height={120} />
       ) : (
         <>
           <div style={{ overflowX: 'auto' }}>
@@ -202,23 +205,6 @@ export function OperationalViewSlaTable({
           </div>
         </>
       )}
-    </div>
-  )
-}
-
-function LoadingState() {
-  return (
-    <div
-      style={{
-        height: '120px',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        color: '#97a2ab',
-        fontSize: '14px',
-      }}
-    >
-      Carregando…
     </div>
   )
 }

--- a/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-team-line-chart.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-team-line-chart.tsx
@@ -14,6 +14,7 @@ import {
 
 import type { OperationalViewGranularity } from '@/http/tickets/get-operational-view'
 
+import { DashboardTaticoDataState } from '../../components/dashboard-tatico-data-state'
 import { DemandVolumeChartGranularity } from '../../volume/components/demand-volume-chart-granularity'
 import styles from '../../volume/components/demand-volume-top.module.css'
 import type { TeamLineChartPoint } from './operational-view-chart-utils'
@@ -26,6 +27,7 @@ interface OperationalViewTeamLineChartProps {
   granularity: OperationalViewGranularity
   onGranularityChange: (granularity: OperationalViewGranularity) => void
   isLoading: boolean
+  isAvailable: boolean
   valueFormatter?: (value: number) => string
 }
 
@@ -49,10 +51,11 @@ export function OperationalViewTeamLineChart({
   granularity,
   onGranularityChange,
   isLoading,
+  isAvailable,
   valueFormatter = (value) =>
     value.toLocaleString('pt-BR', { maximumFractionDigits: 0 }),
 }: OperationalViewTeamLineChartProps) {
-  if (!isLoading && chartData.length === 0) {
+  if (!isLoading && !isAvailable) {
     return null
   }
 
@@ -65,8 +68,8 @@ export function OperationalViewTeamLineChart({
         isLoading={isLoading}
       />
 
-      {isLoading && chartData.length === 0 ? (
-        <LoadingState />
+      {chartData.length === 0 ? (
+        <DashboardTaticoDataState isLoading={isLoading} isEmpty />
       ) : (
         <ResponsiveContainer width="100%" height={280}>
           <LineChart
@@ -169,23 +172,6 @@ function ChartHeader({
         onChange={onGranularityChange}
         disabled={isLoading}
       />
-    </div>
-  )
-}
-
-function LoadingState() {
-  return (
-    <div
-      style={{
-        height: '280px',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        color: '#97a2ab',
-        fontSize: '14px',
-      }}
-    >
-      Carregando…
     </div>
   )
 }

--- a/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-view.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-view.tsx
@@ -216,6 +216,7 @@ export function OperationalViewView() {
         granularity={closedVolumeGranularity}
         onGranularityChange={setClosedVolumeGranularity}
         isLoading={isFetching}
+        isAvailable={data?.closed_volume_by_team != null}
       />
 
       <OperationalViewTeamLineChart
@@ -225,6 +226,7 @@ export function OperationalViewView() {
         granularity={resolutionTimeGranularity}
         onGranularityChange={setResolutionTimeGranularity}
         isLoading={isFetching}
+        isAvailable={data?.avg_resolution_time_by_team != null}
         valueFormatter={(value) =>
           `${value.toLocaleString('pt-BR', {
             minimumFractionDigits: 1,
@@ -237,6 +239,7 @@ export function OperationalViewView() {
         rows={slaPerformanceByTeamRows}
         periodLabels={slaTablePeriodLabels}
         isLoading={isFetching}
+        isAvailable={data?.sla_performance_by_team != null}
       />
     </div>
   )

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-matrix-table.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-matrix-table.tsx
@@ -6,6 +6,7 @@ import type {
   MatrixRowOut,
 } from '@/http/tickets/get-demand-volume'
 
+import { DashboardTaticoDataState } from '../../components/dashboard-tatico-data-state'
 import { formatPeriodLabel } from './demand-volume-period-label'
 
 interface DemandVolumeMatrixTablePagination {
@@ -21,6 +22,7 @@ interface DemandVolumeMatrixTableProps {
   rows: MatrixRowOut[]
   periodLabels: string[]
   isLoading: boolean
+  isAvailable: boolean
   pagination?: DemandVolumeMatrixTablePagination
 }
 
@@ -109,13 +111,14 @@ export function DemandVolumeMatrixTable({
   rows,
   periodLabels,
   isLoading,
+  isAvailable,
   pagination,
 }: DemandVolumeMatrixTableProps) {
   const formattedHeaders = periodLabels.map((pl) =>
     formatPeriodLabel(pl, MATRIX_GRANULARITY),
   )
 
-  if (!isLoading && rows.length === 0) {
+  if (!isLoading && !isAvailable) {
     return null
   }
 
@@ -139,19 +142,8 @@ export function DemandVolumeMatrixTable({
         {title}
       </h2>
 
-      {isLoading && rows.length === 0 ? (
-        <div
-          style={{
-            height: '120px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            color: '#97a2ab',
-            fontSize: '14px',
-          }}
-        >
-          Carregando…
-        </div>
+      {rows.length === 0 ? (
+        <DashboardTaticoDataState isLoading={isLoading} isEmpty height={120} />
       ) : (
         <>
           <div style={{ overflowX: 'auto' }}>

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-media-chart.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-media-chart.tsx
@@ -16,6 +16,7 @@ import type {
   PeriodValueItemOut,
 } from '@/http/tickets/get-demand-volume'
 
+import { DashboardTaticoDataState } from '../../components/dashboard-tatico-data-state'
 import { DemandVolumeChartGranularity } from './demand-volume-chart-granularity'
 import { formatPeriodLabel } from './demand-volume-period-label'
 import styles from './demand-volume-top.module.css'
@@ -25,6 +26,7 @@ interface DemandVolumeMediaChartProps {
   granularity: DemandVolumeGranularity
   onGranularityChange: (granularity: DemandVolumeGranularity) => void
   isLoading: boolean
+  isAvailable: boolean
 }
 
 const CHART_COLORS = {
@@ -39,13 +41,14 @@ export function DemandVolumeMediaChart({
   granularity,
   onGranularityChange,
   isLoading,
+  isAvailable,
 }: DemandVolumeMediaChartProps) {
   const chartData = data.map((item) => ({
     ...item,
     label: formatPeriodLabel(item.period_label, granularity),
   }))
 
-  if (!isLoading && chartData.length === 0) {
+  if (!isLoading && !isAvailable) {
     return null
   }
 
@@ -76,19 +79,8 @@ export function DemandVolumeMediaChart({
         />
       </div>
 
-      {isLoading && chartData.length === 0 ? (
-        <div
-          style={{
-            height: '280px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            color: '#97a2ab',
-            fontSize: '14px',
-          }}
-        >
-          Carregando…
-        </div>
+      {chartData.length === 0 ? (
+        <DashboardTaticoDataState isLoading={isLoading} isEmpty />
       ) : (
         <ResponsiveContainer width="100%" height={280}>
           <LineChart

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-total-chart.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-total-chart.tsx
@@ -16,6 +16,7 @@ import type {
   PeriodVolumeItemOut,
 } from '@/http/tickets/get-demand-volume'
 
+import { DashboardTaticoDataState } from '../../components/dashboard-tatico-data-state'
 import { DemandVolumeChartGranularity } from './demand-volume-chart-granularity'
 import { formatPeriodLabel } from './demand-volume-period-label'
 import styles from './demand-volume-top.module.css'
@@ -25,6 +26,7 @@ interface DemandVolumeTotalChartProps {
   granularity: DemandVolumeGranularity
   onGranularityChange: (granularity: DemandVolumeGranularity) => void
   isLoading: boolean
+  isAvailable: boolean
 }
 
 const SERIES = [
@@ -43,13 +45,14 @@ export function DemandVolumeTotalChart({
   granularity,
   onGranularityChange,
   isLoading,
+  isAvailable,
 }: DemandVolumeTotalChartProps) {
   const chartData = data.map((item) => ({
     ...item,
     label: formatPeriodLabel(item.period_label, granularity),
   }))
 
-  if (!isLoading && chartData.length === 0) {
+  if (!isLoading && !isAvailable) {
     return null
   }
 
@@ -80,19 +83,8 @@ export function DemandVolumeTotalChart({
         />
       </div>
 
-      {isLoading && chartData.length === 0 ? (
-        <div
-          style={{
-            height: '280px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            color: '#97a2ab',
-            fontSize: '14px',
-          }}
-        >
-          Carregando…
-        </div>
+      {chartData.length === 0 ? (
+        <DashboardTaticoDataState isLoading={isLoading} isEmpty />
       ) : (
         <ResponsiveContainer width="100%" height={280}>
           <LineChart

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-urgency-chart.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-urgency-chart.tsx
@@ -16,6 +16,7 @@ import type {
   PeriodUrgencyItemOut,
 } from '@/http/tickets/get-demand-volume'
 
+import { DashboardTaticoDataState } from '../../components/dashboard-tatico-data-state'
 import { DemandVolumeChartGranularity } from './demand-volume-chart-granularity'
 import { formatPeriodLabel } from './demand-volume-period-label'
 import styles from './demand-volume-top.module.css'
@@ -25,6 +26,7 @@ interface DemandVolumeUrgencyChartProps {
   granularity: DemandVolumeGranularity
   onGranularityChange: (granularity: DemandVolumeGranularity) => void
   isLoading: boolean
+  isAvailable: boolean
 }
 
 const SERIES = [
@@ -45,13 +47,14 @@ export function DemandVolumeUrgencyChart({
   granularity,
   onGranularityChange,
   isLoading,
+  isAvailable,
 }: DemandVolumeUrgencyChartProps) {
   const chartData = data.map((item) => ({
     ...item,
     label: formatPeriodLabel(item.period_label, granularity),
   }))
 
-  if (!isLoading && chartData.length === 0) {
+  if (!isLoading && !isAvailable) {
     return null
   }
 
@@ -82,19 +85,8 @@ export function DemandVolumeUrgencyChart({
         />
       </div>
 
-      {isLoading && chartData.length === 0 ? (
-        <div
-          style={{
-            height: '280px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            color: '#97a2ab',
-            fontSize: '14px',
-          }}
-        >
-          Carregando…
-        </div>
+      {chartData.length === 0 ? (
+        <DashboardTaticoDataState isLoading={isLoading} isEmpty />
       ) : (
         <ResponsiveContainer width="100%" height={280}>
           <LineChart

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-view.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-view.tsx
@@ -232,6 +232,7 @@ export function DemandVolumeView() {
         granularity={totalCallVolumeGranularity}
         onGranularityChange={setTotalCallVolumeGranularity}
         isLoading={isFetching}
+        isAvailable={data?.total_call_volume != null}
       />
 
       <DemandVolumeUrgencyChart
@@ -239,6 +240,7 @@ export function DemandVolumeView() {
         granularity={urgencyGranularity}
         onGranularityChange={setUrgencyGranularity}
         isLoading={isFetching}
+        isAvailable={data?.closed_calls_by_urgency != null}
       />
 
       <DemandVolumeMatrixTable
@@ -246,6 +248,7 @@ export function DemandVolumeView() {
         rows={closedCallsByNature}
         periodLabels={matrixPeriodLabels}
         isLoading={isFetching}
+        isAvailable={data?.closed_calls_by_nature != null}
         columnHeader="NATUREZA"
       />
 
@@ -254,6 +257,7 @@ export function DemandVolumeView() {
         rows={closedCallsByService}
         periodLabels={matrixPeriodLabels}
         isLoading={isFetching}
+        isAvailable={data?.closed_calls_by_service != null}
         columnHeader="SERVIÇO"
       />
 
@@ -262,6 +266,7 @@ export function DemandVolumeView() {
         granularity={mediaGranularity}
         onGranularityChange={setMediaGranularity}
         isLoading={isFetching}
+        isAvailable={data?.media_relevant_calls != null}
       />
 
       <DemandVolumeMatrixTable
@@ -269,6 +274,7 @@ export function DemandVolumeView() {
         rows={closedCallsByRequester}
         periodLabels={matrixPeriodLabels}
         isLoading={isFetching}
+        isAvailable={data?.closed_calls_by_requester != null}
         columnHeader="DEMANDANTE"
         pagination={
           data?.closed_calls_by_requester &&


### PR DESCRIPTION
## Description

This branch consolidates improvements to the **Demandas (Tickets)** module focused on usability, robustness, and API alignment.

### 1. Searchable, paginated demandant selection
- New HTTP client `search-operations.ts` with paginated search via `GET /operations`.
- Replaced the static `Select` (limited to 100 items) with a **Popover + Command** UI featuring debounced search (350ms), infinite pagination ("Load more"), and a "Clear selection" action.
- Applied in:
  - Ticket creation (`ticket-create-form`, `use-create-controller`)
  - Email-to-ticket conversion (`email-to-ticket-view`)
  - Requester tab on ticket detail (`ticket-detail-tab-solicitante`)
- `tickets-dashboard-filters.ts` updated to use the same paginated endpoint.

### 2. Attachment upload panel (Services tab)
- Refactored upload tracking from a simple filename list to a **queue with per-item status** (`queued`, `preparing`, `uploading`, `finalizing`, `done`, `error`).
- `GcsUploadProgress` now includes `pendingAttachmentId` to track each attachment individually.
- New visual panel with header ("X of Y completed"), status icons, descriptive labels, and a progress bar for GCS uploads.
- More granular error handling: failed items remain visible in the panel.

### 3. Official letter number — flexibility
- Removed `maskNumeroOficio` and `normalizeNumeroOficio` from `string-formatters.ts`.
- Field accepts free text (no automatic mask or blur normalization).
- Limit increased from **10 → 50** characters.
- Validation updated to accept lowercase letters: `/^[A-Za-z0-9/]+$/`.

### 4. Services mapper fix
- `ticket-servicos-mapper.ts`: uses `(a.address ?? '').trim()` and `(c.camera_code ?? '').trim()` to avoid errors when values are `null`.

### 5. Teams and profiles
- New **"Auxiliar de Adjunto"** role added across teams, profiles, workflow, and screen permissions (with dedicated CSS badge).
- Removed the **"Visible islands"** field (`islands_ids`) from the team member form and listing for Island Leaders.

### 6. Tickets dashboard
- New **"Em aberto" (Open)** card on the general list, consuming the `open` field from the dashboard response.

## Related Issue
<!--- Put the issue link here if you are fixing an issue -->

## Motivation and Context

The demandas module needed practical adjustments identified in real-world usage:

- The fixed demandant (operations) list did not scale — users need to **search** across hundreds of records.
- The upload panel did not provide clear per-file feedback during long uploads (videos/ZIP via GCS).
- The rigid official letter number mask (`XXXXX/YYYY`) blocked valid formats used in practice; the 10-character limit was insufficient.
- `null` values in service addresses/cameras caused save failures.
- The "Auxiliar de Adjunto" role and visible-islands simplification align the frontend with updated business rules.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- [ ] Manual: demandant search in ticket creation, email conversion, and Requester tab
- [ ] Manual: attachment upload on Services tab (including video/ZIP via GCS) and upload progress panel
- [ ] Manual: official letter number with varied formats and 50-character limit
- [ ] Manual: saving services with empty or null addresses/cameras
- [ ] Manual: team member create/edit with "Auxiliar de Adjunto" role
- [ ] Manual: "Em aberto" card on tickets dashboard
- [ ] Automated tests (Jest) — not run during this review

## Screenshots (if appropriate):

## Types of changes

- [x] fix: used when there is correction of errors that are generating bugs in the system.
- [x] feat: