### PR TITLE
Feat/demandas to main

### DIFF
--- a/.cursor/commands/pr.md
+++ b/.cursor/commands/pr.md
@@ -1,0 +1,47 @@
+Review the current branch changes and prepare a summary of them.
+Instructions
+You are reviewing the current branch. Follow these steps:
+Run `git status` and `git diff` to understand the current branch changes
+Check if the current branch tracks a remote branch and if it needs to be pushed
+Run `git log` and `git diff [base-branch]...HEAD` to understand all commits in this branch
+Analyze ALL changes to draft a comprehensive change summary
+
+Summary Template
+```markdown
+## Description
+<!--- Describe your changes in detail -->
+
+## Related Issue
+<!--- Put the issue link here if you are fixing an issue -->
+## Motivation and Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How has this been tested?
+<!--- Please describe in detail how you tested your changes. -->
+<!--- Include details of your testing environment, tests ran to see how -->
+<!--- your change affects other areas of the code, etc. -->
+
+## Screenshots (if appropriate):
+
+## Types of changes
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
+
+- [ ] fix: used when there is correction of errors that are generating bugs in the system.
+- [ ] feat: indicates the development of a new feature for the project.
+- [ ] perf: indicates a change that improved system performance.
+- [ ] test: indicates any type of creation or change of test codes.
+- [ ] refactor: used when there is a code refactoring that does not have any type of impact on the system's business logic/rules.
+- [ ] style: used when there are formatting and code style changes that do not alter the system in any way.
+- [ ] chore: indicates changes to the project that do not affect the system or test files.
+- [ ] docs: used when there are changes to the project documentation.
+- [ ] build: used to indicate changes that affect the project's build process or external dependencies.
+- [ ] ci: used for changes to CI configuration files.
+- [ ] revert: indicates the revert of a previous commit
+
+## Checklist:
+- [ ] My code follows the code style of this project.
+- [ ] My change requires a change to the documentation.
+- [ ] I have updated the documentation accordingly.
+- [ ] I have added tests to cover my changes.
+- [ ] All new and existing tests passed.

--- a/k8s/prod/resources.yaml
+++ b/k8s/prod/resources.yaml
@@ -81,6 +81,7 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
+    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
     cert-manager.io/cluster-issuer: "letsencrypt"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
 spec:

--- a/k8s/staging/resources.yaml
+++ b/k8s/staging/resources.yaml
@@ -81,6 +81,7 @@ metadata:
     nginx.ingress.kubernetes.io/rewrite-target: /
     nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
     nginx.ingress.kubernetes.io/proxy-buffers-number: "8"
+    nginx.ingress.kubernetes.io/proxy-body-size: "50m"
     cert-manager.io/cluster-issuer: "letsencrypt"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
 spec:

--- a/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-servicos.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-servicos.tsx
@@ -28,7 +28,6 @@ import { Progress } from '@/components/ui/progress'
 import type { TicketAttachmentOut } from '@/http/tickets/ticket-attachments'
 import {
   getTicketServicos,
-  replaceTicketServicos,
   type TicketServicosOut,
 } from '@/http/tickets/ticket-servicos'
 import { getApiErrorMessage } from '@/utils/error-handlers'
@@ -47,7 +46,10 @@ import {
   ticketServicosToReplacePayload,
 } from '../ticket-servicos-mapper'
 import type { GcsUploadProgress } from '../ticket-servicos-save'
-import { buildTicketServicosSaveRequest } from '../ticket-servicos-save'
+import {
+  buildTicketServicosSaveRequest,
+  executeTicketServicosSave,
+} from '../ticket-servicos-save'
 import type { TicketDetailTabHandle } from './ticket-detail-tab-handle'
 import { usesGcsSignedUrlUpload } from './ticket-gcs-upload'
 import {
@@ -182,6 +184,10 @@ function buildUploadQueue(
   return items
 }
 
+function multipartQueueIds(queue: UploadQueueItem[]): string[] {
+  return queue.filter((item) => !item.usesGcs).map((item) => item.id)
+}
+
 function gcsPhaseToQueueStatus(
   phase: GcsUploadProgress['phase'],
   uploaded: number,
@@ -298,12 +304,16 @@ export const TicketDetailTabServicos = forwardRef<TicketDetailTabHandle, Props>(
     }, [])
 
     const replaceMutation = useMutation({
-      mutationFn: ({
-        payload,
-        files,
-        attachmentMetadata,
-      }: Awaited<ReturnType<typeof buildTicketServicosSaveRequest>>) =>
-        replaceTicketServicos(ticketId, payload, files, attachmentMetadata),
+      mutationFn: (
+        args: Awaited<ReturnType<typeof buildTicketServicosSaveRequest>> & {
+          onMultipartFileDone?: (fileIndex: number) => void
+        },
+      ) => {
+        const { onMultipartFileDone, ...saveRequest } = args
+        return executeTicketServicosSave(ticketId, saveRequest, {
+          onMultipartFileDone,
+        })
+      },
     })
 
     const rows = useMemo(() => {
@@ -458,18 +468,38 @@ export const TicketDetailTabServicos = forwardRef<TicketDetailTabHandle, Props>(
         }
 
         if (saveRequest.files.length > 0) {
+          const firstMultipartId = multipartQueueIds(initialQueue)[0]
           setUploadQueue((prev) =>
             prev.map((item) =>
-              !item.usesGcs && item.status === 'queued'
+              item.id === firstMultipartId
                 ? { ...item, status: 'uploading' }
                 : item,
             ),
           )
         }
 
+        const multipartIds = multipartQueueIds(initialQueue)
         let saved: TicketServicosOut
         try {
-          saved = await replaceMutation.mutateAsync(saveRequest)
+          saved = await replaceMutation.mutateAsync({
+            ...saveRequest,
+            onMultipartFileDone: (fileIndex) => {
+              setUploadQueue((prev) =>
+                prev.map((item) => {
+                  if (item.id === multipartIds[fileIndex]) {
+                    return { ...item, status: 'done', uploaded: item.total }
+                  }
+                  if (
+                    fileIndex + 1 < multipartIds.length &&
+                    item.id === multipartIds[fileIndex + 1]
+                  ) {
+                    return { ...item, status: 'uploading' }
+                  }
+                  return item
+                }),
+              )
+            },
+          })
         } catch (err: unknown) {
           setUploadQueue((prev) =>
             prev.map((item) =>

--- a/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-servicos.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-servicos.tsx
@@ -28,6 +28,7 @@ import { Progress } from '@/components/ui/progress'
 import type { TicketAttachmentOut } from '@/http/tickets/ticket-attachments'
 import {
   getTicketServicos,
+  replaceTicketServicos,
   type TicketServicosOut,
 } from '@/http/tickets/ticket-servicos'
 import { getApiErrorMessage } from '@/utils/error-handlers'
@@ -46,10 +47,7 @@ import {
   ticketServicosToReplacePayload,
 } from '../ticket-servicos-mapper'
 import type { GcsUploadProgress } from '../ticket-servicos-save'
-import {
-  buildTicketServicosSaveRequest,
-  executeTicketServicosSave,
-} from '../ticket-servicos-save'
+import { buildTicketServicosSaveRequest } from '../ticket-servicos-save'
 import type { TicketDetailTabHandle } from './ticket-detail-tab-handle'
 import { usesGcsSignedUrlUpload } from './ticket-gcs-upload'
 import {
@@ -184,10 +182,6 @@ function buildUploadQueue(
   return items
 }
 
-function multipartQueueIds(queue: UploadQueueItem[]): string[] {
-  return queue.filter((item) => !item.usesGcs).map((item) => item.id)
-}
-
 function gcsPhaseToQueueStatus(
   phase: GcsUploadProgress['phase'],
   uploaded: number,
@@ -304,16 +298,12 @@ export const TicketDetailTabServicos = forwardRef<TicketDetailTabHandle, Props>(
     }, [])
 
     const replaceMutation = useMutation({
-      mutationFn: (
-        args: Awaited<ReturnType<typeof buildTicketServicosSaveRequest>> & {
-          onMultipartFileDone?: (fileIndex: number) => void
-        },
-      ) => {
-        const { onMultipartFileDone, ...saveRequest } = args
-        return executeTicketServicosSave(ticketId, saveRequest, {
-          onMultipartFileDone,
-        })
-      },
+      mutationFn: ({
+        payload,
+        files,
+        attachmentMetadata,
+      }: Awaited<ReturnType<typeof buildTicketServicosSaveRequest>>) =>
+        replaceTicketServicos(ticketId, payload, files, attachmentMetadata),
     })
 
     const rows = useMemo(() => {
@@ -468,38 +458,18 @@ export const TicketDetailTabServicos = forwardRef<TicketDetailTabHandle, Props>(
         }
 
         if (saveRequest.files.length > 0) {
-          const firstMultipartId = multipartQueueIds(initialQueue)[0]
           setUploadQueue((prev) =>
             prev.map((item) =>
-              item.id === firstMultipartId
+              !item.usesGcs && item.status === 'queued'
                 ? { ...item, status: 'uploading' }
                 : item,
             ),
           )
         }
 
-        const multipartIds = multipartQueueIds(initialQueue)
         let saved: TicketServicosOut
         try {
-          saved = await replaceMutation.mutateAsync({
-            ...saveRequest,
-            onMultipartFileDone: (fileIndex) => {
-              setUploadQueue((prev) =>
-                prev.map((item) => {
-                  if (item.id === multipartIds[fileIndex]) {
-                    return { ...item, status: 'done', uploaded: item.total }
-                  }
-                  if (
-                    fileIndex + 1 < multipartIds.length &&
-                    item.id === multipartIds[fileIndex + 1]
-                  ) {
-                    return { ...item, status: 'uploading' }
-                  }
-                  return item
-                }),
-              )
-            },
-          })
+          saved = await replaceMutation.mutateAsync(saveRequest)
         } catch (err: unknown) {
           setUploadQueue((prev) =>
             prev.map((item) =>

--- a/src/app/(app)/demandas/[ticketId]/ticket-servicos-save.ts
+++ b/src/app/(app)/demandas/[ticketId]/ticket-servicos-save.ts
@@ -8,7 +8,10 @@ import {
   resolveGcsSessionUri,
 } from '@/http/tickets/ticket-attachments'
 import { gcsResumableChunkedUpload } from '@/http/tickets/ticket-gcs-resumable'
-import type { TicketServicosOut } from '@/http/tickets/ticket-servicos'
+import {
+  replaceTicketServicos,
+  type TicketServicosOut,
+} from '@/http/tickets/ticket-servicos'
 import type { TicketServicesUpsertIn } from '@/http/tickets/ticket-servicos-types'
 import {
   createUploadSession,
@@ -27,7 +30,10 @@ import {
   pendingAttachmentAsUploadFile,
   type PendingServiceAttachment,
 } from './components/ticket-pending-attachment'
-import { ticketServicosToReplacePayload } from './ticket-servicos-mapper'
+import {
+  isLocalDraftServiceId,
+  ticketServicosToReplacePayload,
+} from './ticket-servicos-mapper'
 
 const SERVICE_KINDS = [
   'plate_search',
@@ -91,7 +97,14 @@ function buildRowRefById(draft: TicketServicosOut): Map<string, ServiceRowRef> {
 function serviceScopeMetadata(
   kind: TicketServiceRowKind,
   index: number,
+  rowId: string,
 ): TicketAttachmentServiceScopeMetadataIn {
+  if (!isLocalDraftServiceId(rowId)) {
+    return {
+      service_type: kind,
+      service_id: rowId,
+    }
+  }
   return {
     service_type: kind,
     service_index: index + 1,
@@ -242,7 +255,7 @@ export async function buildTicketServicosSaveRequest(
     const rowRef = rowRefById.get(rowId)
     if (!rowRef) continue
 
-    const scope = serviceScopeMetadata(rowRef.kind, rowRef.index)
+    const scope = serviceScopeMetadata(rowRef.kind, rowRef.index, rowId)
 
     for (const item of pendingItems) {
       const file = pendingAttachmentAsUploadFile(item)
@@ -274,4 +287,44 @@ export async function buildTicketServicosSaveRequest(
   }
 
   return { payload, files, attachmentMetadata }
+}
+
+export type ExecuteTicketServicosSaveOptions = {
+  /** Chamado após cada ficheiro multipart enviado (índice base 0). */
+  onMultipartFileDone?: (fileIndex: number) => void
+}
+
+/**
+ * Executa o PUT de serviços. Vários anexos multipart (PDF, imagens) são enviados
+ * um a um para evitar 413 quando o proxy limita o tamanho do corpo da requisição.
+ */
+export async function executeTicketServicosSave(
+  ticketId: string,
+  saveRequest: TicketServicosSaveRequest,
+  options?: ExecuteTicketServicosSaveOptions,
+): Promise<TicketServicosOut> {
+  const { payload, files, attachmentMetadata } = saveRequest
+
+  if (files.length <= 1) {
+    return replaceTicketServicos(ticketId, payload, files, attachmentMetadata)
+  }
+
+  let lastResult!: TicketServicosOut
+
+  for (let i = 0; i < files.length; i++) {
+    // Reutiliza o payload original: a resposta intermédia do PUT pode não
+    // refletir a lista de serviços de forma compatível com service_index.
+    const requestPayload: TicketServicesUpsertIn =
+      i === 0 ? payload : { ...payload, attachment_completes: undefined }
+
+    lastResult = await replaceTicketServicos(
+      ticketId,
+      requestPayload,
+      [files[i]!],
+      [attachmentMetadata[i]!],
+    )
+    options?.onMultipartFileDone?.(i)
+  }
+
+  return lastResult
 }

--- a/src/app/(app)/demandas/[ticketId]/ticket-servicos-save.ts
+++ b/src/app/(app)/demandas/[ticketId]/ticket-servicos-save.ts
@@ -8,10 +8,7 @@ import {
   resolveGcsSessionUri,
 } from '@/http/tickets/ticket-attachments'
 import { gcsResumableChunkedUpload } from '@/http/tickets/ticket-gcs-resumable'
-import {
-  replaceTicketServicos,
-  type TicketServicosOut,
-} from '@/http/tickets/ticket-servicos'
+import type { TicketServicosOut } from '@/http/tickets/ticket-servicos'
 import type { TicketServicesUpsertIn } from '@/http/tickets/ticket-servicos-types'
 import {
   createUploadSession,
@@ -287,37 +284,4 @@ export async function buildTicketServicosSaveRequest(
   }
 
   return { payload, files, attachmentMetadata }
-}
-
-export type ExecuteTicketServicosSaveOptions = {
-  onMultipartFileDone?: (fileIndex: number) => void
-}
-
-export async function executeTicketServicosSave(
-  ticketId: string,
-  saveRequest: TicketServicosSaveRequest,
-  options?: ExecuteTicketServicosSaveOptions,
-): Promise<TicketServicosOut> {
-  const { payload, files, attachmentMetadata } = saveRequest
-
-  if (files.length <= 1) {
-    return replaceTicketServicos(ticketId, payload, files, attachmentMetadata)
-  }
-
-  let lastResult!: TicketServicosOut
-
-  for (let i = 0; i < files.length; i++) {
-    const requestPayload: TicketServicesUpsertIn =
-      i === 0 ? payload : { ...payload, attachment_completes: undefined }
-
-    lastResult = await replaceTicketServicos(
-      ticketId,
-      requestPayload,
-      [files[i]!],
-      [attachmentMetadata[i]!],
-    )
-    options?.onMultipartFileDone?.(i)
-  }
-
-  return lastResult
 }

--- a/src/app/(app)/demandas/[ticketId]/ticket-servicos-save.ts
+++ b/src/app/(app)/demandas/[ticketId]/ticket-servicos-save.ts
@@ -290,14 +290,9 @@ export async function buildTicketServicosSaveRequest(
 }
 
 export type ExecuteTicketServicosSaveOptions = {
-  /** Chamado após cada ficheiro multipart enviado (índice base 0). */
   onMultipartFileDone?: (fileIndex: number) => void
 }
 
-/**
- * Executa o PUT de serviços. Vários anexos multipart (PDF, imagens) são enviados
- * um a um para evitar 413 quando o proxy limita o tamanho do corpo da requisição.
- */
 export async function executeTicketServicosSave(
   ticketId: string,
   saveRequest: TicketServicosSaveRequest,
@@ -312,8 +307,6 @@ export async function executeTicketServicosSave(
   let lastResult!: TicketServicosOut
 
   for (let i = 0; i < files.length; i++) {
-    // Reutiliza o payload original: a resposta intermédia do PUT pode não
-    // refletir a lista de serviços de forma compatível com service_index.
     const requestPayload: TicketServicesUpsertIn =
       i === 0 ? payload : { ...payload, attachment_completes: undefined }
 


### PR DESCRIPTION
## Description

This branch consolidates improvements to the **Demandas (Tickets)** module focused on usability, robustness, and API alignment.

### 1. Searchable, paginated demandant selection
- New HTTP client `search-operations.ts` with paginated search via `GET /operations`.
- Replaced the static `Select` (limited to 100 items) with a **Popover + Command** UI featuring debounced search (350ms), infinite pagination ("Load more"), and a "Clear selection" action.
- Applied in:
  - Ticket creation (`ticket-create-form`, `use-create-controller`)
  - Email-to-ticket conversion (`email-to-ticket-view`)
  - Requester tab on ticket detail (`ticket-detail-tab-solicitante`)
- `tickets-dashboard-filters.ts` updated to use the same paginated endpoint.

### 2. Attachment upload panel (Services tab)
- Refactored upload tracking from a simple filename list to a **queue with per-item status** (`queued`, `preparing`, `uploading`, `finalizing`, `done`, `error`).
- `GcsUploadProgress` now includes `pendingAttachmentId` to track each attachment individually.
- New visual panel with header ("X of Y completed"), status icons, descriptive labels, and a progress bar for GCS uploads.
- More granular error handling: failed items remain visible in the panel.

### 3. Official letter number — flexibility
- Removed `maskNumeroOficio` and `normalizeNumeroOficio` from `string-formatters.ts`.
- Field accepts free text (no automatic mask or blur normalization).
- Limit increased from **10 → 50** characters.
- Validation updated to accept lowercase letters: `/^[A-Za-z0-9/]+$/`.

### 4. Services mapper fix
- `ticket-servicos-mapper.ts`: uses `(a.address ?? '').trim()` and `(c.camera_code ?? '').trim()` to avoid errors when values are `null`.

### 5. Teams and profiles
- New **"Auxiliar de Adjunto"** role added across teams, profiles, workflow, and screen permissions (with dedicated CSS badge).
- Removed the **"Visible islands"** field (`islands_ids`) from the team member form and listing for Island Leaders.

### 6. Tickets dashboard
- New **"Em aberto" (Open)** card on the general list, consuming the `open` field from the dashboard response.

## Related Issue
<!--- Put the issue link here if you are fixing an issue -->

## Motivation and Context

The demandas module needed practical adjustments identified in real-world usage:

- The fixed demandant (operations) list did not scale — users need to **search** across hundreds of records.
- The upload panel did not provide clear per-file feedback during long uploads (videos/ZIP via GCS).
- The rigid official letter number mask (`XXXXX/YYYY`) blocked valid formats used in practice; the 10-character limit was insufficient.
- `null` values in service addresses/cameras caused save failures.
- The "Auxiliar de Adjunto" role and visible-islands simplification align the frontend with updated business rules.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- [ ] Manual: demandant search in ticket creation, email conversion, and Requester tab
- [ ] Manual: attachment upload on Services tab (including video/ZIP via GCS) and upload progress panel
- [ ] Manual: official letter number with varied formats and 50-character limit
- [ ] Manual: saving services with empty or null addresses/cameras
- [ ] Manual: team member create/edit with "Auxiliar de Adjunto" role
- [ ] Manual: "Em aberto" card on tickets dashboard
- [ ] Automated tests (Jest) — not run during this review

## Screenshots (if appropriate):

## Types of changes

- [x] fix: used when there is correction of errors that are generating bugs in the system.
- [x] feat: