### PR TITLE
refactor(sla-metrics-filter-utils): reorganize imports for clarity

### DIFF
--- a/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-filter-utils.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/metricas/components/sla-metrics-filter-utils.ts
@@ -6,9 +6,9 @@ import type {
 } from '@/http/tickets/get-sla-dashboard'
 import type {
   SearchOption,
-  TICKET_DASHBOARD_SERVICE_FILTER_OPTIONS,
-  type TicketDashboardServiceFilter,
+  TicketDashboardServiceFilter,
 } from '@/http/tickets/tickets-dashboard-filters'
+import { TICKET_DASHBOARD_SERVICE_FILTER_OPTIONS } from '@/http/tickets/tickets-dashboard-filters'
 
 import {
   DASHBOARD_TATICO_PRIORITY_OPTIONS,

--- a/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-filter-utils.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/visao-operacional/components/operational-view-filter-utils.ts
@@ -5,9 +5,9 @@ import type {
 } from '@/http/tickets/get-operational-view'
 import type {
   SearchOption,
-  TICKET_DASHBOARD_SERVICE_FILTER_OPTIONS,
-  type TicketDashboardServiceFilter,
+  TicketDashboardServiceFilter,
 } from '@/http/tickets/tickets-dashboard-filters'
+import { TICKET_DASHBOARD_SERVICE_FILTER_OPTIONS } from '@/http/tickets/tickets-dashboard-filters'
 
 import {
   DASHBOARD_TATICO_PRIORITY_OPTIONS,

--- a/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-filter-utils.ts
+++ b/src/app/(app)/demandas/dashboard-tatico/volume/components/demand-volume-filter-utils.ts
@@ -5,9 +5,9 @@ import type {
 } from '@/http/tickets/get-demand-volume'
 import type {
   SearchOption,
-  TICKET_DASHBOARD_SERVICE_FILTER_OPTIONS,
-  type TicketDashboardServiceFilter,
+  TicketDashboardServiceFilter,
 } from '@/http/tickets/tickets-dashboard-filters'
+import { TICKET_DASHBOARD_SERVICE_FILTER_OPTIONS } from '@/http/tickets/tickets-dashboard-filters'
 
 import {
   DASHBOARD_TATICO_PRIORITY_OPTIONS,


### PR DESCRIPTION
## Description

This PR delivers a set of improvements and fixes across the Demandas module, covering dashboard filters, chart visualizations, ticket creation flow, and file attachment support.

## Related Issue

N/A

## Motivation and Context

Several features were missing or incomplete in the tactical dashboard and ticket creation screens. Charts lacked data labels, advanced filters did not include Nature and Service fields, the ticket creation flow did not differentiate between Conventional and non-Conventional associated tickets, and service filter options were duplicated across modules.

## How has this been tested?

- Manually verified chart data labels render correctly across all dashboard views (Volume, SLA Metrics, Operational View)
- Tested advanced filter modal with Nature and Service fields in all three dashboard scopes
- Verified ticket creation flow correctly routes to `addConventionalPendingAttachments` vs `convertToConventional` based on the associated ticket type
- Confirmed matrix table sort toggle (asc/desc) works for Nature, Service, and Requester tables
- Verified daily granularity option appears only in the Total chart
- Confirmed `.csv` and `.xlsx` files are accepted in the file attachment input

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] feat: indicates the development of a new feature for the project.
- [x] fix: used when there is correction of errors that are generating bugs in the system.
- [x] refactor: used when there is a code refactoring that does not have any type of impact on the system's business logic/rules.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

---

### Summary of changes

**Dashboard Tactical — Advanced Filters**
- Added `nature_id` and `services` fields to `DashboardTaticoAdvancedFilterForm` type and `emptyDashboardTaticoAdvancedFilters` factory
- Added Nature and Service multi-select fields to `DashboardTaticoFilterModal`
- Propagated new filter fields through all three dashboard scopes: Volume, SLA Metrics, and Operational View (filter utils, API patch/strip helpers, count helpers, and summary formatters)
- Introduced `usePersistedAdvancedFilters` hook to prevent the filter form from resetting to API state on every render; used in all three filter components

**Dashboard Tactical — Charts**
- Added `LabelList` data labels to all line charts (Volume Total, Volume Urgency, Volume Media, SLA General, SLA Media, SLA Priority, Operational Team Line Chart) — values shown directly on data points with alternating top/bottom positions to avoid overlap
- Added `LabelList` inside each bar segment and a custom total label on top of each stacked bar column in `OperationalViewOpenTicketsChart`
- Updated dot rendering from `dot={false}` to visible filled dots (`r: 3`) across all line charts
- Increased top margin from 8 to 24 on all line charts to prevent label clipping

**Dashboard Tactical — Volume**
- Added `daily` granularity option to `DemandVolumeGranularity` type and `pickDemandVolumeGranularitySeries` (handles optional bucket safely)
- Added `formatPeriodLabel` support for daily labels (`YYYY-MM-DD` → `DD/MM`)
- Exposed `includeDaily` prop on `DemandVolumeChartGranularity`; enabled only for the Total chart
- Added `MatrixSortOrder` type (`asc | desc`) and sort params (`nature_sort`, `service_sort`, `requester_sort`) to `DemandVolumeFilterIn`
- Matrix tables for Nature, Service, and Requester now display a clickable sort toggle button on the Total column header

**Service Filter — Consolidation**
- Moved `TicketDashboardServiceFilter` type and `TICKET_DASHBOARD_SERVICE_FILTER_OPTIONS` constant to `tickets-dashboard-filters.ts` as the single source of truth
- Removed duplicate `dashboardServicosFilterOptions` from `tickets-general-list-filters.tsx`
- Updated `get-ticket-archive.ts` to re-export `TicketDashboardServiceFilter` instead of re-declaring it
- Updated all consumers to import from the canonical location

**Ticket Creation Flow**
- Added `ticket_type_name` to `GetTicketsResponse` type
- `applyAssociatedTicketFromSearch` now accepts and stores `ticketTypeName`
- On submit, if the associated ticket is already of type `Convencional`, the new `addConventionalPendingAttachments` endpoint is called instead of converting the ticket; otherwise the existing `convertToConventional` flow is preserved
- New HTTP helper `add-conventional-pending-attachments.ts` added

**Ticket Detail & Attachments**
- `MAX_OFICIO_PROC` constant replaced by `CREATE_STR_LIMITS.procedure_number` (limit updated from 12 to 25)
- File input now accepts `.csv` and `.xlsx` in addition to existing formats
- Service tag classifier in archived tickets fixed: `'other'` → `'outros'`