### PR TITLE
refactor(ticket-servicos): update plate handling in ticket services

### DIFF
--- a/src/app/(app)/demandas/[ticketId]/components/ticket-servicos-expanded-form.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-servicos-expanded-form.tsx
@@ -337,7 +337,7 @@ export function ServicosExpandedForm({
           <div className={styles.servicosFieldBlock}>
             <span className={styles.servicosFieldLabel}>Placas do veículo</span>
             <div className={styles.servicosStack}>
-              {item.plates.map((p, pi) => (
+              {(item.plates ?? []).map((p, pi) => (
                 <Fragment key={p.id}>
                   <div className={styles.servicosPlateRow}>
                     <Input
@@ -345,7 +345,9 @@ export function ServicosExpandedForm({
                       value={p.plate ?? ''}
                       onChange={(e) =>
                         patch((n) => {
-                          const plates = [...n.radar_search[index].plates]
+                          const plates = [
+                            ...(n.radar_search[index].plates ?? []),
+                          ]
                           plates[pi] = {
                             ...plates[pi],
                             plate: maskPlateBR(e.target.value),
@@ -357,37 +359,26 @@ export function ServicosExpandedForm({
                         })
                       }
                     />
-                    {item.plates.length > 1 ? (
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        className={styles.servicosIconBtn}
-                        onClick={() =>
-                          patch((n) => {
-                            const plates = n.radar_search[index].plates.filter(
-                              (_, i) => i !== pi,
-                            )
-                            n.radar_search[index] = {
-                              ...n.radar_search[index],
-                              plates:
-                                plates.length > 0
-                                  ? plates
-                                  : [
-                                      {
-                                        id: newNestedEntityId(),
-                                        created_at: nowIso(),
-                                        plate: '',
-                                      },
-                                    ],
-                            }
-                          })
-                        }
-                      >
-                        <Trash className="h-4 w-4" />
-                      </Button>
-                    ) : null}
-                    {pi === item.plates.length - 1 ? (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      className={styles.servicosIconBtn}
+                      onClick={() =>
+                        patch((n) => {
+                          const plates = (
+                            n.radar_search[index].plates ?? []
+                          ).filter((_, i) => i !== pi)
+                          n.radar_search[index] = {
+                            ...n.radar_search[index],
+                            plates,
+                          }
+                        })
+                      }
+                    >
+                      <Trash className="h-4 w-4" />
+                    </Button>
+                    {pi === (item.plates ?? []).length - 1 ? (
                       <Button
                         type="button"
                         variant="ghost"
@@ -398,7 +389,7 @@ export function ServicosExpandedForm({
                             n.radar_search[index] = {
                               ...n.radar_search[index],
                               plates: [
-                                ...n.radar_search[index].plates,
+                                ...(n.radar_search[index].plates ?? []),
                                 {
                                   id: newNestedEntityId(),
                                   created_at: nowIso(),
@@ -422,6 +413,32 @@ export function ServicosExpandedForm({
                   ) : null}
                 </Fragment>
               ))}
+              {(item.plates ?? []).length === 0 ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className={styles.servicosAddLineBtn}
+                  onClick={() =>
+                    patch((n) => {
+                      n.radar_search[index] = {
+                        ...n.radar_search[index],
+                        plates: [
+                          {
+                            id: newNestedEntityId(),
+                            created_at: nowIso(),
+                            plate: '',
+                          },
+                        ],
+                      }
+                    })
+                  }
+                  aria-label="Adicionar placa"
+                  title="Adicionar placa"
+                >
+                  <Plus className="h-4 w-4" />
+                </Button>
+              ) : null}
             </div>
           </div>
         </div>,

--- a/src/app/(app)/demandas/[ticketId]/ticket-servicos-mapper.ts
+++ b/src/app/(app)/demandas/[ticketId]/ticket-servicos-mapper.ts
@@ -96,7 +96,6 @@ function normalizeServicosForDraft(s: TicketServicosOut): TicketServicosOut {
   return {
     ...s,
     plate_search: ensureAtLeastOnePlateRow(s.plate_search),
-    radar_search: ensureAtLeastOnePlateRow(s.radar_search),
     correlated_plates: ensureAtLeastOnePlateRow(s.correlated_plates),
     joint_plates: ensureAtLeastOnePlateRow(s.joint_plates),
   }
@@ -339,7 +338,7 @@ export function appendEmptyService(
           completed: false,
           period_start: null,
           period_end: null,
-          plates: [{ id: newNestedEntityId(), created_at: created, plate: '' }],
+          plates: [],
           radar_address: null,
           orientation: null,
         },

--- a/src/app/(app)/demandas/criar/components/services/service-modal.tsx
+++ b/src/app/(app)/demandas/criar/components/services/service-modal.tsx
@@ -498,14 +498,13 @@ function BuscaPorRadarForm({
     formState: { errors },
   } = form
 
-  const plates = form.watch('plates') ?? ['']
+  const plates = form.watch('plates') ?? []
 
   const addPlate = () => {
     form.setValue('plates', [...plates, ''], { shouldValidate: true })
   }
 
   const removePlate = (index: number) => {
-    if (plates.length <= 1) return
     form.setValue(
       'plates',
       plates.filter((_, i) => i !== index),
@@ -578,17 +577,15 @@ function BuscaPorRadarForm({
                       />
                     )}
                   />
-                  {plates.length > 1 && (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      className="h-11 w-11 shrink-0 p-0"
-                      onClick={() => removePlate(index)}
-                      title="Remover placa"
-                    >
-                      <Trash className="h-4 w-4" />
-                    </Button>
-                  )}
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    className="h-11 w-11 shrink-0 p-0"
+                    onClick={() => removePlate(index)}
+                    title="Remover placa"
+                  >
+                    <Trash className="h-4 w-4" />
+                  </Button>
                 </div>
               ))}
               {errors.plates?.message && (

--- a/src/app/(app)/demandas/criar/ticket-create/ticket-create.constant.ts
+++ b/src/app/(app)/demandas/criar/ticket-create/ticket-create.constant.ts
@@ -159,7 +159,7 @@ export function emptyBuscaPorRadarDraft(): BuscaPorRadarDraft {
   return {
     period_start: '',
     period_end: '',
-    plates: [''],
+    plates: [],
     orientation: '',
   }
 }
@@ -181,7 +181,7 @@ export function normalizeBuscaPorRadarForForm(
     return {
       period_start: null,
       period_end: null,
-      plates: [''],
+      plates: [],
       orientation: null,
     }
   }
@@ -189,7 +189,7 @@ export function normalizeBuscaPorRadarForForm(
   const plates =
     initialValue.plates != null && initialValue.plates.length > 0
       ? [...initialValue.plates]
-      : ['']
+      : []
 
   const orientationRaw = initialValue.orientation
   const orientation =


### PR DESCRIPTION
## Description

This branch integrates the full **Demandas/Chamados** (tickets/requests) module into `staging`, along with authentication improvements, map/LPR updates, reporting changes, and infrastructure updates. It is a large release that adds the operational ticket workflow to Civitas.

### Demandas/Chamados module (core)

- **23 screens** under `/demandas`: listing, creation, ticket detail, inbox, email-to-ticket conversion, archived tickets, replied emails, spam, teams, profiles, screen permissions, workflow, shift closings, and dashboards.
- **Ticket detail** with tabs: ticket, requester, services, documents, response, internal opinion, demand report, and history.
- **Ticket services**: expanded forms by type (plate search, radar search, correlated plates, joint plates, etc.), completion logic, mapper, and persistence.
- **Service attachments**: multipart upload to GCS, progress tracking, unique filenames, **30 MB** per-file limit.
- **Inbox**: email listing, preview, reply, and conversion into a ticket.
- **Tactical dashboards**: demand volume, operational view, and SLA metrics with filters, charts, and export.
- **Administration**: teams, access profiles, role-based permissions, SLA/widget configuration, and role-based workflow.
- **Impersonation** controlled by `NEXT_PUBLIC_ENABLE_IMPERSONATION`.
- Feature flag `NEXT_PUBLIC_ENABLE_CHAMADOS` to enable the module in the sidebar and routes.

### Authentication and session

- Session hardening via BFF (`/api/bff/[...path]`).
- New endpoints: `/api/auth/session-touch`, `/api/auth/logout`.
- `SessionActivityTracker`, CSRF, configurable timeouts (`AUTH_*`), and runtime-only secret loading.

### Map and LPR (SENTRY)

- Separate layers for SENTRY radars (violet) and DC3 cameras (magenta).
- Renamed "radar" to "LPR"/"equipment" across UI and reports.
- SENTRY passage support in plate search.
- Fixes in layer tests and collection points.

### Reports and other changes

- Metadata in CSV exports, circulation KPIs in trip reports, **Privacy Notice** page.
- Searchable operation selection with popover UI.
- Official letter number limit increased from 10 to 50 characters.

### Infrastructure and CI

- `proxy-body-size: 50m` on ingress (staging and prod).
- Updates to `.dockerignore`, `cloudbuild`, and pre-push hook with Jest in lint-staged.
- Environment variables for chamados and impersonation in K8s manifests.

### Recent commits

1. `feat(ticket-servicos)`: unique attachment filenames and improved pending file handling
2. `feat(ticket-servico-anexos)`: 30 MB upload limit
3. `refactor(ticket-servicos-save)`: simplified multipart upload
4. `feat(nginx)`: 50m proxy body size
5. `fix(ticket-servicos-mapper)`: null values in address/camera_code

---

## Related Issue

_Not referenced in commits._

## Motivation and Context

The Chamados/Demandas module needs to be available in `staging` for integrated validation before production. This branch consolidates:

- The full ticket module (already merged into `main` via PR #315).
- Follow-up improvements: attachment uploads, tactical dashboards, auth hardening, and infrastructure changes for large files.
- Fixes and features from other workstreams brought in via merge with `main` (LPR/SENTRY, CSV, privacy, tests).

**Note:** the branch is **67 commits ahead** and **171 commits behind** `staging` — the merge may require conflict resolution.

## How has this been tested?

- Unit tests updated for LPR, map layers, CSV, and auth (`session-config`, `session`).
- CI configured to run the full Jest suite in the staging pipeline.
- No evidence in commits of documented manual testing of the full demandas flow in staging.

**Suggested manual validation:**

- [ ] Create a ticket with multiple service types and attachments (>20 MB)
- [ ] Convert an email into a ticket; reply from the inbox
- [ ] Workflow, reassignment, and shift closing
- [ ] Tactical dashboards (volume, operational, SLA) with filters and export
- [ ] Role-based permissions and impersonation (if enabled)
- [ ] Idle/absolute session timeout and logout
- [ ] Sidebar with `NEXT_PUBLIC_ENABLE_CHAMADOS=true/false`

## Screenshots (if appropriate)

_Not included in commits._

## Types of changes

- [x] fix: used when there is correction of errors that are generating bugs in the system.
- [x] feat: indicates the development of a new feature for the project.
- [ ] perf: indicates a change that improved system performance.
- [x] test: indicates any type of creation or change of test codes.
- [x] refactor: used when there is a code refactoring that does not have any type of impact on the system's business logic/rules.
- [ ] style: used when there are formatting and code style changes that do not alter the system in any way.
- [x] chore: indicates changes to the project that do not affect the system or test files.
- [x] docs: used when there are changes to the project documentation.
- [x] build: used to indicate changes that affect the project's build process or external dependencies.
- [x] ci: used for changes to CI configuration files.
- [ ] revert: indicates the revert of a previous commit

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.