### PR TITLE
feat(ticket-servico-anexos): increase maximum file upload size to 20 MB

### DIFF
--- a/src/app/(app)/demandas/[ticketId]/components/ticket-servico-anexos.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-servico-anexos.tsx
@@ -55,7 +55,7 @@ import {
 
 export type { PendingServiceAttachment } from './ticket-pending-attachment'
 
-const MAX_MULTIPART_BYTES = 10 * 1024 * 1024
+const MAX_MULTIPART_BYTES = 20 * 1024 * 1024
 const MAX_GCS_UPLOAD_GB = 20
 const MAX_GCS_UPLOAD_BYTES = MAX_GCS_UPLOAD_GB * 1024 * 1024 * 1024
 const MULTIPART_ACCEPT = [
@@ -391,7 +391,7 @@ export function TicketServicoAnexos({
       const bad = otherFiles.filter((f) => !multipartFileAllowed(f))
       if (bad.length || otherFiles.length === 0) {
         toast.error(
-          'Só PDF, imagens (JPEG, PNG, GIF, WebP) ou Word (.doc), até 10 MB cada.',
+          'Só PDF, imagens (JPEG, PNG, GIF, WebP) ou Word (.doc), até 20 MB cada.',
         )
         e.target.value = ''
         return


### PR DESCRIPTION
## Description

This branch consolidates improvements to the **Demandas (Tickets)** module focused on usability, robustness, and API alignment.

### 1. Searchable, paginated demandant selection
- New HTTP client `search-operations.ts` with paginated search via `GET /operations`.
- Replaced the static `Select` (limited to 100 items) with a **Popover + Command** UI featuring debounced search (350ms), infinite pagination ("Load more"), and a "Clear selection" action.
- Applied in:
  - Ticket creation (`ticket-create-form`, `use-create-controller`)
  - Email-to-ticket conversion (`email-to-ticket-view`)
  - Requester tab on ticket detail (`ticket-detail-tab-solicitante`)
- `tickets-dashboard-filters.ts` updated to use the same paginated endpoint.

### 2. Attachment upload panel (Services tab)
- Refactored upload tracking from a simple filename list to a **queue with per-item status** (`queued`, `preparing`, `uploading`, `finalizing`, `done`, `error`).
- `GcsUploadProgress` now includes `pendingAttachmentId` to track each attachment individually.
- New visual panel with header ("X of Y completed"), status icons, descriptive labels, and a progress bar for GCS uploads.
- More granular error handling: failed items remain visible in the panel.

### 3. Official letter number — flexibility
- Removed `maskNumeroOficio` and `normalizeNumeroOficio` from `string-formatters.ts`.
- Field accepts free text (no automatic mask or blur normalization).
- Limit increased from **10 → 50** characters.
- Validation updated to accept lowercase letters: `/^[A-Za-z0-9/]+$/`.

### 4. Services mapper fix
- `ticket-servicos-mapper.ts`: uses `(a.address ?? '').trim()` and `(c.camera_code ?? '').trim()` to avoid errors when values are `null`.

### 5. Teams and profiles
- New **"Auxiliar de Adjunto"** role added across teams, profiles, workflow, and screen permissions (with dedicated CSS badge).
- Removed the **"Visible islands"** field (`islands_ids`) from the team member form and listing for Island Leaders.

### 6. Tickets dashboard
- New **"Em aberto" (Open)** card on the general list, consuming the `open` field from the dashboard response.

## Related Issue
<!--- Put the issue link here if you are fixing an issue -->

## Motivation and Context

The demandas module needed practical adjustments identified in real-world usage:

- The fixed demandant (operations) list did not scale — users need to **search** across hundreds of records.
- The upload panel did not provide clear per-file feedback during long uploads (videos/ZIP via GCS).
- The rigid official letter number mask (`XXXXX/YYYY`) blocked valid formats used in practice; the 10-character limit was insufficient.
- `null` values in service addresses/cameras caused save failures.
- The "Auxiliar de Adjunto" role and visible-islands simplification align the frontend with updated business rules.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

- [ ] Manual: demandant search in ticket creation, email conversion, and Requester tab
- [ ] Manual: attachment upload on Services tab (including video/ZIP via GCS) and upload progress panel
- [ ] Manual: official letter number with varied formats and 50-character limit
- [ ] Manual: saving services with empty or null addresses/cameras
- [ ] Manual: team member create/edit with "Auxiliar de Adjunto" role
- [ ] Manual: "Em aberto" card on tickets dashboard
- [ ] Automated tests (Jest) — not run during this review

## Screenshots (if appropriate):

## Types of changes

- [x] fix: used when there is correction of errors that are generating bugs in the system.
- [x] feat: