### PR TITLE
Feat/demandas to main

### DIFF
--- a/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-servicos.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-servicos.tsx
@@ -116,6 +116,23 @@ function computeCompletedServicoFieldErrors(
   return out
 }
 
+function attachmentFilenamesForRow(
+  draft: TicketServicosOut,
+  rowId: string,
+): string[] {
+  for (const kind of SERVICE_KINDS) {
+    const list = (draft[kind] ?? []) as {
+      id: string
+      attachments?: { filename: string }[]
+    }[]
+    const row = list.find((item) => item.id === rowId)
+    if (row) {
+      return (row.attachments ?? []).map((att) => att.filename)
+    }
+  }
+  return []
+}
+
 function buildRows(s: TicketServicosOut): RowMeta[] {
   const out: RowMeta[] = []
   const titleFor = (base: string, index: number, total: number) =>
@@ -336,13 +353,26 @@ export const TicketDetailTabServicos = forwardRef<TicketDetailTabHandle, Props>(
     const queuePendingFiles = useCallback(
       (rowId: string, files: File[]) => {
         if (!files.length) return
-        setPendingFilesByRowId((prev) => ({
-          ...prev,
-          [rowId]: [
-            ...(prev[rowId] ?? []),
-            ...createPendingServiceAttachments(files, internalNumber),
-          ],
-        }))
+        setPendingFilesByRowId((prev) => {
+          const existingPending = prev[rowId] ?? []
+          const existingFilenames = [
+            ...existingPending.map((item) => item.filename),
+            ...(draftRef.current
+              ? attachmentFilenamesForRow(draftRef.current, rowId)
+              : []),
+          ]
+          return {
+            ...prev,
+            [rowId]: [
+              ...existingPending,
+              ...createPendingServiceAttachments(
+                files,
+                internalNumber,
+                existingFilenames,
+              ),
+            ],
+          }
+        })
       },
       [internalNumber],
     )

--- a/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-servicos.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-servicos.tsx
@@ -175,7 +175,7 @@ function buildUploadQueue(
         total: file.size,
         uploaded: 0,
         status: 'queued',
-        usesGcs: usesGcsSignedUrlUpload(file),
+        usesGcs: usesGcsSignedUrlUpload(),
       })
     }
   }
@@ -300,10 +300,8 @@ export const TicketDetailTabServicos = forwardRef<TicketDetailTabHandle, Props>(
     const replaceMutation = useMutation({
       mutationFn: ({
         payload,
-        files,
-        attachmentMetadata,
       }: Awaited<ReturnType<typeof buildTicketServicosSaveRequest>>) =>
-        replaceTicketServicos(ticketId, payload, files, attachmentMetadata),
+        replaceTicketServicos(ticketId, payload),
     })
 
     const rows = useMemo(() => {
@@ -452,19 +450,9 @@ export const TicketDetailTabServicos = forwardRef<TicketDetailTabHandle, Props>(
             ),
           )
           toast.error(
-            'Não foi possível enviar um ou mais vídeos/ZIP. Tente novamente.',
+            'Não foi possível enviar um ou mais anexos. Tente novamente.',
           )
           return false
-        }
-
-        if (saveRequest.files.length > 0) {
-          setUploadQueue((prev) =>
-            prev.map((item) =>
-              !item.usesGcs && item.status === 'queued'
-                ? { ...item, status: 'uploading' }
-                : item,
-            ),
-          )
         }
 
         let saved: TicketServicosOut

--- a/src/app/(app)/demandas/[ticketId]/components/ticket-gcs-upload.ts
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-gcs-upload.ts
@@ -17,15 +17,15 @@ export function isVideoFile(file: File): boolean {
   return file.type.toLowerCase().startsWith('video/')
 }
 
-export function usesGcsSignedUrlUpload(file: File): boolean {
-  return isVideoFile(file) || isZipFile(file)
+export function usesGcsSignedUrlUpload(): boolean {
+  return true
 }
 
 export function resolveGcsUploadContentType(file: File): string {
   if (isZipFile(file)) {
     return file.type || DEFAULT_ZIP_CONTENT_TYPE
   }
-  return file.type || 'video/mp4'
+  return file.type || 'application/octet-stream'
 }
 
 export function isZipAttachment(att: TicketAttachmentOut): boolean {

--- a/src/app/(app)/demandas/[ticketId]/components/ticket-pending-attachment.ts
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-pending-attachment.ts
@@ -81,15 +81,53 @@ export function prefixPendingServiceFilename(
   return `${prefix}${filename}`
 }
 
+function filenameKey(name: string): string {
+  return name.toLowerCase()
+}
+
+/** Garante nome único entre `taken` (comparação case-insensitive). Atualiza `taken`. */
+export function ensureUniqueFilename(
+  candidate: string,
+  taken: Set<string>,
+): string {
+  if (!taken.has(filenameKey(candidate))) return candidate
+
+  const ext = getFilenameExtension(candidate)
+  const base = getFilenameBase(candidate)
+
+  for (let counter = 2; counter < 10_000; counter++) {
+    const next = buildFilenameWithExtension(`${base} (${counter})`, ext)
+    if (!taken.has(filenameKey(next))) return next
+  }
+
+  return buildFilenameWithExtension(
+    `${base} (${crypto.randomUUID().slice(0, 8)})`,
+    ext,
+  )
+}
+
 export function createPendingServiceAttachments(
   files: File[],
   internalNumber?: string | number | null,
+  existingFilenames: Iterable<string> = [],
 ): PendingServiceAttachment[] {
-  return files.map((file) => ({
-    id: crypto.randomUUID(),
-    file,
-    filename: prefixPendingServiceFilename(internalNumber, file.name),
-  }))
+  const taken = new Set(
+    Array.from(existingFilenames, (name) => filenameKey(name)),
+  )
+  const result: PendingServiceAttachment[] = []
+
+  for (const file of files) {
+    const prefixed = prefixPendingServiceFilename(internalNumber, file.name)
+    const unique = ensureUniqueFilename(prefixed, taken)
+    taken.add(filenameKey(unique))
+    result.push({
+      id: crypto.randomUUID(),
+      file,
+      filename: unique,
+    })
+  }
+
+  return result
 }
 
 /** File com o nome escolhido no rascunho, para envio multipart / vídeo. */

--- a/src/app/(app)/demandas/[ticketId]/components/ticket-servico-anexos.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-servico-anexos.tsx
@@ -27,7 +27,6 @@ import { Input } from '@/components/ui/input'
 import {
   downloadTicketAttachmentFile,
   fetchTicketAttachmentBlob,
-  fetchTicketServiceAttachmentBlob,
 } from '@/http/tickets/download-ticket-attachment'
 import {
   deleteTicketAttachment,
@@ -37,13 +36,14 @@ import {
   type TicketAttachmentServiceScopeMetadataIn,
 } from '@/http/tickets/ticket-attachments'
 import { isApiError } from '@/lib/api'
+import { downloadFile } from '@/utils/download-file'
 
 import styles from '../ticket-detail.module.css'
 import {
   gcsAttachmentLabel,
+  isVideoFile,
   isZipFile,
   usesGcsSignedUrlAttachment,
-  usesGcsSignedUrlUpload,
 } from './ticket-gcs-upload'
 import {
   getFilenameExtension,
@@ -55,17 +55,9 @@ import {
 
 export type { PendingServiceAttachment } from './ticket-pending-attachment'
 
-const MAX_MULTIPART_BYTES = 20 * 1024 * 1024
+const MAX_REGULAR_BYTES = 20 * 1024 * 1024
 const MAX_GCS_UPLOAD_GB = 20
 const MAX_GCS_UPLOAD_BYTES = MAX_GCS_UPLOAD_GB * 1024 * 1024 * 1024
-const MULTIPART_ACCEPT = [
-  'application/pdf',
-  'image/jpeg',
-  'image/png',
-  'image/gif',
-  'image/webp',
-  'application/msword',
-] as const
 
 const BLOCKED_DOCX = /\.docx$/i
 const BLOCKED_MOV = /\.mov$/i
@@ -76,16 +68,6 @@ function formatBytes(bytes: number): string {
   if (kb < 1024) return `${kb.toFixed(1)} KB`
   const mb = kb / 1024
   return `${mb.toFixed(1)} MB`
-}
-
-function multipartFileAllowed(file: File): boolean {
-  if (usesGcsSignedUrlUpload(file)) return false
-  if (file.size > MAX_MULTIPART_BYTES) return false
-  const t = file.type.toLowerCase()
-  if (MULTIPART_ACCEPT.includes(t as (typeof MULTIPART_ACCEPT)[number]))
-    return true
-  const n = file.name.toLowerCase()
-  return /\.(pdf|jpe?g|png|gif|webp|doc)$/i.test(n)
 }
 
 function invalidateAttachmentQueries(
@@ -152,6 +134,7 @@ export function TicketServicoAnexos({
 
   const [deletingId, setDeletingId] = useState<string | null>(null)
   const [viewingId, setViewingId] = useState<string | null>(null)
+  const [downloadingId, setDownloadingId] = useState<string | null>(null)
   const [videoCopyingId, setVideoCopyingId] = useState<string | null>(null)
   const [videoRefreshingId, setVideoRefreshingId] = useState<string | null>(
     null,
@@ -227,10 +210,26 @@ export function TicketServicoAnexos({
 
   const handleDownload = useCallback(
     async (att: TicketAttachmentOut) => {
+      if (serviceScope) {
+        setDownloadingId(att.id)
+        try {
+          const { signed_url: signedUrl } =
+            await getTicketServiceAttachmentPlaybackUrl(ticketId, att.id)
+          const response = await fetch(signedUrl)
+          if (!response.ok) throw new Error('download_failed')
+          const blob = await response.blob()
+          downloadFile(blob, att.filename)
+        } catch (err) {
+          toast.error(
+            getApiDetailUnless500(err) ?? 'Não foi possível baixar o anexo.',
+          )
+        } finally {
+          setDownloadingId(null)
+        }
+        return
+      }
       try {
-        await downloadTicketAttachmentFile(att, ticketId, {
-          serviceAttachment: Boolean(serviceScope),
-        })
+        await downloadTicketAttachmentFile(att, ticketId)
       } catch {
         toast.error('Não foi possível baixar o anexo.')
       }
@@ -240,11 +239,28 @@ export function TicketServicoAnexos({
 
   const handleView = useCallback(
     async (att: TicketAttachmentOut) => {
+      if (serviceScope) {
+        setViewingId(att.id)
+        try {
+          const { signed_url: signedUrl } =
+            await getTicketServiceAttachmentPlaybackUrl(ticketId, att.id)
+          window.open(signedUrl, '_blank', 'noopener,noreferrer')
+        } catch (err) {
+          toast.error(
+            getApiDetailUnless500(err) ??
+              'Não foi possível visualizar o anexo.',
+          )
+        } finally {
+          setViewingId(null)
+        }
+        return
+      }
       try {
         setViewingId(att.id)
-        const { blob, contentType } = serviceScope
-          ? await fetchTicketServiceAttachmentBlob(ticketId, att.id)
-          : await fetchTicketAttachmentBlob(ticketId, att.id)
+        const { blob, contentType } = await fetchTicketAttachmentBlob(
+          ticketId,
+          att.id,
+        )
         const previewBlob = new Blob([blob], { type: contentType })
         const previewUrl = URL.createObjectURL(previewBlob)
         window.open(previewUrl, '_blank', 'noopener,noreferrer')
@@ -350,49 +366,20 @@ export function TicketServicoAnexos({
         return
       }
 
-      const gcsFiles = files.filter(usesGcsSignedUrlUpload)
-      const otherFiles = files.filter((f) => !usesGcsSignedUrlUpload(f))
-
-      if (gcsFiles.length > 0 && otherFiles.length > 0) {
+      const tooBig = files.find((f) => f.size > MAX_GCS_UPLOAD_BYTES)
+      if (tooBig) {
         toast.error(
-          'Envie vídeos ou ZIP separados dos demais attachments para usar o endpoint correto.',
+          `"${tooBig.name}" excede o limite de ${MAX_GCS_UPLOAD_GB} GB.`,
         )
         e.target.value = ''
         return
       }
 
-      if (gcsFiles.length > 0) {
-        const gcsFile = gcsFiles[0]
-        if (gcsFiles.length > 1) {
-          toast.error('Envie apenas um vídeo ou ZIP por vez.')
-          e.target.value = ''
-          return
-        }
-        if (gcsFile.size > MAX_GCS_UPLOAD_BYTES) {
-          const label = isZipFile(gcsFile) ? 'O ZIP' : 'O vídeo'
-          toast.error(`${label} excede o limite de ${MAX_GCS_UPLOAD_GB} GB.`)
-          e.target.value = ''
-          return
-        }
-        if (uploadBlocked && onQueuePendingFiles) {
-          onQueuePendingFiles(gcsFiles)
-          const pendingLabel = isZipFile(gcsFile) ? 'ZIP' : 'Vídeo'
-          toast.success(
-            `${pendingLabel} adicionado. Será enviado após guardar serviços.`,
-          )
-          e.target.value = ''
-          return
-        }
-        toast.error('Guarde os serviços para anexar vídeos ou ZIP.')
-        e.target.value = ''
-        return
-      }
-
-      const bad = otherFiles.filter((f) => !multipartFileAllowed(f))
-      if (bad.length || otherFiles.length === 0) {
-        toast.error(
-          'Só PDF, imagens (JPEG, PNG, GIF, WebP) ou Word (.doc), até 20 MB cada.',
-        )
+      const tooBigRegular = files.find(
+        (f) => !isVideoFile(f) && !isZipFile(f) && f.size > MAX_REGULAR_BYTES,
+      )
+      if (tooBigRegular) {
+        toast.error(`"${tooBigRegular.name}" excede o limite de 20 MB.`)
         e.target.value = ''
         return
       }
@@ -400,7 +387,9 @@ export function TicketServicoAnexos({
       if (uploadBlocked && onQueuePendingFiles) {
         onQueuePendingFiles(files)
         toast.success(
-          'Anexos adicionados. Serão enviados após guardar serviços.',
+          files.length === 1
+            ? 'Anexo adicionado. Será enviado após guardar serviços.'
+            : `${files.length} anexos adicionados. Serão enviados após guardar serviços.`,
         )
         e.target.value = ''
         return
@@ -571,10 +560,15 @@ export function TicketServicoAnexos({
                           disabled={
                             deletingId === att.id ||
                             viewingId === att.id ||
+                            downloadingId === att.id ||
                             busy
                           }
                         >
-                          <Eye size={16} />
+                          {viewingId === att.id ? (
+                            <Loader2 size={16} className="animate-spin" />
+                          ) : (
+                            <Eye size={16} />
+                          )}
                         </button>
                         <button
                           type="button"
@@ -587,10 +581,15 @@ export function TicketServicoAnexos({
                           disabled={
                             deletingId === att.id ||
                             viewingId === att.id ||
+                            downloadingId === att.id ||
                             busy
                           }
                         >
-                          <Download size={16} />
+                          {downloadingId === att.id ? (
+                            <Loader2 size={16} className="animate-spin" />
+                          ) : (
+                            <Download size={16} />
+                          )}
                         </button>
                         {!readOnly ? (
                           <button

--- a/src/app/(app)/demandas/[ticketId]/components/ticket-servico-anexos.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-servico-anexos.tsx
@@ -55,7 +55,7 @@ import {
 
 export type { PendingServiceAttachment } from './ticket-pending-attachment'
 
-const MAX_REGULAR_BYTES = 20 * 1024 * 1024
+const MAX_REGULAR_BYTES = 30 * 1024 * 1024
 const MAX_GCS_UPLOAD_GB = 20
 const MAX_GCS_UPLOAD_BYTES = MAX_GCS_UPLOAD_GB * 1024 * 1024 * 1024
 
@@ -379,7 +379,7 @@ export function TicketServicoAnexos({
         (f) => !isVideoFile(f) && !isZipFile(f) && f.size > MAX_REGULAR_BYTES,
       )
       if (tooBigRegular) {
-        toast.error(`"${tooBigRegular.name}" excede o limite de 20 MB.`)
+        toast.error(`"${tooBigRegular.name}" excede o limite de 30 MB.`)
         e.target.value = ''
         return
       }

--- a/src/app/(app)/demandas/[ticketId]/ticket-servicos-save.ts
+++ b/src/app/(app)/demandas/[ticketId]/ticket-servicos-save.ts
@@ -19,9 +19,9 @@ import {
 } from '@/lib/gcs-upload-idb'
 
 import {
+  isVideoFile,
   isZipFile,
   resolveGcsUploadContentType,
-  usesGcsSignedUrlUpload,
 } from './components/ticket-gcs-upload'
 import {
   pendingAttachmentAsUploadFile,
@@ -60,7 +60,7 @@ export type PendingServiceFilesByRowId = Record<
 export type GcsUploadProgress = {
   pendingAttachmentId: string
   fileName: string
-  uploadKind: 'ZIP' | 'vídeo'
+  uploadKind: 'ZIP' | 'vídeo' | 'anexo'
   phase: 'preparing' | 'uploading' | 'finalizing'
   percent: number
   uploadedBytes?: number
@@ -74,8 +74,6 @@ export type BuildTicketServicosSaveOptions = {
 
 export type TicketServicosSaveRequest = {
   payload: TicketServicesUpsertIn
-  files: File[]
-  attachmentMetadata: TicketAttachmentServiceScopeMetadataIn[]
 }
 
 function buildRowRefById(draft: TicketServicosOut): Map<string, ServiceRowRef> {
@@ -124,7 +122,11 @@ async function uploadPendingGcsAttachment(
   options?: BuildTicketServicosSaveOptions,
 ): Promise<TicketAttachmentCompleteIn> {
   const contentType = resolveGcsUploadContentType(file)
-  const uploadKind = isZipFile(file) ? 'ZIP' : 'vídeo'
+  const uploadKind = isZipFile(file)
+    ? 'ZIP'
+    : isVideoFile(file)
+      ? 'vídeo'
+      : 'anexo'
 
   reportGcsProgress(options, {
     pendingAttachmentId: item.id,
@@ -234,7 +236,7 @@ async function uploadPendingGcsAttachment(
   }
 }
 
-/** Monta payload multipart e faz pré-upload GCS de vídeos/ZIP pendentes. */
+/** Faz pré-upload GCS de todos os anexos pendentes e monta o payload JSON. */
 export async function buildTicketServicosSaveRequest(
   ticketId: string,
   draft: TicketServicosOut,
@@ -243,8 +245,6 @@ export async function buildTicketServicosSaveRequest(
 ): Promise<TicketServicosSaveRequest> {
   const rowRefById = buildRowRefById(draft)
   const attachmentCompletes: TicketAttachmentCompleteIn[] = []
-  const files: File[] = []
-  const attachmentMetadata: TicketAttachmentServiceScopeMetadataIn[] = []
 
   for (const [rowId, pendingItems] of Object.entries(pendingByRowId)) {
     if (!pendingItems.length) continue
@@ -256,22 +256,15 @@ export async function buildTicketServicosSaveRequest(
 
     for (const item of pendingItems) {
       const file = pendingAttachmentAsUploadFile(item)
-
-      if (usesGcsSignedUrlUpload(file)) {
-        const complete = await uploadPendingGcsAttachment(
-          ticketId,
-          rowId,
-          item,
-          file,
-          scope,
-          options,
-        )
-        attachmentCompletes.push(complete)
-        continue
-      }
-
-      files.push(file)
-      attachmentMetadata.push(scope)
+      const complete = await uploadPendingGcsAttachment(
+        ticketId,
+        rowId,
+        item,
+        file,
+        scope,
+        options,
+      )
+      attachmentCompletes.push(complete)
     }
   }
 
@@ -283,5 +276,5 @@ export async function buildTicketServicosSaveRequest(
       : {}),
   }
 
-  return { payload, files, attachmentMetadata }
+  return { payload }
 }

--- a/src/http/tickets/ticket-servicos.ts
+++ b/src/http/tickets/ticket-servicos.ts
@@ -1,10 +1,7 @@
 import { api } from '@/lib/api'
 
 import type { TicketOut } from './get-ticket-by-id'
-import type {
-  TicketAttachmentOut,
-  TicketAttachmentServiceScopeMetadataIn,
-} from './ticket-attachments'
+import type { TicketAttachmentOut } from './ticket-attachments'
 import type { TicketServicesUpsertIn } from './ticket-servicos-types'
 
 /** Mesmo formato dos campos de serviços em TicketOut + anexos sem serviço (GET `/services` enriquecido). */
@@ -53,26 +50,13 @@ export async function getTicketServicos(ticketId: string) {
   return normalizeTicketServicosOut(data)
 }
 
-/** PUT multipart: `payload` (JSON) + `files` + `attachment_metadata`, como em POST `/tickets`. */
 export async function replaceTicketServicos(
   ticketId: string,
   payload: TicketServicesUpsertIn,
-  files: File[] = [],
-  attachmentMetadata: TicketAttachmentServiceScopeMetadataIn[] = [],
 ) {
-  const form = new FormData()
-  form.append('payload', JSON.stringify(payload))
-  for (const f of files) {
-    form.append('files', f)
-  }
-  if (attachmentMetadata.length > 0) {
-    form.append('attachment_metadata', JSON.stringify(attachmentMetadata))
-  }
-
   const { data } = await api.put<TicketServicesOut>(
     `/tickets/${ticketId}/services`,
-    form,
-    { headers: { 'Content-Type': 'multipart/form-data' } },
+    payload,
   )
   return normalizeTicketServicosOut(data)
 }


### PR DESCRIPTION
## Description

This branch integrates the **Chamados (Demandas)** module into staging, along with improvements already on `main` (BFF auth, Sentry LPR, privacy policy, CSV, etc.).

### Chamados module (`/demandas`)
- **Inbox** — email listing, preview, reply, and conversion to ticket
- **Ticket creation** — full form with services (plate search, radar, electronic fence, images, correlated plates, etc.)
- **Ticket detail** — tabs: ticket, requester, services, documents, response, internal opinion, report, history
- **Listings** — general tickets, archived, replied, and spam
- **Tactical dashboard** — SLA metrics, operational view, and demand volume (filters, charts, export)
- **Admin dashboard** — SLA and widget configuration
- **Teams and profiles** — CRUD for teams/members and role-based permissions
- **Workflow** — role configuration in the flow
- **Shift closings** — listing, detail view, and report
- **Impersonation** — context bar for testing with `NEXT_PUBLIC_ENABLE_IMPERSONATION`
- Feature flag `NEXT_PUBLIC_ENABLE_CHAMADOS` controls sidebar visibility and route access

### HTTP layer and infrastructure
- ~40 endpoints under `src/http/tickets/`, plus emails, teams, workflow, and operations
- Attachment upload via **GCS resumable** for videos/ZIP; smaller files via **multipart** on the services PUT
- Upload progress tracking with queue and visual states
- Environment variables for chamados/impersonation in `k8s/prod` and `k8s/staging`
- nginx `proxy-body-size` limit increased to **50 MB**

### Authentication and session (merge from `main`)
- BFF proxy (`/api/bff/[...path]`)
- Session with idle/absolute timeouts, CSRF, and `SessionActivityTracker`
- Session secrets loaded only at runtime

### General improvements (merge from `main`)
- **Sentry LPR** integration — violet radars, magenta DC3 cameras, SENTRY plate search
- Rename "radar" → "LPR"/"equipment" across UI and reports
- **Privacy notice** page
- CSV export metadata and circulation KPIs on trip reports
- CI: full Jest suite on staging; pre-push hook with lint-staged

### Recent branch-specific commits
- Multipart attachment upload when saving ticket services
- 20 MB limit for regular attachments (PDF, images, Word)
- Searchable operations popover
- Official letter number limit increased from 10 to 50 characters
- Null-safety fix in services mapper (`address`, `camera_code`)
- Loading/empty states on tactical dashboard
- Shift closing filters refactor

## Related Issue
<!--- Put the issue link here if you are fixing an issue -->

## Motivation and Context

The Chamados module was built on staging; this branch prepares full integration, including:
- End-to-end UI (inbox → creation → detail → dashboards → administration)
- Robust attachment upload (GCS for large files, multipart for documents)
- Auth hardening required for production
- Alignment with `main` (LPR, privacy, tests, CI)

The `NEXT_PUBLIC_ENABLE_CHAMADOS` feature flag allows enabling the module gradually per environment.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
- [ ] Existing unit tests (Jest) — expanded suite on staging
- [ ] Manual flow: inbox → convert email → create ticket
- [ ] Manual flow: ticket detail — edit services, attach files (PDF and video/ZIP), save
- [ ] Tactical dashboard — filters, charts, and export
- [ ] Teams, profiles, workflow, and shift closings
- [ ] Verify chamados routes return 404 when `enableChamados=false`
- [ ] Large attachment upload via GCS with progress bar
- [ ] Session: idle timeout, logout, and impersonation (if enabled)

## Screenshots (if appropriate):

## Types of changes

- [x] fix: used when there is correction of errors that are generating bugs in the system.
- [x] feat: indicates the development of a new feature for the project.
- [ ] perf: indicates a change that improved system performance.
- [x] test: indicates any type of creation or change of test codes.
- [x] refactor: used when there is a code refactoring that does not have any type of impact on the system's business logic/rules.
- [ ] style: used when there are formatting and code style changes that do not alter the system in any way.
- [x] chore: indicates changes to the project that do not affect the system or test files.
- [x] docs: used when there are changes to the project documentation.
- [x] build: used to indicate changes that affect the project's build process or external dependencies.
- [x] ci: used for changes to CI configuration files.
- [ ] revert: indicates the revert of a previous commit

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.