### PR TITLE
feat(ticket-creation): enhance ticket creation and filtering features

### DIFF
--- a/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-chamado.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-detail-tab-chamado.tsx
@@ -41,7 +41,6 @@ import { shouldShowTicketSeiFields } from '../ticket-detail.constants'
 import styles from '../ticket-detail.module.css'
 import type { TicketDetailTabHandle } from './ticket-detail-tab-handle'
 
-const MAX_OFICIO_PROC = 60
 const MAX_APELIDO = 120
 const MAX_NUMERO_SEI = 60
 const MAX_LINK_SEI = 2048
@@ -134,8 +133,10 @@ function buildChamadoPayload(
     )
     return null
   }
-  if (proc.length > MAX_OFICIO_PROC) {
-    toast.error(`Nº de procedimento: no máximo ${MAX_OFICIO_PROC} caracteres.`)
+  if (proc.length > CREATE_STR_LIMITS.procedure_number) {
+    toast.error(
+      `Nº de procedimento: no máximo ${CREATE_STR_LIMITS.procedure_number} caracteres.`,
+    )
     return null
   }
 
@@ -465,7 +466,7 @@ export const TicketDetailTabChamado = forwardRef<TicketDetailTabHandle, Props>(
                   <input
                     className={`${styles.editableField} ${styles.solicitanteEditField}`}
                     value={d.procedure_number ?? ''}
-                    maxLength={MAX_OFICIO_PROC}
+                    maxLength={CREATE_STR_LIMITS.procedure_number}
                     onChange={(e) =>
                       setDraft((prev) =>
                         prev

--- a/src/app/(app)/demandas/[ticketId]/components/ticket-servico-anexos.tsx
+++ b/src/app/(app)/demandas/[ticketId]/components/ticket-servico-anexos.tsx
@@ -426,7 +426,7 @@ export function TicketServicoAnexos({
                 type="file"
                 className={styles.servicoAnexosFileInput}
                 multiple
-                accept="video/*,.zip,application/zip,.pdf,.jpg,.jpeg,.png,.gif,.webp,.doc"
+                accept="video/*,.zip,application/zip,.pdf,.jpg,.jpeg,.png,.gif,.webp,.doc,.csv,text/csv,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
                 onChange={onPickUpload}
                 aria-hidden
                 tabIndex={-1}

--- a/src/app/(app)/demandas/arquivados/components/ticket-archive-list.tsx
+++ b/src/app/(app)/demandas/arquivados/components/ticket-archive-list.tsx
@@ -35,7 +35,7 @@ function getServiceClassName(label: string) {
   if (normalized.includes('busca por radar')) return styles.serviceTagBlue
   if (normalized.includes('placas correlatas')) return styles.serviceTagOrange
   if (normalized.includes('placas conjuntas')) return styles.serviceTagPurple
-  if (normalized.includes('other')) return styles.serviceTagRed
+  if (normalized.includes('outros')) return styles.serviceTagRed
   if (normalized.includes('atlas')) return styles.serviceTagDefault
 
   return styles.serviceTagDefault

--- a/src/app/(app)/demandas/converter/components/email-to-ticket-view.tsx
+++ b/src/app/(app)/demandas/converter/components/email-to-ticket-view.tsx
@@ -748,6 +748,7 @@ export function EmailToTicketView() {
                                           vm.applyAssociatedTicketFromSearch(
                                             ticket.id,
                                             ticket.title,
+                                            ticket.ticket_type_name,
                                           ).catch(() => {})
                                           vm.setTicketPopoverOpen(false)
                                         }}

--- a/src/app/(app)/demandas/criar/hooks/use-create-controller.ts
+++ b/src/app/(app)/demandas/criar/hooks/use-create-controller.ts
@@ -21,6 +21,7 @@ import {
   getTicketTypes,
   type TicketType,
 } from '@/http/ticket-types/get-ticket.types'
+import { addConventionalPendingAttachments } from '@/http/tickets/add-conventional-pending-attachments'
 import { convertTicketToConventional } from '@/http/tickets/convert-ticket-to-conventional'
 import { createTicket } from '@/http/tickets/create-ticket'
 import { getTicketById } from '@/http/tickets/get-ticket-by-id'
@@ -63,6 +64,10 @@ function associarChamadoIdOrNull(value?: string | null): string | null {
   return trimmed.length ? trimmed : null
 }
 
+function isConvencionalTicketType(ticketTypeName: string | null | undefined) {
+  return (ticketTypeName ?? '').trim().toLowerCase() === 'convencional'
+}
+
 export function useTicketCreateController() {
   const router = useRouter()
   const queryClient = useQueryClient()
@@ -87,6 +92,10 @@ export function useTicketCreateController() {
   const debouncedTicketSearch = useDebounce(ticketSearch, 350)
   const [ticketPopoverOpen, setTicketPopoverOpen] = useState(false)
   const [selectedTicketLabel, setSelectedTicketLabel] = useState('')
+  const [
+    selectedAssociatedTicketTypeName,
+    setSelectedAssociatedTicketTypeName,
+  ] = useState<string | null>(null)
 
   const [operationSearch, setOperationSearch] = useState('')
   const debouncedOperationSearch = useDebounce(operationSearch, 350)
@@ -219,6 +228,7 @@ export function useTicketCreateController() {
         toast.error('Tipo "Convencional" não encontrado no catálogo.')
         setValue('linked_ticket_id', null)
         setSelectedTicketLabel('')
+        setSelectedAssociatedTicketTypeName(null)
         setTicketSearch('')
         return
       }
@@ -237,6 +247,7 @@ export function useTicketCreateController() {
       toast.error(getApiErrorMessage(error))
       setValue('linked_ticket_id', null)
       setSelectedTicketLabel('')
+      setSelectedAssociatedTicketTypeName(null)
       setTicketSearch('')
     },
   })
@@ -254,6 +265,43 @@ export function useTicketCreateController() {
     }) => convertTicketToConventional(ticketId, filesToSend, { emailId }),
     onSuccess: (_data, variables) => {
       toast.success('Demanda convertida para convencional com sucesso.')
+      if (variables.saveAndNew) {
+        const current = getValues()
+        reset({
+          ...current,
+          plate_search: [],
+          radar_search: [],
+          electronic_fence: [],
+          image_search: [],
+          correlated_plates: [],
+          joint_plates: [],
+          image_reservation: [],
+          image_analysis: [],
+          other: [],
+          atlas_civitas: [],
+        })
+        setFiles([])
+        closeServiceModal()
+      } else {
+        router.push('/demandas')
+      }
+    },
+    onError: (error) => toast.error(getApiErrorMessage(error)),
+  })
+
+  const addConventionalPendingAttachmentsMutation = useMutation({
+    mutationFn: async ({
+      ticketId,
+      files: filesToSend,
+      emailId,
+    }: {
+      ticketId: string
+      files: File[]
+      saveAndNew?: boolean
+      emailId?: string | null
+    }) => addConventionalPendingAttachments(ticketId, filesToSend, { emailId }),
+    onSuccess: (_data, variables) => {
+      toast.success('Anexos adicionados à demanda convencional com sucesso.')
       if (variables.saveAndNew) {
         const current = getValues()
         reset({
@@ -365,15 +413,18 @@ export function useTicketCreateController() {
     isSubmitting ||
     createMutation.isPending ||
     convertToConventionalMutation.isPending ||
+    addConventionalPendingAttachmentsMutation.isPending ||
     isTeamsLoading ||
     applyAssociatedTicketMutation.isPending
 
   async function applyAssociatedTicketFromSearch(
     ticketId: string,
     titulo: string,
+    ticketTypeName: string,
   ) {
     setSelectedTicketLabel(titulo)
     setTicketSearch(titulo)
+    setSelectedAssociatedTicketTypeName(ticketTypeName)
     setValue('linked_ticket_id', ticketId)
     await applyAssociatedTicketMutation.mutateAsync({ ticketId })
   }
@@ -436,11 +487,19 @@ export function useTicketCreateController() {
   async function onSubmit(data: TicketCreateForm) {
     const associarId = associarChamadoIdOrNull(data.linked_ticket_id)
     if (associarId) {
-      await convertToConventionalMutation.mutateAsync({
-        ticketId: associarId,
-        files,
-        saveAndNew: false,
-      })
+      if (isConvencionalTicketType(selectedAssociatedTicketTypeName)) {
+        await addConventionalPendingAttachmentsMutation.mutateAsync({
+          ticketId: associarId,
+          files,
+          saveAndNew: false,
+        })
+      } else {
+        await convertToConventionalMutation.mutateAsync({
+          ticketId: associarId,
+          files,
+          saveAndNew: false,
+        })
+      }
       return
     }
     const payload = buildTicketCreatePayload(data)
@@ -455,12 +514,21 @@ export function useTicketCreateController() {
   ) {
     const associarId = associarChamadoIdOrNull(data.linked_ticket_id)
     if (associarId) {
-      await convertToConventionalMutation.mutateAsync({
-        ticketId: associarId,
-        files: filesForTicket ?? files,
-        saveAndNew: options?.saveAndNew ?? false,
-        emailId,
-      })
+      if (isConvencionalTicketType(selectedAssociatedTicketTypeName)) {
+        await addConventionalPendingAttachmentsMutation.mutateAsync({
+          ticketId: associarId,
+          files: filesForTicket ?? files,
+          saveAndNew: options?.saveAndNew ?? false,
+          emailId,
+        })
+      } else {
+        await convertToConventionalMutation.mutateAsync({
+          ticketId: associarId,
+          files: filesForTicket ?? files,
+          saveAndNew: options?.saveAndNew ?? false,
+          emailId,
+        })
+      }
       return
     }
     const basePayload = buildTicketCreatePayload(data)
@@ -493,6 +561,7 @@ export function useTicketCreateController() {
     reset(defaultValues)
     setFiles([])
     setSelectedTicketLabel('')
+    setSelectedAssociatedTicketTypeName(null)
     setTicketSearch('')
     setTicketPopoverOpen(false)
     setSelectedOperationLabel('')
@@ -524,6 +593,9 @@ export function useTicketCreateController() {
     isTicketsLoading,
     isApplyingAssociatedTicket: applyAssociatedTicketMutation.isPending,
     isConvertingToConventional: convertToConventionalMutation.isPending,
+    isAddingConventionalAttachments:
+      addConventionalPendingAttachmentsMutation.isPending,
+    selectedAssociatedTicketTypeName,
     isTeamsLoading,
     operationOptions,
     ticketTypes,

--- a/src/app/(app)/demandas/criar/ticket-create/ticket-create-form.tsx
+++ b/src/app/(app)/demandas/criar/ticket-create/ticket-create-form.tsx
@@ -231,6 +231,7 @@ export function TicketCreateForm() {
                                   vm.applyAssociatedTicketFromSearch(
                                     ticket.id,
                                     ticket.title,
+                                    ticket.ticket_type_name,
                                   ).catch(() => {})
                                   vm.setTicketPopoverOpen(false)
                                 }}

--- a/src/app/(app)/demandas/criar/ticket-create/ticket-create.constant.ts
+++ b/src/app/(app)/demandas/criar/ticket-create/ticket-create.constant.ts
@@ -88,7 +88,7 @@ export type AtlasCivitasDraft = {
 }
 
 export const TICKET_CREATE_STRING_LIMITS = {
-  procedure_number: 12,
+  procedure_number: 25,
   official_letter_number: 50,
   press_alias: 120,
   article_link: 2048,

--- a/src/app/(app)/demandas/dashboard-tatico/components/filters/constants.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/components/filters/constants.ts
@@ -15,6 +15,8 @@ export function emptyDashboardTaticoAdvancedFilters(): DashboardTaticoAdvancedFi
     priority: [],
     status: [],
     ticket_type_id: [],
+    nature_id: [],
+    services: [],
     relevanteImprensa: false,
   }
 }

--- a/src/app/(app)/demandas/dashboard-tatico/components/filters/dashboard-tatico-filter-modal.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/components/filters/dashboard-tatico-filter-modal.tsx
@@ -5,11 +5,13 @@ import { X } from 'lucide-react'
 import { useEffect, useState } from 'react'
 
 import { Button } from '@/components/ui/button'
+import { getTicketNatures } from '@/http/get-ticket-natures/get-ticket-natures'
 import { getTicketTypes } from '@/http/ticket-types/get-ticket.types'
 import type { SearchOption } from '@/http/tickets/tickets-dashboard-filters'
 import {
   searchOperations,
   searchRequesters,
+  TICKET_DASHBOARD_SERVICE_FILTER_OPTIONS,
 } from '@/http/tickets/tickets-dashboard-filters'
 
 import {
@@ -57,6 +59,20 @@ export function DashboardTaticoFilterModal({
       queryKey: ['ticket-types', 'dashboard-tatico-filter', scope],
       queryFn: async () => {
         const response = await getTicketTypes({ isActive: true })
+        return (response.data ?? []).map((item) => ({
+          value: item.id,
+          label: item.name,
+        }))
+      },
+      enabled: isOpen,
+      staleTime: 1000 * 60 * 5,
+    })
+
+  const { data: ticketNatureOptions, isFetching: isTicketNaturesLoading } =
+    useQuery({
+      queryKey: ['ticket-natures', 'dashboard-tatico-filter', scope],
+      queryFn: async () => {
+        const response = await getTicketNatures({ isActive: true })
         return (response.data ?? []).map((item) => ({
           value: item.id,
           label: item.name,
@@ -170,6 +186,35 @@ export function DashboardTaticoFilterModal({
               }
               staticOptions={ticketTypeOptions ?? []}
               optionsLoading={isTicketTypesLoading}
+            />
+
+            <DashboardTaticoSearchMultiSelect
+              scope={scope}
+              label="NATUREZA"
+              placeholder="Selecione"
+              value={draftFilters.nature_id}
+              onChange={(value) =>
+                setDraftFilters((current) => ({
+                  ...current,
+                  nature_id: value,
+                }))
+              }
+              staticOptions={ticketNatureOptions ?? []}
+              optionsLoading={isTicketNaturesLoading}
+            />
+
+            <DashboardTaticoSearchMultiSelect
+              scope={scope}
+              label="SERVIÇO"
+              placeholder="Selecione"
+              value={draftFilters.services}
+              onChange={(value) =>
+                setDraftFilters((current) => ({
+                  ...current,
+                  services: value,
+                }))
+              }
+              staticOptions={TICKET_DASHBOARD_SERVICE_FILTER_OPTIONS}
             />
           </div>
 

--- a/src/app/(app)/demandas/dashboard-tatico/components/filters/types.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/components/filters/types.ts
@@ -6,6 +6,8 @@ export type DashboardTaticoAdvancedFilterForm = {
   priority: SearchOption[]
   status: SearchOption[]
   ticket_type_id: SearchOption[]
+  nature_id: SearchOption[]
+  services: SearchOption[]
   relevanteImprensa: boolean
 }
 

--- a/src/app/(app)/demandas/dashboard-tatico/components/filters/use-persisted-advanced-filters.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/components/filters/use-persisted-advanced-filters.ts
@@ -1,0 +1,19 @@
+import { useCallback, useState } from 'react'
+
+import type { DashboardTaticoAdvancedFilterForm } from './types'
+
+export function usePersistedAdvancedFilters<
+  T extends DashboardTaticoAdvancedFilterForm,
+>(createInitialForm: () => T) {
+  const [form, setForm] = useState(createInitialForm)
+
+  const applyAdvancedFilters = useCallback(
+    (next: T, onApply: (filters: T) => void) => {
+      setForm(next)
+      onApply(next)
+    },
+    [],
+  )
+
+  return { form, applyAdvancedFilters }
+}

--- a/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-filter-utils.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-filter-utils.ts
@@ -4,7 +4,11 @@ import type {
   SlaTicketStatus,
   TicketPriority,
 } from '@/http/tickets/get-sla-dashboard'
-import type { SearchOption } from '@/http/tickets/tickets-dashboard-filters'
+import type {
+  SearchOption,
+  TICKET_DASHBOARD_SERVICE_FILTER_OPTIONS,
+  type TicketDashboardServiceFilter,
+} from '@/http/tickets/tickets-dashboard-filters'
 
 import {
   DASHBOARD_TATICO_PRIORITY_OPTIONS,
@@ -25,6 +29,9 @@ const priorityLabelByValue = new Map(
 const statusLabelByValue = new Map(
   SLA_METRICS_STATUS_OPTIONS.map((o) => [o.value, o.label]),
 )
+const serviceLabelByValue = new Map(
+  TICKET_DASHBOARD_SERVICE_FILTER_OPTIONS.map((o) => [o.value, o.label]),
+)
 
 export const emptySlaMetricsAdvancedFilters =
   emptyDashboardTaticoAdvancedFilters
@@ -38,6 +45,8 @@ export function countSlaMetricsAdvancedFiltersFromApi(
   count += filters.priority?.length ?? 0
   count += filters.status?.length ?? 0
   count += filters.ticket_type_id?.length ?? 0
+  count += filters.nature_id?.length ?? 0
+  count += filters.services?.length ?? 0
   if (filters.media_relevant === true) {
     count += 1
   }
@@ -79,6 +88,11 @@ export function advancedFiltersFromApi(
       value,
       label: value,
     })),
+    nature_id: (filters.nature_id ?? []).map((value) => ({
+      value,
+      label: value,
+    })),
+    services: toSearchOptions(filters.services, serviceLabelByValue),
     relevanteImprensa: filters.media_relevant === true,
   }
 }
@@ -92,6 +106,8 @@ export function advancedFiltersToApiPatch(
   | 'priority'
   | 'status'
   | 'ticket_type_id'
+  | 'nature_id'
+  | 'services'
   | 'media_relevant'
 > {
   return {
@@ -110,6 +126,14 @@ export function advancedFiltersToApiPatch(
     ticket_type_id: form.ticket_type_id.length
       ? form.ticket_type_id.map((item) => item.value)
       : undefined,
+    nature_id: form.nature_id.length
+      ? form.nature_id.map((item) => item.value)
+      : undefined,
+    services: form.services.length
+      ? (form.services.map(
+          (item) => item.value,
+        ) as TicketDashboardServiceFilter[])
+      : undefined,
     media_relevant: form.relevanteImprensa ? true : null,
   }
 }
@@ -123,6 +147,8 @@ export function stripAdvancedFiltersFromApi(
   delete rest.priority
   delete rest.status
   delete rest.ticket_type_id
+  delete rest.nature_id
+  delete rest.services
   delete rest.media_relevant
   return rest
 }
@@ -149,6 +175,13 @@ export function formatSlaMetricsAdvancedFiltersSummary(
     lines.push(
       `Tipo de chamado: ${filters.ticket_type_id.length} selecionado(s)`,
     )
+  }
+  if (filters.nature_id?.length) {
+    lines.push(`Natureza: ${filters.nature_id.length} selecionado(s)`)
+  }
+  if (filters.services?.length) {
+    const labels = filters.services.map((s) => serviceLabelByValue.get(s) ?? s)
+    lines.push(`Serviço: ${labels.join(', ')}`)
   }
   if (filters.media_relevant === true) {
     lines.push('Relevante para imprensa: Sim')

--- a/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-filters.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-filters.tsx
@@ -17,6 +17,7 @@ import {
   DashboardTaticoFilterModal,
   SLA_METRICS_STATUS_OPTIONS,
 } from '../../components/filters'
+import { usePersistedAdvancedFilters } from '../../components/filters/use-persisted-advanced-filters'
 import {
   parseDemandVolumeDate,
   toDemandVolumeDateString,
@@ -141,10 +142,8 @@ export function SlaMetricsFilters({
     () => countSlaMetricsAdvancedFiltersFromApi(appliedFilters),
     [appliedFilters],
   )
-  const advancedFiltersForm = useMemo(
-    () => advancedFiltersFromApi(appliedFilters),
-    [appliedFilters],
-  )
+  const { form: advancedFiltersForm, applyAdvancedFilters } =
+    usePersistedAdvancedFilters(() => advancedFiltersFromApi(appliedFilters))
 
   return (
     <div className={styles.periodBar}>
@@ -209,7 +208,7 @@ export function SlaMetricsFilters({
         isOpen={isFilterModalOpen}
         onClose={() => setIsFilterModalOpen(false)}
         filters={advancedFiltersForm}
-        onApply={onApplyAdvancedFilters}
+        onApply={(form) => applyAdvancedFilters(form, onApplyAdvancedFilters)}
       />
     </div>
   )

--- a/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-general-chart.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-general-chart.tsx
@@ -3,6 +3,7 @@
 import type { CSSProperties } from 'react'
 import {
   CartesianGrid,
+  LabelList,
   Legend,
   Line,
   LineChart,
@@ -35,11 +36,13 @@ const SERIES = [
     key: 'from_registration_days',
     label: 'A partir do cadastro',
     color: '#b93d52',
+    labelPosition: 'top' as const,
   },
   {
     key: 'from_email_days',
     label: 'A partir do e-mail',
     color: '#06b2bb',
+    labelPosition: 'bottom' as const,
   },
 ] as const
 
@@ -108,7 +111,7 @@ export function SlaMetricsGeneralChart({
         <ResponsiveContainer width="100%" height={280}>
           <LineChart
             data={chartData}
-            margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+            margin={{ top: 24, right: 16, left: 0, bottom: 0 }}
           >
             <CartesianGrid
               strokeDasharray="3 3"
@@ -167,10 +170,22 @@ export function SlaMetricsGeneralChart({
                 name={s.label}
                 stroke={s.color}
                 strokeWidth={2}
-                dot={false}
+                dot={{ r: 3, fill: s.color, strokeWidth: 0 }}
                 connectNulls
-                activeDot={{ r: 4, strokeWidth: 0 }}
-              />
+                activeDot={{ r: 5, strokeWidth: 0 }}
+              >
+                <LabelList
+                  dataKey={s.key}
+                  position={s.labelPosition}
+                  formatter={(v: unknown) => {
+                    const n = Number(v)
+                    return !isNaN(n) && v != null && v !== ''
+                      ? n.toFixed(1)
+                      : ''
+                  }}
+                  style={{ fontSize: 10, fill: s.color, fontWeight: 600 }}
+                />
+              </Line>
             ))}
           </LineChart>
         </ResponsiveContainer>

--- a/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-media-chart.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-media-chart.tsx
@@ -3,6 +3,7 @@
 import type { CSSProperties } from 'react'
 import {
   CartesianGrid,
+  LabelList,
   Legend,
   Line,
   LineChart,
@@ -96,7 +97,7 @@ export function SlaMetricsMediaChart({
         <ResponsiveContainer width="100%" height={280}>
           <LineChart
             data={chartData}
-            margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+            margin={{ top: 24, right: 16, left: 0, bottom: 0 }}
           >
             <CartesianGrid
               strokeDasharray="3 3"
@@ -144,10 +145,24 @@ export function SlaMetricsMediaChart({
               name="Tempo médio (dias)"
               stroke={CHART_COLORS.line}
               strokeWidth={2}
-              dot={false}
+              dot={{ r: 3, fill: CHART_COLORS.line, strokeWidth: 0 }}
               connectNulls
-              activeDot={{ r: 4, strokeWidth: 0 }}
-            />
+              activeDot={{ r: 5, strokeWidth: 0 }}
+            >
+              <LabelList
+                dataKey="avg_days"
+                position="top"
+                formatter={(v: unknown) => {
+                  const n = Number(v)
+                  return !isNaN(n) && v != null && v !== '' ? n.toFixed(1) : ''
+                }}
+                style={{
+                  fontSize: 10,
+                  fill: CHART_COLORS.line,
+                  fontWeight: 600,
+                }}
+              />
+            </Line>
           </LineChart>
         </ResponsiveContainer>
       )}

--- a/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-priority-chart.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-priority-chart.tsx
@@ -3,6 +3,7 @@
 import type { CSSProperties } from 'react'
 import {
   CartesianGrid,
+  LabelList,
   Legend,
   Line,
   LineChart,
@@ -31,10 +32,30 @@ interface SlaMetricsPriorityChartProps {
 }
 
 const SERIES = [
-  { key: 'urgent_days', label: 'Urgente', color: '#b93d52' },
-  { key: 'high_days', label: 'Alta', color: '#5b4db2' },
-  { key: 'routine_days', label: 'Rotina', color: '#06b2bb' },
-  { key: 'no_priority_days', label: 'Sem Prioridade', color: '#97a2ab' },
+  {
+    key: 'urgent_days',
+    label: 'Urgente',
+    color: '#b93d52',
+    labelPosition: 'top' as const,
+  },
+  {
+    key: 'high_days',
+    label: 'Alta',
+    color: '#5b4db2',
+    labelPosition: 'bottom' as const,
+  },
+  {
+    key: 'routine_days',
+    label: 'Rotina',
+    color: '#06b2bb',
+    labelPosition: 'top' as const,
+  },
+  {
+    key: 'no_priority_days',
+    label: 'Sem Prioridade',
+    color: '#97a2ab',
+    labelPosition: 'bottom' as const,
+  },
 ] as const
 
 const CHART_COLORS = {
@@ -102,7 +123,7 @@ export function SlaMetricsPriorityChart({
         <ResponsiveContainer width="100%" height={280}>
           <LineChart
             data={chartData}
-            margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+            margin={{ top: 24, right: 16, left: 0, bottom: 0 }}
           >
             <CartesianGrid
               strokeDasharray="3 3"
@@ -152,10 +173,22 @@ export function SlaMetricsPriorityChart({
                 name={s.label}
                 stroke={s.color}
                 strokeWidth={2}
-                dot={false}
+                dot={{ r: 3, fill: s.color, strokeWidth: 0 }}
                 connectNulls
-                activeDot={{ r: 4, strokeWidth: 0 }}
-              />
+                activeDot={{ r: 5, strokeWidth: 0 }}
+              >
+                <LabelList
+                  dataKey={s.key}
+                  position={s.labelPosition}
+                  formatter={(v: unknown) => {
+                    const n = Number(v)
+                    return !isNaN(n) && v != null && v !== ''
+                      ? n.toFixed(1)
+                      : ''
+                  }}
+                  style={{ fontSize: 10, fill: s.color, fontWeight: 600 }}
+                />
+              </Line>
             ))}
           </LineChart>
         </ResponsiveContainer>

--- a/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-filter-utils.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-filter-utils.ts
@@ -3,7 +3,11 @@ import type {
   OperationalViewPriority,
   OperationalViewStatus,
 } from '@/http/tickets/get-operational-view'
-import type { SearchOption } from '@/http/tickets/tickets-dashboard-filters'
+import type {
+  SearchOption,
+  TICKET_DASHBOARD_SERVICE_FILTER_OPTIONS,
+  type TicketDashboardServiceFilter,
+} from '@/http/tickets/tickets-dashboard-filters'
 
 import {
   DASHBOARD_TATICO_PRIORITY_OPTIONS,
@@ -27,6 +31,9 @@ const priorityLabelByValue = new Map(
 const statusLabelByValue = new Map(
   OPERATIONAL_VIEW_STATUS_OPTIONS.map((o) => [o.value, o.label]),
 )
+const serviceLabelByValue = new Map(
+  TICKET_DASHBOARD_SERVICE_FILTER_OPTIONS.map((o) => [o.value, o.label]),
+)
 
 export const emptyOperationalViewAdvancedFilters =
   emptyDashboardTaticoAdvancedFilters
@@ -44,6 +51,8 @@ export function countOperationalViewAdvancedFiltersFromApi(
   count += filters.status?.length ?? 0
 
   count += filters.ticket_type_id?.length ?? 0
+  count += filters.nature_id?.length ?? 0
+  count += filters.services?.length ?? 0
 
   if (filters.media_relevant === true) {
     count += 1
@@ -98,6 +107,12 @@ export function advancedFiltersFromApi(
       label: value,
     })),
 
+    nature_id: (filters.nature_id ?? []).map((value) => ({
+      value,
+      label: value,
+    })),
+    services: toSearchOptions(filters.services, serviceLabelByValue),
+
     relevanteImprensa: filters.media_relevant === true,
   }
 }
@@ -111,6 +126,8 @@ export function advancedFiltersToApiPatch(
   | 'priority'
   | 'status'
   | 'ticket_type_id'
+  | 'nature_id'
+  | 'services'
   | 'media_relevant'
 > {
   return {
@@ -133,6 +150,15 @@ export function advancedFiltersToApiPatch(
       ? form.ticket_type_id.map((item) => item.value)
       : undefined,
 
+    nature_id: form.nature_id.length
+      ? form.nature_id.map((item) => item.value)
+      : undefined,
+    services: form.services.length
+      ? (form.services.map(
+          (item) => item.value,
+        ) as TicketDashboardServiceFilter[])
+      : undefined,
+
     media_relevant: form.relevanteImprensa ? true : null,
   }
 }
@@ -150,6 +176,8 @@ export function stripAdvancedFiltersFromApi(
   delete rest.status
 
   delete rest.ticket_type_id
+  delete rest.nature_id
+  delete rest.services
 
   delete rest.media_relevant
 
@@ -184,6 +212,14 @@ export function formatOperationalViewAdvancedFiltersSummary(
     lines.push(
       `Tipo de chamado: ${filters.ticket_type_id.length} selecionado(s)`,
     )
+  }
+
+  if (filters.nature_id?.length) {
+    lines.push(`Natureza: ${filters.nature_id.length} selecionado(s)`)
+  }
+  if (filters.services?.length) {
+    const labels = filters.services.map((s) => serviceLabelByValue.get(s) ?? s)
+    lines.push(`Serviço: ${labels.join(', ')}`)
   }
 
   if (filters.media_relevant === true) {

--- a/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-filters.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-filters.tsx
@@ -17,6 +17,7 @@ import {
   DashboardTaticoFilterModal,
   OPERATIONAL_VIEW_STATUS_OPTIONS,
 } from '../../components/filters'
+import { usePersistedAdvancedFilters } from '../../components/filters/use-persisted-advanced-filters'
 import {
   parseDemandVolumeDate,
   toDemandVolumeDateString,
@@ -141,10 +142,8 @@ export function OperationalViewFilters({
     () => countOperationalViewAdvancedFiltersFromApi(appliedFilters),
     [appliedFilters],
   )
-  const advancedFiltersForm = useMemo(
-    () => advancedFiltersFromApi(appliedFilters),
-    [appliedFilters],
-  )
+  const { form: advancedFiltersForm, applyAdvancedFilters } =
+    usePersistedAdvancedFilters(() => advancedFiltersFromApi(appliedFilters))
 
   return (
     <div className={styles.periodBar}>
@@ -191,7 +190,7 @@ export function OperationalViewFilters({
         isOpen={isFilterModalOpen}
         onClose={() => setIsFilterModalOpen(false)}
         filters={advancedFiltersForm}
-        onApply={onApplyAdvancedFilters}
+        onApply={(form) => applyAdvancedFilters(form, onApplyAdvancedFilters)}
       />
     </div>
   )

--- a/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-open-tickets-chart.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-open-tickets-chart.tsx
@@ -5,6 +5,7 @@ import {
   Bar,
   BarChart,
   CartesianGrid,
+  LabelList,
   Legend,
   ResponsiveContainer,
   Tooltip,
@@ -133,7 +134,7 @@ export function OperationalViewOpenTicketsChart({
                 <span style={{ color: '#97a2ab' }}>{value}</span>
               )}
             />
-            {statusSeries.map((status) => (
+            {statusSeries.map((status, idx) => (
               <Bar
                 key={status.key}
                 dataKey={status.key}
@@ -141,7 +142,58 @@ export function OperationalViewOpenTicketsChart({
                 stackId="open_tickets"
                 fill={status.color}
                 radius={[0, 0, 0, 0]}
-              />
+              >
+                <LabelList
+                  dataKey={status.key}
+                  position="inside"
+                  formatter={(v: unknown) => {
+                    const n = Number(v)
+                    return n > 0 ? String(n) : ''
+                  }}
+                  style={{ fontSize: 10, fill: '#f9fafa', fontWeight: 600 }}
+                />
+                {idx === statusSeries.length - 1 && (
+                  <LabelList
+                    dataKey={status.key}
+                    position="top"
+                    content={(props) => {
+                      const { x, y, width, index } = props as {
+                        x?: number
+                        y?: number
+                        width?: number
+                        index?: number
+                      }
+                      if (
+                        x == null ||
+                        y == null ||
+                        width == null ||
+                        index == null
+                      )
+                        return null
+                      const rowValues = statusSeries.map((s) => {
+                        const val = ((
+                          props as { payload?: Record<string, unknown> }
+                        ).payload ?? {})[s.key]
+                        return typeof val === 'number' ? val : 0
+                      })
+                      const total = rowValues.reduce((a, b) => a + b, 0)
+                      if (total === 0) return null
+                      return (
+                        <text
+                          x={Number(x) + Number(width) / 2}
+                          y={Number(y) - 6}
+                          textAnchor="middle"
+                          fill="#97a2ab"
+                          fontSize={10}
+                          fontWeight={600}
+                        >
+                          {total}
+                        </text>
+                      )
+                    }}
+                  />
+                )}
+              </Bar>
             ))}
           </BarChart>
         </ResponsiveContainer>

--- a/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-team-line-chart.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-team-line-chart.tsx
@@ -3,6 +3,7 @@
 import type { CSSProperties } from 'react'
 import {
   CartesianGrid,
+  LabelList,
   Legend,
   Line,
   LineChart,
@@ -74,7 +75,7 @@ export function OperationalViewTeamLineChart({
         <ResponsiveContainer width="100%" height={280}>
           <LineChart
             data={chartData}
-            margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+            margin={{ top: 24, right: 16, left: 0, bottom: 0 }}
           >
             <CartesianGrid
               strokeDasharray="3 3"
@@ -124,19 +125,33 @@ export function OperationalViewTeamLineChart({
                 <span style={{ color: '#97a2ab' }}>{value}</span>
               )}
             />
-            {teams.map((team) => (
-              <Line
-                key={team}
-                type="monotone"
-                dataKey={team}
-                name={team}
-                stroke={getTeamColor(team, teams)}
-                strokeWidth={2}
-                dot={false}
-                connectNulls
-                activeDot={{ r: 4, strokeWidth: 0 }}
-              />
-            ))}
+            {teams.map((team, idx) => {
+              const color = getTeamColor(team, teams)
+              const labelPosition =
+                idx % 2 === 0 ? ('top' as const) : ('bottom' as const)
+              return (
+                <Line
+                  key={team}
+                  type="monotone"
+                  dataKey={team}
+                  name={team}
+                  stroke={color}
+                  strokeWidth={2}
+                  dot={{ r: 3, fill: color, strokeWidth: 0 }}
+                  connectNulls
+                  activeDot={{ r: 5, strokeWidth: 0 }}
+                >
+                  <LabelList
+                    dataKey={team}
+                    position={labelPosition}
+                    formatter={(v: unknown) =>
+                      v != null && v !== '' ? valueFormatter(Number(v)) : ''
+                    }
+                    style={{ fontSize: 10, fill: color, fontWeight: 600 }}
+                  />
+                </Line>
+              )
+            })}
           </LineChart>
         </ResponsiveContainer>
       )}

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-chart-granularity.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-chart-granularity.tsx
@@ -11,7 +11,7 @@ import type { DemandVolumeGranularity } from '@/http/tickets/get-demand-volume'
 
 import styles from './demand-volume-top.module.css'
 
-const GRANULARITY_OPTIONS: {
+const BASE_GRANULARITY_OPTIONS: {
   value: DemandVolumeGranularity
   label: string
 }[] = [
@@ -24,13 +24,21 @@ interface DemandVolumeChartGranularityProps {
   value: DemandVolumeGranularity
   onChange: (value: DemandVolumeGranularity) => void
   disabled?: boolean
+  includeDaily?: boolean
 }
 
 export function DemandVolumeChartGranularity({
   value,
   onChange,
   disabled,
+  includeDaily,
 }: DemandVolumeChartGranularityProps) {
+  const granularityOptions = includeDaily
+    ? [
+        { value: 'daily' as const, label: 'Diário' },
+        ...BASE_GRANULARITY_OPTIONS,
+      ]
+    : BASE_GRANULARITY_OPTIONS
   return (
     <div className={styles.pageSelectWrapCompact}>
       <Select
@@ -45,7 +53,7 @@ export function DemandVolumeChartGranularity({
           <SelectValue />
         </SelectTrigger>
         <SelectContent className={styles.selectContentForm}>
-          {GRANULARITY_OPTIONS.map((opt) => (
+          {granularityOptions.map((opt) => (
             <SelectItem
               key={opt.value}
               value={opt.value}

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-filter-utils.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-filter-utils.ts
@@ -3,7 +3,11 @@ import type {
   TicketPriority,
   TicketStatus,
 } from '@/http/tickets/get-demand-volume'
-import type { SearchOption } from '@/http/tickets/tickets-dashboard-filters'
+import type {
+  SearchOption,
+  TICKET_DASHBOARD_SERVICE_FILTER_OPTIONS,
+  type TicketDashboardServiceFilter,
+} from '@/http/tickets/tickets-dashboard-filters'
 
 import {
   DASHBOARD_TATICO_PRIORITY_OPTIONS,
@@ -24,6 +28,9 @@ const priorityLabelByValue = new Map(
 const statusLabelByValue = new Map(
   DEMAND_VOLUME_STATUS_OPTIONS.map((o) => [o.value, o.label]),
 )
+const serviceLabelByValue = new Map(
+  TICKET_DASHBOARD_SERVICE_FILTER_OPTIONS.map((o) => [o.value, o.label]),
+)
 
 export const emptyDemandVolumeAdvancedFilters =
   emptyDashboardTaticoAdvancedFilters
@@ -37,6 +44,8 @@ export function countDemandVolumeAdvancedFilters(
   count += form.priority.length
   count += form.status.length
   count += form.ticket_type_id.length
+  count += form.nature_id.length
+  count += form.services.length
   if (form.relevanteImprensa) count += 1
   return count
 }
@@ -50,6 +59,8 @@ export function countDemandVolumeAdvancedFiltersFromApi(
   count += filters.priority?.length ?? 0
   count += filters.status?.length ?? 0
   count += filters.ticket_type_id?.length ?? 0
+  count += filters.nature_id?.length ?? 0
+  count += filters.services?.length ?? 0
   if (filters.media_relevant === true) {
     count += 1
   }
@@ -91,6 +102,11 @@ export function advancedFiltersFromApi(
       value,
       label: value,
     })),
+    nature_id: (filters.nature_id ?? []).map((value) => ({
+      value,
+      label: value,
+    })),
+    services: toSearchOptions(filters.services, serviceLabelByValue),
     relevanteImprensa: filters.media_relevant === true,
   }
 }
@@ -104,6 +120,8 @@ export function advancedFiltersToApiPatch(
   | 'priority'
   | 'status'
   | 'ticket_type_id'
+  | 'nature_id'
+  | 'services'
   | 'media_relevant'
 > {
   return {
@@ -122,6 +140,14 @@ export function advancedFiltersToApiPatch(
     ticket_type_id: form.ticket_type_id.length
       ? form.ticket_type_id.map((item) => item.value)
       : undefined,
+    nature_id: form.nature_id.length
+      ? form.nature_id.map((item) => item.value)
+      : undefined,
+    services: form.services.length
+      ? (form.services.map(
+          (item) => item.value,
+        ) as TicketDashboardServiceFilter[])
+      : undefined,
     media_relevant: form.relevanteImprensa ? true : null,
   }
 }
@@ -135,6 +161,8 @@ export function stripAdvancedFiltersFromApi(
   delete rest.priority
   delete rest.status
   delete rest.ticket_type_id
+  delete rest.nature_id
+  delete rest.services
   delete rest.media_relevant
   return rest
 }
@@ -161,6 +189,13 @@ export function formatDemandVolumeAdvancedFiltersSummary(
     lines.push(
       `Tipo de chamado: ${filters.ticket_type_id.length} selecionado(s)`,
     )
+  }
+  if (filters.nature_id?.length) {
+    lines.push(`Natureza: ${filters.nature_id.length} selecionado(s)`)
+  }
+  if (filters.services?.length) {
+    const labels = filters.services.map((s) => serviceLabelByValue.get(s) ?? s)
+    lines.push(`Serviço: ${labels.join(', ')}`)
   }
   if (filters.media_relevant === true) {
     lines.push('Relevante para imprensa: Sim')

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-filters.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-filters.tsx
@@ -17,6 +17,7 @@ import {
   DashboardTaticoFilterModal,
   DEMAND_VOLUME_STATUS_OPTIONS,
 } from '../../components/filters'
+import { usePersistedAdvancedFilters } from '../../components/filters/use-persisted-advanced-filters'
 import {
   parseDemandVolumeDate,
   toDemandVolumeDateString,
@@ -141,10 +142,8 @@ export function DemandVolumeFilters({
     () => countDemandVolumeAdvancedFiltersFromApi(appliedFilters),
     [appliedFilters],
   )
-  const advancedFiltersForm = useMemo(
-    () => advancedFiltersFromApi(appliedFilters),
-    [appliedFilters],
-  )
+  const { form: advancedFiltersForm, applyAdvancedFilters } =
+    usePersistedAdvancedFilters(() => advancedFiltersFromApi(appliedFilters))
 
   return (
     <div className={styles.periodBar}>
@@ -209,7 +208,7 @@ export function DemandVolumeFilters({
         isOpen={isFilterModalOpen}
         onClose={() => setIsFilterModalOpen(false)}
         filters={advancedFiltersForm}
-        onApply={onApplyAdvancedFilters}
+        onApply={(form) => applyAdvancedFilters(form, onApplyAdvancedFilters)}
       />
     </div>
   )

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-matrix-table.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-matrix-table.tsx
@@ -4,6 +4,7 @@ import { Pagination } from '@/components/ui/pagination'
 import type {
   DemandVolumeGranularity,
   MatrixRowOut,
+  MatrixSortOrder,
 } from '@/http/tickets/get-demand-volume'
 
 import { DashboardTaticoDataState } from '../../components/dashboard-tatico-data-state'
@@ -24,6 +25,8 @@ interface DemandVolumeMatrixTableProps {
   isLoading: boolean
   isAvailable: boolean
   pagination?: DemandVolumeMatrixTablePagination
+  sortOrder?: MatrixSortOrder
+  onSortOrderChange?: (order: MatrixSortOrder) => void
 }
 
 /** Tabelas usam agrupamento fixo (mensal) definido pelo backend. */
@@ -113,10 +116,17 @@ export function DemandVolumeMatrixTable({
   isLoading,
   isAvailable,
   pagination,
+  sortOrder = 'desc',
+  onSortOrderChange,
 }: DemandVolumeMatrixTableProps) {
   const formattedHeaders = periodLabels.map((pl) =>
     formatPeriodLabel(pl, MATRIX_GRANULARITY),
   )
+
+  function handleSortToggle() {
+    if (!onSortOrderChange) return
+    onSortOrderChange(sortOrder === 'desc' ? 'asc' : 'desc')
+  }
 
   if (!isLoading && !isAvailable) {
     return null
@@ -180,7 +190,37 @@ export function DemandVolumeMatrixTable({
                       borderLeft: '1px solid #1d3449',
                     }}
                   >
-                    Total
+                    {onSortOrderChange ? (
+                      <button
+                        type="button"
+                        onClick={handleSortToggle}
+                        aria-label={`Ordenar por total, ${
+                          sortOrder === 'desc'
+                            ? 'maior para menor'
+                            : 'menor para maior'
+                        }`}
+                        style={{
+                          display: 'inline-flex',
+                          alignItems: 'center',
+                          gap: '4px',
+                          background: 'none',
+                          border: 'none',
+                          padding: 0,
+                          cursor: 'pointer',
+                          font: 'inherit',
+                          color: 'inherit',
+                          textTransform: 'inherit',
+                          letterSpacing: 'inherit',
+                        }}
+                      >
+                        Total
+                        <span aria-hidden="true" style={{ fontSize: '10px' }}>
+                          {sortOrder === 'desc' ? '▼' : '▲'}
+                        </span>
+                      </button>
+                    ) : (
+                      'Total'
+                    )}
                   </th>
                 </tr>
               </thead>

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-media-chart.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-media-chart.tsx
@@ -2,6 +2,7 @@
 
 import {
   CartesianGrid,
+  LabelList,
   Legend,
   Line,
   LineChart,
@@ -85,7 +86,7 @@ export function DemandVolumeMediaChart({
         <ResponsiveContainer width="100%" height={280}>
           <LineChart
             data={chartData}
-            margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+            margin={{ top: 24, right: 16, left: 0, bottom: 0 }}
           >
             <CartesianGrid
               strokeDasharray="3 3"
@@ -132,9 +133,22 @@ export function DemandVolumeMediaChart({
               name="Relevância na Mídia"
               stroke={CHART_COLORS.line}
               strokeWidth={2}
-              dot={false}
-              activeDot={{ r: 4, strokeWidth: 0 }}
-            />
+              dot={{ r: 3, fill: CHART_COLORS.line, strokeWidth: 0 }}
+              activeDot={{ r: 5, strokeWidth: 0 }}
+            >
+              <LabelList
+                dataKey="count"
+                position="top"
+                formatter={(v: unknown) =>
+                  v != null && v !== '' ? String(v) : ''
+                }
+                style={{
+                  fontSize: 10,
+                  fill: CHART_COLORS.line,
+                  fontWeight: 600,
+                }}
+              />
+            </Line>
           </LineChart>
         </ResponsiveContainer>
       )}

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-period-label.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-period-label.ts
@@ -19,6 +19,13 @@ export function formatPeriodLabel(
   label: string,
   granularity: DemandVolumeGranularity,
 ): string {
+  if (granularity === 'daily') {
+    // "2026-03-19" → "19/03"
+    const [, month, day] = label.split('-')
+    if (day && month) return `${day}/${month}`
+    return label
+  }
+
   if (granularity === 'monthly') {
     // "2026-03" → "Mar/26"
     const [year, month] = label.split('-')

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-total-chart.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-total-chart.tsx
@@ -2,6 +2,7 @@
 
 import {
   CartesianGrid,
+  LabelList,
   Legend,
   Line,
   LineChart,
@@ -30,8 +31,18 @@ interface DemandVolumeTotalChartProps {
 }
 
 const SERIES = [
-  { key: 'created', label: 'Chamados Criados', color: '#b93d52' },
-  { key: 'closed', label: 'Chamados Encerrados', color: '#06b2bb' },
+  {
+    key: 'created',
+    label: 'Chamados Criados',
+    color: '#b93d52',
+    labelPosition: 'top' as const,
+  },
+  {
+    key: 'closed',
+    label: 'Chamados Encerrados',
+    color: '#06b2bb',
+    labelPosition: 'bottom' as const,
+  },
 ] as const
 
 const CHART_COLORS = {
@@ -80,6 +91,7 @@ export function DemandVolumeTotalChart({
           value={granularity}
           onChange={onGranularityChange}
           disabled={isLoading}
+          includeDaily
         />
       </div>
 
@@ -89,7 +101,7 @@ export function DemandVolumeTotalChart({
         <ResponsiveContainer width="100%" height={280}>
           <LineChart
             data={chartData}
-            margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+            margin={{ top: 24, right: 16, left: 0, bottom: 0 }}
           >
             <CartesianGrid
               strokeDasharray="3 3"
@@ -142,9 +154,18 @@ export function DemandVolumeTotalChart({
                 name={s.label}
                 stroke={s.color}
                 strokeWidth={2}
-                dot={false}
-                activeDot={{ r: 4, strokeWidth: 0 }}
-              />
+                dot={{ r: 3, fill: s.color, strokeWidth: 0 }}
+                activeDot={{ r: 5, strokeWidth: 0 }}
+              >
+                <LabelList
+                  dataKey={s.key}
+                  position={s.labelPosition}
+                  formatter={(v: unknown) =>
+                    v != null && v !== '' ? String(v) : ''
+                  }
+                  style={{ fontSize: 10, fill: s.color, fontWeight: 600 }}
+                />
+              </Line>
             ))}
           </LineChart>
         </ResponsiveContainer>

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-urgency-chart.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-urgency-chart.tsx
@@ -2,6 +2,7 @@
 
 import {
   CartesianGrid,
+  LabelList,
   Legend,
   Line,
   LineChart,
@@ -30,10 +31,30 @@ interface DemandVolumeUrgencyChartProps {
 }
 
 const SERIES = [
-  { key: 'urgent', label: 'Urgente', color: '#b93d52' },
-  { key: 'high', label: 'Alta', color: '#5b4db2' },
-  { key: 'routine', label: 'Rotina', color: '#06b2bb' },
-  { key: 'no_priority', label: 'Sem Prioridade', color: '#97a2ab' },
+  {
+    key: 'urgent',
+    label: 'Urgente',
+    color: '#b93d52',
+    labelPosition: 'top' as const,
+  },
+  {
+    key: 'high',
+    label: 'Alta',
+    color: '#5b4db2',
+    labelPosition: 'bottom' as const,
+  },
+  {
+    key: 'routine',
+    label: 'Rotina',
+    color: '#06b2bb',
+    labelPosition: 'top' as const,
+  },
+  {
+    key: 'no_priority',
+    label: 'Sem Prioridade',
+    color: '#97a2ab',
+    labelPosition: 'bottom' as const,
+  },
 ] as const
 
 const CHART_COLORS = {
@@ -91,7 +112,7 @@ export function DemandVolumeUrgencyChart({
         <ResponsiveContainer width="100%" height={280}>
           <LineChart
             data={chartData}
-            margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+            margin={{ top: 24, right: 16, left: 0, bottom: 0 }}
           >
             <CartesianGrid
               strokeDasharray="3 3"
@@ -140,9 +161,18 @@ export function DemandVolumeUrgencyChart({
                 name={s.label}
                 stroke={s.color}
                 strokeWidth={2}
-                dot={false}
-                activeDot={{ r: 4, strokeWidth: 0 }}
-              />
+                dot={{ r: 3, fill: s.color, strokeWidth: 0 }}
+                activeDot={{ r: 5, strokeWidth: 0 }}
+              >
+                <LabelList
+                  dataKey={s.key}
+                  position={s.labelPosition}
+                  formatter={(v: unknown) =>
+                    v != null && v !== '' ? String(v) : ''
+                  }
+                  style={{ fontSize: 10, fill: s.color, fontWeight: 600 }}
+                />
+              </Line>
             ))}
           </LineChart>
         </ResponsiveContainer>

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-view.tsx
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-view.tsx
@@ -8,6 +8,7 @@ import {
   type DemandVolumeGranularity,
   type DemandVolumeSummaryPeriod,
   getDemandVolume,
+  type MatrixSortOrder,
   pickDemandVolumeGranularitySeries,
 } from '@/http/tickets/get-demand-volume'
 import { unwrapDashboardItems } from '@/http/tickets/unwrap-dashboard-items'
@@ -98,6 +99,22 @@ export function DemandVolumeView() {
     setAppliedFilters((prev) => ({
       ...prev,
       closed_calls_by_requester_page: page,
+    }))
+  }
+
+  function handleNatureSortChange(order: MatrixSortOrder) {
+    setAppliedFilters((prev) => ({ ...prev, nature_sort: order }))
+  }
+
+  function handleServiceSortChange(order: MatrixSortOrder) {
+    setAppliedFilters((prev) => ({ ...prev, service_sort: order }))
+  }
+
+  function handleRequesterSortChange(order: MatrixSortOrder) {
+    setAppliedFilters((prev) => ({
+      ...prev,
+      requester_sort: order,
+      closed_calls_by_requester_page: undefined,
     }))
   }
 
@@ -250,6 +267,8 @@ export function DemandVolumeView() {
         isLoading={isFetching}
         isAvailable={data?.closed_calls_by_nature != null}
         columnHeader="NATUREZA"
+        sortOrder={appliedFilters.nature_sort ?? 'desc'}
+        onSortOrderChange={handleNatureSortChange}
       />
 
       <DemandVolumeMatrixTable
@@ -259,6 +278,8 @@ export function DemandVolumeView() {
         isLoading={isFetching}
         isAvailable={data?.closed_calls_by_service != null}
         columnHeader="SERVIÇO"
+        sortOrder={appliedFilters.service_sort ?? 'desc'}
+        onSortOrderChange={handleServiceSortChange}
       />
 
       <DemandVolumeMediaChart
@@ -276,6 +297,8 @@ export function DemandVolumeView() {
         isLoading={isFetching}
         isAvailable={data?.closed_calls_by_requester != null}
         columnHeader="DEMANDANTE"
+        sortOrder={appliedFilters.requester_sort ?? 'desc'}
+        onSortOrderChange={handleRequesterSortChange}
         pagination={
           data?.closed_calls_by_requester &&
           typeof data.closed_calls_by_requester === 'object' &&

--- a/src/app/(app)/demandas/list/components/filter/tickets-general-list-filters.tsx
+++ b/src/app/(app)/demandas/list/components/filter/tickets-general-list-filters.tsx
@@ -12,6 +12,7 @@ import {
   type SearchOption,
   searchRequesters,
   searchTicketResponsibles,
+  TICKET_DASHBOARD_SERVICE_FILTER_OPTIONS,
 } from '@/http/tickets/tickets-dashboard-filters'
 
 import styles from './tickets-general-list-filters.module.css'
@@ -90,20 +91,6 @@ const prioritySearchOptions: SearchOption[] = priorityOptions.map((p) => ({
   value: p,
   label: formatLabel(p),
 }))
-
-/** Labels em português; `value` é o enviado no body (`services`). */
-export const dashboardServicosFilterOptions: SearchOption[] = [
-  { value: 'plate_search_services', label: 'Busca por placa' },
-  { value: 'radar_search_services', label: 'Busca por radar' },
-  { value: 'electronic_fence_services', label: 'Cerco eletrônico' },
-  { value: 'image_search_services', label: 'Busca por imagem' },
-  { value: 'correlated_plate_services', label: 'Placas correlatas' },
-  { value: 'joint_plate_services', label: 'Placas conjuntas' },
-  { value: 'image_reservation_services', label: 'Reserva de imagem' },
-  { value: 'image_analysis_services', label: 'Análise de imagem' },
-  { value: 'other_services', label: 'Outros' },
-  { value: 'atlas_civitas_services', label: 'Atlas Civitas' },
-]
 
 function SearchMultiSelect({
   label,
@@ -359,7 +346,7 @@ export function TicketsDashboardFilterModal({
                   services: value,
                 }))
               }
-              staticOptions={dashboardServicosFilterOptions}
+              staticOptions={TICKET_DASHBOARD_SERVICE_FILTER_OPTIONS}
             />
           </div>
 

--- a/src/http/tickets/add-conventional-pending-attachments.ts
+++ b/src/http/tickets/add-conventional-pending-attachments.ts
@@ -1,0 +1,22 @@
+import { api } from '@/lib/api'
+
+export async function addConventionalPendingAttachments(
+  ticketId: string,
+  files: File[],
+  options?: { emailId?: string | null },
+) {
+  const form = new FormData()
+  for (const f of files) {
+    form.append('files', f)
+  }
+
+  const emailId = options?.emailId?.trim()
+  const path = emailId
+    ? `/tickets/${ticketId}/conventional-pending/attachments?email_id=${encodeURIComponent(emailId)}`
+    : `/tickets/${ticketId}/conventional-pending/attachments`
+
+  const response = await api.post(path, form, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  })
+  return response
+}

--- a/src/http/tickets/get-demand-volume.ts
+++ b/src/http/tickets/get-demand-volume.ts
@@ -1,9 +1,10 @@
 import type { TicketStatus } from '@/app/(app)/demandas/dashboard-tatico/utils/ticket-status'
 import { api } from '@/lib/api'
 
+import type { TicketDashboardServiceFilter } from './tickets-dashboard-filters'
 import { unwrapDashboardItems } from './unwrap-dashboard-items'
 
-export type DemandVolumeGranularity = 'monthly' | 'weekly' | 'yearly'
+export type DemandVolumeGranularity = 'daily' | 'monthly' | 'weekly' | 'yearly'
 
 export type DemandVolumeSummaryPeriod =
   | 'current_year'
@@ -11,6 +12,8 @@ export type DemandVolumeSummaryPeriod =
   | 'current_week'
 
 export type TicketPriority = 'URGENTE' | 'ALTA' | 'ROTINA'
+
+export type MatrixSortOrder = 'asc' | 'desc'
 
 export type { TicketStatus } from '@/app/(app)/demandas/dashboard-tatico/utils/ticket-status'
 
@@ -24,9 +27,17 @@ export interface DemandVolumeFilterIn {
   priority?: TicketPriority[]
   status?: TicketStatus[]
   ticket_type_id?: string[]
+  nature_id?: string[]
+  services?: TicketDashboardServiceFilter[]
   media_relevant?: boolean | null
   /** Página da matriz closed_calls_by_requester (1-based). Padrão: 1 */
   closed_calls_by_requester_page?: number
+  /** Ordenação por total — closed_calls_by_nature. Padrão: desc */
+  nature_sort?: MatrixSortOrder
+  /** Ordenação por total — closed_calls_by_service. Padrão: desc */
+  service_sort?: MatrixSortOrder
+  /** Ordenação por total — closed_calls_by_requester. Padrão: desc */
+  requester_sort?: MatrixSortOrder
 }
 
 export interface DemandVolumeSummaryOut {
@@ -74,6 +85,7 @@ export interface PaginatedMatrixRowsOut {
 export type DemandVolumeGranularityBucket<T> = T[] | { items?: T[] | null }
 
 export interface DemandVolumeGranularitySeries<T> {
+  daily?: DemandVolumeGranularityBucket<T>
   monthly: DemandVolumeGranularityBucket<T>
   weekly: DemandVolumeGranularityBucket<T>
   yearly: DemandVolumeGranularityBucket<T>
@@ -84,7 +96,9 @@ export function pickDemandVolumeGranularitySeries<T>(
   granularity: DemandVolumeGranularity,
 ): T[] {
   if (!series) return []
-  return unwrapDashboardItems(series[granularity])
+  const bucket = series[granularity]
+  if (!bucket) return []
+  return unwrapDashboardItems(bucket)
 }
 
 export interface DemandVolumeOut {
@@ -107,6 +121,8 @@ export function sanitizeDemandVolumeFilters(
   if (!payload.priority?.length) delete payload.priority
   if (!payload.status?.length) delete payload.status
   if (!payload.ticket_type_id?.length) delete payload.ticket_type_id
+  if (!payload.nature_id?.length) delete payload.nature_id
+  if (!payload.services?.length) delete payload.services
   if (payload.media_relevant === undefined) {
     delete payload.media_relevant
   }

--- a/src/http/tickets/get-operational-view.ts
+++ b/src/http/tickets/get-operational-view.ts
@@ -5,6 +5,7 @@ import type {
   DemandVolumeTicketItemOut,
   DemandVolumeTicketsOut,
 } from './get-demand-volume'
+import type { TicketDashboardServiceFilter } from './tickets-dashboard-filters'
 import { unwrapDashboardItems } from './unwrap-dashboard-items'
 
 export type OperationalViewGranularity = 'monthly' | 'weekly' | 'yearly'
@@ -27,6 +28,8 @@ export interface OperationalViewFilterIn {
   priority?: OperationalViewPriority[]
   status?: OperationalViewStatus[]
   ticket_type_id?: string[]
+  nature_id?: string[]
+  services?: TicketDashboardServiceFilter[]
   media_relevant?: boolean | null
 }
 
@@ -109,6 +112,8 @@ export function sanitizeOperationalViewFilters(
   if (!payload.priority?.length) delete payload.priority
   if (!payload.status?.length) delete payload.status
   if (!payload.ticket_type_id?.length) delete payload.ticket_type_id
+  if (!payload.nature_id?.length) delete payload.nature_id
+  if (!payload.services?.length) delete payload.services
   if (payload.media_relevant === undefined) {
     delete payload.media_relevant
   }

--- a/src/http/tickets/get-sla-dashboard.ts
+++ b/src/http/tickets/get-sla-dashboard.ts
@@ -5,6 +5,7 @@ import type {
   DemandVolumeTicketItemOut,
   DemandVolumeTicketsOut,
 } from './get-demand-volume'
+import type { TicketDashboardServiceFilter } from './tickets-dashboard-filters'
 import { unwrapDashboardItems } from './unwrap-dashboard-items'
 
 export type SlaDashboardGranularity = 'monthly' | 'weekly' | 'yearly'
@@ -23,6 +24,8 @@ export interface SlaDashboardFilterIn {
   priority?: TicketPriority[]
   status?: SlaTicketStatus[]
   ticket_type_id?: string[]
+  nature_id?: string[]
+  services?: TicketDashboardServiceFilter[]
   media_relevant?: boolean | null
 }
 
@@ -103,6 +106,8 @@ export function sanitizeSlaDashboardFilters(
   if (!payload.priority?.length) delete payload.priority
   if (!payload.status?.length) delete payload.status
   if (!payload.ticket_type_id?.length) delete payload.ticket_type_id
+  if (!payload.nature_id?.length) delete payload.nature_id
+  if (!payload.services?.length) delete payload.services
   if (payload.media_relevant === undefined) {
     delete payload.media_relevant
   }

--- a/src/http/tickets/get-ticket-archive.ts
+++ b/src/http/tickets/get-ticket-archive.ts
@@ -1,16 +1,8 @@
 import { api } from '@/lib/api'
 
-export type TicketArchiveServiceFilter =
-  | 'plate_search_services'
-  | 'radar_search_services'
-  | 'electronic_fence_services'
-  | 'image_search_services'
-  | 'correlated_plate_services'
-  | 'joint_plate_services'
-  | 'image_reservation_services'
-  | 'image_analysis_services'
-  | 'other_services'
-  | 'atlas_civitas_services'
+import type { TicketDashboardServiceFilter } from './tickets-dashboard-filters'
+
+export type TicketArchiveServiceFilter = TicketDashboardServiceFilter
 
 export type TicketArchiveFilters = {
   search?: string

--- a/src/http/tickets/get-tickets-list.ts
+++ b/src/http/tickets/get-tickets-list.ts
@@ -8,6 +8,7 @@ export type GetTicketsResponse = Array<{
   id: string
   created_at: string
   title: string
+  ticket_type_name: string
 }>
 
 export async function getTicketsSelect({ search }: GetTicketsParams) {

--- a/src/http/tickets/tickets-dashboard-filters.ts
+++ b/src/http/tickets/tickets-dashboard-filters.ts
@@ -7,6 +7,32 @@ export type SearchOption = {
   value: string
 }
 
+export type TicketDashboardServiceFilter =
+  | 'plate_search_services'
+  | 'radar_search_services'
+  | 'electronic_fence_services'
+  | 'image_search_services'
+  | 'correlated_plate_services'
+  | 'joint_plate_services'
+  | 'image_reservation_services'
+  | 'image_analysis_services'
+  | 'other_services'
+  | 'atlas_civitas_services'
+
+/** Labels em português; `value` é o enviado no body (`services`). */
+export const TICKET_DASHBOARD_SERVICE_FILTER_OPTIONS: SearchOption[] = [
+  { value: 'plate_search_services', label: 'Busca por placa' },
+  { value: 'radar_search_services', label: 'Busca por radar' },
+  { value: 'electronic_fence_services', label: 'Cerco eletrônico' },
+  { value: 'image_search_services', label: 'Busca por imagem' },
+  { value: 'correlated_plate_services', label: 'Placas correlatas' },
+  { value: 'joint_plate_services', label: 'Placas conjuntas' },
+  { value: 'image_reservation_services', label: 'Reserva de imagem' },
+  { value: 'image_analysis_services', label: 'Análise de imagem' },
+  { value: 'other_services', label: 'Outros' },
+  { value: 'atlas_civitas_services', label: 'Atlas Civitas' },
+]
+
 type TicketTypeItem = {
   id: string
 


### PR DESCRIPTION
## Description

This PR delivers a set of improvements and fixes across the Demandas module, covering dashboard filters, chart visualizations, ticket creation flow, and file attachment support.

## Related Issue

N/A

## Motivation and Context

Several features were missing or incomplete in the tactical dashboard and ticket creation screens. Charts lacked data labels, advanced filters did not include Nature and Service fields, the ticket creation flow did not differentiate between Conventional and non-Conventional associated tickets, and service filter options were duplicated across modules.

## How has this been tested?

- Manually verified chart data labels render correctly across all dashboard views (Volume, SLA Metrics, Operational View)
- Tested advanced filter modal with Nature and Service fields in all three dashboard scopes
- Verified ticket creation flow correctly routes to `addConventionalPendingAttachments` vs `convertToConventional` based on the associated ticket type
- Confirmed matrix table sort toggle (asc/desc) works for Nature, Service, and Requester tables
- Verified daily granularity option appears only in the Total chart
- Confirmed `.csv` and `.xlsx` files are accepted in the file attachment input

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] feat: indicates the development of a new feature for the project.
- [x] fix: used when there is correction of errors that are generating bugs in the system.
- [x] refactor: used when there is a code refactoring that does not have any type of impact on the system's business logic/rules.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

---

### Summary of changes

**Dashboard Tactical — Advanced Filters**
- Added `nature_id` and `services` fields to `DashboardTaticoAdvancedFilterForm` type and `emptyDashboardTaticoAdvancedFilters` factory
- Added Nature and Service multi-select fields to `DashboardTaticoFilterModal`
- Propagated new filter fields through all three dashboard scopes: Volume, SLA Metrics, and Operational View (filter utils, API patch/strip helpers, count helpers, and summary formatters)
- Introduced `usePersistedAdvancedFilters` hook to prevent the filter form from resetting to API state on every render; used in all three filter components

**Dashboard Tactical — Charts**
- Added `LabelList` data labels to all line charts (Volume Total, Volume Urgency, Volume Media, SLA General, SLA Media, SLA Priority, Operational Team Line Chart) — values shown directly on data points with alternating top/bottom positions to avoid overlap
- Added `LabelList` inside each bar segment and a custom total label on top of each stacked bar column in `OperationalViewOpenTicketsChart`
- Updated dot rendering from `dot={false}` to visible filled dots (`r: 3`) across all line charts
- Increased top margin from 8 to 24 on all line charts to prevent label clipping

**Dashboard Tactical — Volume**
- Added `daily` granularity option to `DemandVolumeGranularity` type and `pickDemandVolumeGranularitySeries` (handles optional bucket safely)
- Added `formatPeriodLabel` support for daily labels (`YYYY-MM-DD` → `DD/MM`)
- Exposed `includeDaily` prop on `DemandVolumeChartGranularity`; enabled only for the Total chart
- Added `MatrixSortOrder` type (`asc | desc`) and sort params (`nature_sort`, `service_sort`, `requester_sort`) to `DemandVolumeFilterIn`
- Matrix tables for Nature, Service, and Requester now display a clickable sort toggle button on the Total column header

**Service Filter — Consolidation**
- Moved `TicketDashboardServiceFilter` type and `TICKET_DASHBOARD_SERVICE_FILTER_OPTIONS` constant to `tickets-dashboard-filters.ts` as the single source of truth
- Removed duplicate `dashboardServicosFilterOptions` from `tickets-general-list-filters.tsx`
- Updated `get-ticket-archive.ts` to re-export `TicketDashboardServiceFilter` instead of re-declaring it
- Updated all consumers to import from the canonical location

**Ticket Creation Flow**
- Added `ticket_type_name` to `GetTicketsResponse` type
- `applyAssociatedTicketFromSearch` now accepts and stores `ticketTypeName`
- On submit, if the associated ticket is already of type `Convencional`, the new `addConventionalPendingAttachments` endpoint is called instead of converting the ticket; otherwise the existing `convertToConventional` flow is preserved
- New HTTP helper `add-conventional-pending-attachments.ts` added

**Ticket Detail & Attachments**
- `MAX_OFICIO_PROC` constant replaced by `CREATE_STR_LIMITS.procedure_number` (limit updated from 12 to 25)
- File input now accepts `.csv` and `.xlsx` in addition to existing formats
- Service tag classifier in archived tickets fixed: `'other'` → `'outros'`